### PR TITLE
feat(mcp): expose published guides as MCP servers for external AI agents

### DIFF
--- a/docker/docker-compose.cpu.api-only-local-build.yml
+++ b/docker/docker-compose.cpu.api-only-local-build.yml
@@ -187,7 +187,6 @@ services:
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
       - ALLOWED_ORIGINS=*
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://guideants-ai:80

--- a/docker/docker-compose.cpu.yml
+++ b/docker/docker-compose.cpu.yml
@@ -195,7 +195,6 @@ services:
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
       - ALLOWED_ORIGINS=*
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://guideants-ai:80

--- a/docker/docker-compose.cuda.api-only-local-build.yml
+++ b/docker/docker-compose.cuda.api-only-local-build.yml
@@ -215,7 +215,6 @@ services:
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
       - ALLOWED_ORIGINS=*
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://guideants-ai:80

--- a/docker/docker-compose.cuda.yml
+++ b/docker/docker-compose.cuda.yml
@@ -223,7 +223,6 @@ services:
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
       - ALLOWED_ORIGINS=*
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://guideants-ai:80

--- a/docker/docker-compose.ghcr-cpu.yml
+++ b/docker/docker-compose.ghcr-cpu.yml
@@ -177,7 +177,6 @@ services:
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
       - ALLOWED_ORIGINS=*
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://guideants-ai:80

--- a/docker/docker-compose.ghcr-cuda13.yml
+++ b/docker/docker-compose.ghcr-cuda13.yml
@@ -200,7 +200,6 @@ services:
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
       - ALLOWED_ORIGINS=*
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://guideants-ai:80

--- a/docker/docker-compose.ghcr-rocm.yml
+++ b/docker/docker-compose.ghcr-rocm.yml
@@ -178,7 +178,6 @@ services:
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
       - ALLOWED_ORIGINS=*
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://guideants-ai:80

--- a/docker/docker-compose.ghcr-slim.yml
+++ b/docker/docker-compose.ghcr-slim.yml
@@ -81,7 +81,6 @@ services:
       - FileStorage__Path=/app/ContentFiles
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://127.0.0.1:9

--- a/docker/docker-compose.rocm.yml
+++ b/docker/docker-compose.rocm.yml
@@ -201,7 +201,6 @@ services:
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
       - ALLOWED_ORIGINS=*
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://guideants-ai:80

--- a/docker/docker-compose.slim.yml
+++ b/docker/docker-compose.slim.yml
@@ -80,7 +80,6 @@ services:
       - FileStorage__Path=/app/ContentFiles
       - Ui__RootPath=/app/ui
       - Ui__DevServerUrl=
-      - ANTRUNNER_SERVICES_HOST_URL=http://guideants-webapi-ui:8080/
       - SearXngSearch__BaseUrl=http://searxng:8080
       - BrowserRendering__BaseUrl=http://searxng:8080
       - LocalServiceHosts__SpeechTranscriptionBaseUrl=http://127.0.0.1:9

--- a/src/client/src/components/guides/PublishGuideDialog.tsx
+++ b/src/client/src/components/guides/PublishGuideDialog.tsx
@@ -7,6 +7,7 @@ import { InterfaceTab } from './configTabs/InterfaceTab';
 import { FeaturesTab } from './configTabs/FeaturesTab';
 import { LimitsTab } from './configTabs/LimitsTab';
 import { AuthTab } from './configTabs/AuthTab';
+import { McpTab } from './configTabs/McpTab';
 
 interface PublishGuideDialogProps {
   guideName: string;
@@ -19,7 +20,7 @@ interface PublishGuideDialogProps {
   onCancel: () => void;
 }
 
-type TabId = 'general' | 'interface' | 'features' | 'limits' | 'auth';
+type TabId = 'general' | 'interface' | 'features' | 'limits' | 'auth' | 'mcp';
 
 export function PublishGuideDialog({ 
   guideName, 
@@ -67,7 +68,16 @@ export function PublishGuideDialog({
   const [authWebhookTimeout, setAuthWebhookTimeout] = useState<number>(publishedGuide?.authWebhookTimeoutSeconds || 5);
   const [hasApiKey, setHasApiKey] = useState(publishedGuide?.hasApiKey || false);
 
+  // MCP
+  const [mcpEnabled, setMcpEnabled] = useState(publishedGuide?.mcpEnabled || false);
+  const [mcpDescription, setMcpDescription] = useState(publishedGuide?.mcpDescription || '');
+
   const isActive = publishedGuide?.active ?? true;
+
+  // MCP requires an API key — keep it disabled while none is configured
+  useEffect(() => {
+    if (!hasApiKey) setMcpEnabled(false);
+  }, [hasApiKey]);
 
   // Debounced friendly name validation
   const validateFriendlyName = useCallback(async (name: string) => {
@@ -145,6 +155,8 @@ export function PublishGuideDialog({
       billingPeriodChargeLimitUsd: billingPeriodChargeLimitUsd ?? undefined,
       authValidationWebhookUrl: authWebhookUrl.trim() || undefined,
       authWebhookTimeoutSeconds: authWebhookUrl.trim() ? authWebhookTimeout : undefined,
+      mcpEnabled,
+      mcpDescription: mcpDescription.trim() || undefined,
     };
 
     if (isEditMode && onUpdate) {
@@ -163,6 +175,14 @@ export function PublishGuideDialog({
       onDeactivate();
     }
     setShowDeactivateConfirm(false);
+  };
+
+  const handleGenerateApiKey = async (): Promise<string> => {
+    const pubId = publishedGuide?.id;
+    if (!pubId) throw new Error('Guide must be published first');
+    const response = await api.guides.guides.generateApiKey(guideId, pubId);
+    setHasApiKey(true);
+    return response.apiKey;
   };
 
   useEffect(() => {
@@ -191,6 +211,7 @@ export function PublishGuideDialog({
     { id: 'features', label: 'Features' },
     { id: 'limits', label: 'Limits' },
     { id: 'auth', label: 'Auth' },
+    { id: 'mcp', label: 'MCP' },
   ];
 
   const dialogMarkup = (
@@ -329,6 +350,18 @@ export function PublishGuideDialog({
                 guideId={guideId}
                 publishedGuideId={publishedGuide?.id}
                 onApiKeyChange={setHasApiKey}
+              />
+            )}
+
+            {activeTab === 'mcp' && (
+              <McpTab
+                mcpEnabled={mcpEnabled}
+                setMcpEnabled={setMcpEnabled}
+                mcpDescription={mcpDescription}
+                setMcpDescription={setMcpDescription}
+                hasApiKey={hasApiKey}
+                publishedGuideId={publishedGuide?.id}
+                onGenerateApiKey={publishedGuide?.id ? handleGenerateApiKey : undefined}
               />
             )}
           </fieldset>

--- a/src/client/src/components/guides/configTabs/McpTab.tsx
+++ b/src/client/src/components/guides/configTabs/McpTab.tsx
@@ -1,0 +1,261 @@
+import { useState } from 'react';
+import { API_BASE_URL } from '../../../config/apiConfig';
+
+interface McpTabProps {
+  mcpEnabled: boolean;
+  setMcpEnabled: (enabled: boolean) => void;
+  mcpDescription: string;
+  setMcpDescription: (desc: string) => void;
+  hasApiKey: boolean;
+  publishedGuideId?: string;
+  onGenerateApiKey?: () => Promise<string>;
+}
+
+export function McpTab({
+  mcpEnabled,
+  setMcpEnabled,
+  mcpDescription,
+  setMcpDescription,
+  hasApiKey,
+  publishedGuideId,
+  onGenerateApiKey
+}: McpTabProps) {
+  const [copied, setCopied] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generatedKey, setGeneratedKey] = useState<string | null>(null);
+  const [keyCopied, setKeyCopied] = useState(false);
+  const [genError, setGenError] = useState<string | null>(null);
+
+  // GuideAnts API_BASE_URL already includes the "/api" prefix, so the resolved
+  // endpoint is "<base>/api/published/mcp?pubId=..." per the cross-team contract.
+  const mcpEndpointUrl = publishedGuideId
+    ? `${API_BASE_URL}/published/mcp?pubId=${publishedGuideId}`
+    : null;
+
+  const copyEndpoint = async () => {
+    if (mcpEndpointUrl) {
+      await navigator.clipboard.writeText(mcpEndpointUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleGenerateAndEnable = async () => {
+    if (!onGenerateApiKey) return;
+    setIsGenerating(true);
+    setGenError(null);
+    try {
+      const key = await onGenerateApiKey();
+      setGeneratedKey(key);
+      setMcpEnabled(true);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to generate API key';
+      setGenError(message);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const copyApiKey = async () => {
+    if (generatedKey) {
+      await navigator.clipboard.writeText(generatedKey);
+      setKeyCopied(true);
+      setTimeout(() => setKeyCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium text-gray-900">MCP Server</h3>
+        <p className="text-sm text-gray-500 mt-1">
+          Expose this guide as a <a href="https://modelcontextprotocol.io" target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">Model Context Protocol</a> server so AI agents and MCP clients can interact with it programmatically.
+        </p>
+      </div>
+
+      {/* Client-facing description — always visible so it can be drafted before enabling */}
+      <div>
+        <label htmlFor="mcpDescription" className="block text-sm font-medium text-gray-700 mb-1">
+          Guide Description for MCP Clients
+        </label>
+        <textarea
+          id="mcpDescription"
+          value={mcpDescription}
+          onChange={(e) => setMcpDescription(e.target.value)}
+          rows={4}
+          maxLength={2000}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500 resize-y"
+          placeholder={"Describe what this guide does and how MCP clients should interact with it.\n\nExample: This guide assists with software architecture design. It has access to code execution and diagram tools. Provide requirements or paste existing code for review. Supports multi-turn conversations for iterative design work."}
+        />
+        <div className="flex justify-between mt-1">
+          <p className="text-xs text-gray-500">
+            Shown as the tool description for the guide assistant in <code className="bg-gray-100 px-1 rounded">tools/list</code>.
+          </p>
+          <span className="text-xs text-gray-400">{mcpDescription.length}/2000</span>
+        </div>
+      </div>
+
+      {!hasApiKey ? (
+        <div className="space-y-4">
+          <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg">
+            <div className="flex items-start gap-3">
+              <svg className="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+              <div>
+                <p className="text-sm font-medium text-amber-900">API key required</p>
+                <p className="text-sm text-amber-700 mt-1">
+                  MCP access requires API key authentication. Generate one to get started.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {onGenerateApiKey ? (
+            <button
+              type="button"
+              onClick={handleGenerateAndEnable}
+              disabled={isGenerating}
+              className="w-full px-4 py-3 text-sm font-medium text-white bg-purple-600 rounded-lg hover:bg-purple-700 disabled:opacity-50 flex items-center justify-center gap-2"
+            >
+              {isGenerating ? (
+                <>
+                  <svg className="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  Generating...
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+                  </svg>
+                  Generate API Key &amp; Enable MCP
+                </>
+              )}
+            </button>
+          ) : (
+            <p className="text-xs text-gray-500 italic">
+              Publish the guide first, then return here to generate an API key and enable MCP.
+            </p>
+          )}
+
+          {genError && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800">
+              {genError}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {/* Show freshly generated key */}
+          {generatedKey && (
+            <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
+              <div className="flex items-center gap-2 mb-2">
+                <svg className="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span className="text-sm font-medium text-green-800">API Key Generated &amp; MCP Enabled</span>
+              </div>
+              <div className="flex items-center gap-2 mb-3">
+                <code className="flex-1 px-3 py-2 bg-white border border-green-300 rounded font-mono text-xs text-gray-900 select-all break-all">
+                  {generatedKey}
+                </code>
+                <button
+                  type="button"
+                  onClick={copyApiKey}
+                  className="px-3 py-2 text-xs font-medium text-green-700 bg-white border border-green-300 rounded hover:bg-green-50 flex-shrink-0"
+                >
+                  {keyCopied ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+              <div className="p-3 bg-amber-50 border border-amber-200 rounded text-xs text-amber-800">
+                <p className="font-medium">Save this key now!</p>
+                <p className="mt-1">This API key will only be displayed once. Store it securely — you will not be able to retrieve it again.</p>
+              </div>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between py-3 border-b border-gray-100">
+            <div>
+              <span className="block text-sm font-medium text-gray-700">Enable MCP Endpoint</span>
+              <span className="block text-xs text-gray-500">Allow MCP clients to connect using the API key for authentication</span>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={mcpEnabled}
+                onChange={(e) => setMcpEnabled(e.target.checked)}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-purple-600"></div>
+            </label>
+          </div>
+
+          {mcpEnabled && mcpEndpointUrl && (
+            <div className="space-y-4">
+              <div className="p-4 bg-purple-50 border border-purple-200 rounded-lg">
+                <p className="text-xs font-medium text-purple-800 mb-2">Endpoint URL</p>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 px-3 py-2 bg-white border border-purple-300 rounded font-mono text-xs text-gray-900 select-all break-all">
+                    {mcpEndpointUrl}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={copyEndpoint}
+                    className="px-3 py-2 text-xs font-medium text-purple-700 bg-white border border-purple-300 rounded hover:bg-purple-50 flex-shrink-0"
+                  >
+                    {copied ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+              </div>
+
+              <div className="border border-gray-200 rounded-lg p-4">
+                <h4 className="text-sm font-medium text-gray-900 mb-3">Connection Details</h4>
+                <div className="space-y-2 text-sm">
+                  <div className="flex items-start gap-2">
+                    <span className="text-gray-500 flex-shrink-0 w-20">Transport:</span>
+                    <span className="text-gray-900">HTTP (Streamable HTTP), stateless</span>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <span className="text-gray-500 flex-shrink-0 w-20">Method:</span>
+                    <span className="text-gray-900 font-mono text-xs">POST</span>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <span className="text-gray-500 flex-shrink-0 w-20">Auth header:</span>
+                    <code className="text-gray-900 bg-gray-100 px-1.5 py-0.5 rounded text-xs">x-guideants-apikey: gak_...</code>
+                  </div>
+                </div>
+              </div>
+
+              <div className="border border-gray-200 rounded-lg p-4">
+                <h4 className="text-sm font-medium text-gray-900 mb-3">MCP Tools</h4>
+                <div className="space-y-3 text-sm text-gray-600">
+                  <p>
+                    <code className="text-purple-700 bg-purple-50 px-1.5 py-0.5 rounded text-xs font-medium">tools/list</code>{' '}
+                    returns one tool per addressable assistant — the guide plus each crew member — using each assistant&apos;s name and description.
+                  </p>
+                  <p>
+                    Each assistant tool accepts <code className="bg-gray-100 px-1 rounded text-xs">instructions</code> and an optional{' '}
+                    <code className="bg-gray-100 px-1 rounded text-xs">conversationId</code> to continue on a shared thread (you can switch assistants between turns).
+                  </p>
+                  <p>
+                    <code className="text-purple-700 bg-purple-50 px-1.5 py-0.5 rounded text-xs font-medium">conversation_get</code>{' '}
+                    retrieves conversation history. Client-side tool execution is not supported over MCP.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {mcpEnabled && !publishedGuideId && (
+            <div className="p-3 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-600 italic">
+              The MCP endpoint URL will be shown after saving.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/client/src/types/guides.ts
+++ b/src/client/src/types/guides.ts
@@ -360,6 +360,10 @@ export interface PublishedGuideDto {
   showAttachments?: boolean;
   /** Indicates whether an API key is configured (the key itself is never returned) */
   hasApiKey?: boolean;
+  /** Whether MCP (Model Context Protocol) access is enabled */
+  mcpEnabled?: boolean;
+  /** Client-facing description for MCP discovery */
+  mcpDescription?: string | null;
 }
 
 /** Response returned when generating or regenerating an API key */
@@ -386,6 +390,8 @@ export interface PublishGuideDto {
   collapsible?: boolean;
   showConversationStarters?: boolean;
   showAttachments?: boolean;
+  mcpEnabled?: boolean;
+  mcpDescription?: string;
 }
 
 export interface UpdatePublishedGuideDto {
@@ -403,4 +409,6 @@ export interface UpdatePublishedGuideDto {
   collapsible?: boolean;
   showConversationStarters?: boolean;
   showAttachments?: boolean;
+  mcpEnabled?: boolean;
+  mcpDescription?: string;
 }

--- a/src/client/src/utils/__tests__/notebookPath.test.ts
+++ b/src/client/src/utils/__tests__/notebookPath.test.ts
@@ -23,6 +23,10 @@ describe('notebookPath', () => {
     ]);
   });
 
+  it('matches CWD-relative filenames to Runs folder paths', () => {
+    expect(notebookPathMatches('Runs/ABC123/friendly_duck.png', 'friendly_duck.png')).toBe(true);
+  });
+
   it('matches CWD-relative assistant paths to Output tree paths', () => {
     expect(notebookPathMatches('Output/docs/guideants-product-sheet-v2.md', 'docs/guideants-product-sheet-v2.md')).toBe(true);
   });

--- a/src/client/src/utils/notebookPath.ts
+++ b/src/client/src/utils/notebookPath.ts
@@ -41,6 +41,20 @@ export function notebookPathMatches(candidatePath: string, requestedPath: string
     return false;
   }
 
-  return getNotebookPathCandidates(requestedPath)
-    .some(pathCandidate => normalizeNotebookRelativePath(pathCandidate).toLowerCase() === normalizedCandidate);
+  if (getNotebookPathCandidates(requestedPath)
+    .some(pathCandidate => normalizeNotebookRelativePath(pathCandidate).toLowerCase() === normalizedCandidate)) {
+    return true;
+  }
+
+  const normalizedRequested = normalizeNotebookRelativePath(requestedPath).toLowerCase();
+  if (!normalizedRequested) {
+    return false;
+  }
+
+  // CWD-relative paths from published runs (e.g. "duck.png" -> "Runs/{runId}/duck.png")
+  if (normalizedCandidate === normalizedRequested) {
+    return true;
+  }
+
+  return normalizedCandidate.endsWith(`/${normalizedRequested}`);
 }

--- a/src/server/GuideAntsApi.DataModel/Migrations/20260615164437_AddMcpToPublishedGuide.Designer.cs
+++ b/src/server/GuideAntsApi.DataModel/Migrations/20260615164437_AddMcpToPublishedGuide.Designer.cs
@@ -4,6 +4,7 @@ using GuideAntsApi.DataModel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GuideAntsApi.DataModel.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615164437_AddMcpToPublishedGuide")]
+    partial class AddMcpToPublishedGuide
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/GuideAntsApi.DataModel/Migrations/20260615164437_AddMcpToPublishedGuide.cs
+++ b/src/server/GuideAntsApi.DataModel/Migrations/20260615164437_AddMcpToPublishedGuide.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GuideAntsApi.DataModel.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMcpToPublishedGuide : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "McpDescription",
+                table: "PublishedGuides",
+                type: "nvarchar(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "McpEnabled",
+                table: "PublishedGuides",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "McpDescription",
+                table: "PublishedGuides");
+
+            migrationBuilder.DropColumn(
+                name: "McpEnabled",
+                table: "PublishedGuides");
+        }
+    }
+}

--- a/src/server/GuideAntsApi.DataModel/Models/PublishedGuide.cs
+++ b/src/server/GuideAntsApi.DataModel/Models/PublishedGuide.cs
@@ -123,6 +123,22 @@ namespace GuideAntsApi.DataModel.Models
         public string? ApiKeyHash { get; set; }
 
         /// <summary>
+        /// Whether MCP (Model Context Protocol) access is enabled for this published guide.
+        /// Requires an API key (ApiKeyHash must be set). When enabled, clients can connect
+        /// via the /api/published/mcp?pubId={id} endpoint using a stateless HTTP transport.
+        /// </summary>
+        public bool McpEnabled { get; set; }
+
+        /// <summary>
+        /// Client-facing description exposed via MCP discovery (guide_info tool).
+        /// Written for external AI agents and MCP clients to understand what this guide does,
+        /// what it's good at, and how to interact with it effectively.
+        /// Not the system prompt — this is specifically crafted for client consumption.
+        /// </summary>
+        [StringLength(2000)]
+        public string? McpDescription { get; set; }
+
+        /// <summary>
         /// Optional maximum customer charge (USD) allowed per UTC day for this published guide's notebook.
         /// When exceeded, the guide is automatically blocked for public access until the next UTC day.
         /// </summary>

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/PublishedAssistantHistoryBuilderTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/PublishedAssistantHistoryBuilderTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.Services.Conversations;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class PublishedAssistantHistoryBuilderTests
+{
+    [TestMethod]
+    public void FilterMessages_on_switch_keeps_user_and_plain_assistant_text()
+    {
+        var conv = new NotebookConversation
+        {
+            Id = Guid.NewGuid(),
+            Turns =
+            [
+                new ConversationTurn { TurnIndex = 1, AssistantName = "Guide" }
+            ],
+            Messages =
+            [
+                new NotebookConversationMessage
+                {
+                    TurnIndex = 1,
+                    MessageSequence = 1,
+                    Role = ChatRole.User,
+                    Content = "hello"
+                },
+                new NotebookConversationMessage
+                {
+                    TurnIndex = 1,
+                    MessageSequence = 2,
+                    Role = ChatRole.Assistant,
+                    AssistantName = "Guide",
+                    Content = "hi from guide"
+                }
+            ]
+        };
+
+        var filtered = PublishedAssistantHistoryBuilder.FilterMessages(conv, "Researcher", isAssistantSwitch: true);
+
+        filtered.Should().HaveCount(2);
+        filtered[0].Role.Should().Be(ChatRole.User);
+        filtered[1].Content.Should().Be("hi from guide");
+    }
+
+    [TestMethod]
+    public void IsAssistantSwitch_true_when_last_turn_differs()
+    {
+        var conv = new NotebookConversation
+        {
+            Turns = [new ConversationTurn { TurnIndex = 1, AssistantName = "Guide" }]
+        };
+
+        PublishedAssistantHistoryBuilder.IsAssistantSwitch(conv, "Researcher").Should().BeTrue();
+        PublishedAssistantHistoryBuilder.IsAssistantSwitch(conv, "Guide").Should().BeFalse();
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Mcp/McpAssistantToolNamingTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Mcp/McpAssistantToolNamingTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using GuideAntsApi.Services.Mcp;
+
+namespace GuideAntsApi.Tests.Services.Mcp;
+
+[TestClass]
+public sealed class McpAssistantToolNamingTests
+{
+    [TestMethod]
+    public void AssignToolNames_Sanitizes_and_dedupes()
+    {
+        var roster = McpAssistantToolNaming.AssignToolNames(
+        [
+            (Guid.NewGuid(), "Creative Guide", "Guide desc", true),
+            (Guid.NewGuid(), "Copy Editor", "Edits copy", false),
+            (Guid.NewGuid(), "Copy-Editor", "Duplicate-ish", false)
+        ]);
+
+        roster.Should().HaveCount(3);
+        roster[0].ToolName.Should().Be("Creative_Guide");
+        roster[1].ToolName.Should().Be("Copy_Editor");
+        roster[2].ToolName.Should().Be("Copy-Editor");
+    }
+
+    [TestMethod]
+    public void FindByToolName_is_case_insensitive()
+    {
+        var id = Guid.NewGuid();
+        var roster = McpAssistantToolNaming.AssignToolNames(
+        [
+            (id, "Researcher", "Researches", false)
+        ]);
+
+        var found = McpPublishedAssistantCatalog.FindByToolName(roster, "researcher");
+        found.Should().NotBeNull();
+        found!.AssistantId.Should().Be(id);
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Mcp/McpPublishedContentUrlRewriterTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Mcp/McpPublishedContentUrlRewriterTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using GuideAntsApi.Services.Mcp;
+
+namespace GuideAntsApi.Tests.Services.Mcp;
+
+[TestClass]
+public sealed class McpPublishedContentUrlRewriterTests
+{
+    private const string PublicOrigin = "http://localhost:5107";
+    private const string InternalOrigin = "http://guideants-webapi-ui:8080";
+    private const string PublishedPath =
+        "/api/published/projects/9c7121ba-774c-4f48-8257-f6606911d2cf/notebooks/cd942472-3238-4f65-b4fb-3a6654e93e0c/conversations/66581e63-881d-4480-bb7c-af32866c9d11/files/content?path=Runs%2Fduck.png&pubId=01fd0738-5401-49c7-9af7-fffc8ab5aefc";
+
+    [TestMethod]
+    public void Rewrite_Replaces_internal_host_in_markdown_image()
+    {
+        var input = $"![duck]({InternalOrigin}{PublishedPath})";
+
+        var result = McpPublishedContentUrlRewriter.Rewrite(input, PublicOrigin);
+
+        result.Should().Be($"![duck]({PublicOrigin}{PublishedPath})");
+    }
+
+    [TestMethod]
+    public void Rewrite_Prefixes_path_only_markdown_url_with_public_origin()
+    {
+        var input = $"![duck]({PublishedPath})";
+
+        var result = McpPublishedContentUrlRewriter.Rewrite(input, PublicOrigin);
+
+        result.Should().Be($"![duck]({PublicOrigin}{PublishedPath})");
+    }
+
+    [TestMethod]
+    public void Rewrite_Replaces_internal_host_in_markdown_link()
+    {
+        var input = $"[Full image]({InternalOrigin}{PublishedPath})";
+
+        var result = McpPublishedContentUrlRewriter.Rewrite(input, PublicOrigin);
+
+        result.Should().Be($"[Full image]({PublicOrigin}{PublishedPath})");
+    }
+
+    [TestMethod]
+    public void Rewrite_Replaces_internal_host_in_html_src_attribute()
+    {
+        var input = $"<img src=\"{InternalOrigin}{PublishedPath}\" alt=\"duck\" />";
+
+        var result = McpPublishedContentUrlRewriter.Rewrite(input, PublicOrigin);
+
+        result.Should().Be($"<img src=\"{PublicOrigin}{PublishedPath}\" alt=\"duck\" />");
+    }
+
+    [TestMethod]
+    public void Rewrite_Leaves_non_published_urls_unchanged()
+    {
+        var input = "![chart](https://example.com/assets/chart.png)";
+
+        var result = McpPublishedContentUrlRewriter.Rewrite(input, PublicOrigin);
+
+        result.Should().Be(input);
+    }
+
+    [TestMethod]
+    public void Rewrite_Returns_empty_when_content_null()
+    {
+        McpPublishedContentUrlRewriter.Rewrite(null, PublicOrigin).Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void Rewrite_Returns_original_when_public_origin_missing()
+    {
+        var input = $"![duck]({PublishedPath})";
+
+        McpPublishedContentUrlRewriter.Rewrite(input, null).Should().Be(input);
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Mcp/McpPublishedRunImageEmbedderTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Mcp/McpPublishedRunImageEmbedderTests.cs
@@ -1,0 +1,244 @@
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.Services.Components;
+using GuideAntsApi.Services.Mcp;
+
+namespace GuideAntsApi.Tests.Services.Mcp;
+
+[TestClass]
+public sealed class McpPublishedRunImageEmbedderTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private static ApplicationDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static McpPublishedRunImageEmbedder CreateEmbedder(
+        ApplicationDbContext db,
+        INotebookFileService fileService,
+        McpImageEmbeddingOptions? options = null) =>
+        new(
+            db,
+            fileService,
+            Microsoft.Extensions.Options.Options.Create(options ?? new McpImageEmbeddingOptions()),
+            NullLogger<McpPublishedRunImageEmbedder>.Instance);
+
+    private static NotebookFile AddFile(
+        ApplicationDbContext db,
+        Guid notebookId,
+        string relativePath,
+        DateTime? lastModified = null)
+    {
+        var file = new NotebookFile
+        {
+            Id = Guid.NewGuid(),
+            NotebookId = notebookId,
+            RelativePath = relativePath,
+            FileSize = 1,
+            LastModifiedUtc = lastModified ?? DateTime.UtcNow,
+            FileHash = "hash"
+        };
+        file.GenerateDocumentId(notebookId);
+        db.NotebookFiles.Add(file);
+        return file;
+    }
+
+    private static void AddTurn(
+        ApplicationDbContext db,
+        Guid conversationId,
+        int turnIndex,
+        IEnumerable<string>? created = null,
+        IEnumerable<string>? modified = null)
+    {
+        db.ConversationTurns.Add(new ConversationTurn
+        {
+            Id = Guid.NewGuid(),
+            NotebookConversationId = conversationId,
+            TurnIndex = turnIndex,
+            AssistantName = "Media_Creator",
+            Instructions = "make a dolphin",
+            FilesCreated = created != null ? JsonSerializer.Serialize(created.ToList(), JsonOptions) : null,
+            FilesModified = modified != null ? JsonSerializer.Serialize(modified.ToList(), JsonOptions) : null
+        });
+    }
+
+    private static Mock<INotebookFileService> CreateFileServiceMock(
+        IDictionary<Guid, (byte[] Bytes, string ContentType)> files)
+    {
+        var mock = new Mock<INotebookFileService>();
+        mock.Setup(s => s.GetFileContentStreamAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid id, CancellationToken _) =>
+            {
+                if (!files.TryGetValue(id, out var entry))
+                {
+                    return null;
+                }
+
+                return (new MemoryStream(entry.Bytes) as Stream, entry.ContentType, "file");
+            });
+        return mock;
+    }
+
+    [TestMethod]
+    public async Task EmbedTurnImagesAsync_Embeds_created_png_from_run_folder()
+    {
+        await using var db = CreateContext();
+        var notebookId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+
+        var file = AddFile(db, notebookId, "Runs/xrNV7kuljr/friendly_dolphin.png");
+        AddTurn(db, conversationId, 1, created: ["friendly_dolphin.png"]);
+        await db.SaveChangesAsync();
+
+        var bytes = Encoding.UTF8.GetBytes("PNGDATA");
+        var fileService = CreateFileServiceMock(new Dictionary<Guid, (byte[], string)>
+        {
+            [file.Id] = (bytes, "image/png")
+        });
+
+        var embedder = CreateEmbedder(db, fileService.Object);
+
+        var blocks = await embedder.EmbedTurnImagesAsync(notebookId, conversationId, 1, CancellationToken.None);
+
+        blocks.Should().HaveCount(1);
+        blocks[0].MimeType.Should().Be("image/png");
+        blocks[0].DecodedData.ToArray().Should().Equal(bytes);
+    }
+
+    [TestMethod]
+    public async Task EmbedTurnImagesAsync_Skips_non_image_files()
+    {
+        await using var db = CreateContext();
+        var notebookId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+
+        var script = AddFile(db, notebookId, "Runs/r1/generate.py");
+        var notes = AddFile(db, notebookId, "Runs/r1/notes.txt");
+        AddTurn(db, conversationId, 1, created: ["generate.py", "notes.txt"]);
+        await db.SaveChangesAsync();
+
+        var fileService = CreateFileServiceMock(new Dictionary<Guid, (byte[], string)>
+        {
+            [script.Id] = (Encoding.UTF8.GetBytes("print('hi')"), "text/x-python"),
+            [notes.Id] = (Encoding.UTF8.GetBytes("hello"), "text/plain")
+        });
+
+        var embedder = CreateEmbedder(db, fileService.Object);
+
+        var blocks = await embedder.EmbedTurnImagesAsync(notebookId, conversationId, 1, CancellationToken.None);
+
+        blocks.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task EmbedTurnImagesAsync_Skips_files_over_size_cap()
+    {
+        await using var db = CreateContext();
+        var notebookId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+
+        var file = AddFile(db, notebookId, "Runs/r1/big.png");
+        AddTurn(db, conversationId, 1, created: ["big.png"]);
+        await db.SaveChangesAsync();
+
+        var fileService = CreateFileServiceMock(new Dictionary<Guid, (byte[], string)>
+        {
+            [file.Id] = (new byte[64], "image/png")
+        });
+
+        var embedder = CreateEmbedder(db, fileService.Object, new McpImageEmbeddingOptions { MaxImageBytes = 16 });
+
+        var blocks = await embedder.EmbedTurnImagesAsync(notebookId, conversationId, 1, CancellationToken.None);
+
+        blocks.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task EmbedTurnImagesAsync_Caps_count_and_dedupes()
+    {
+        await using var db = CreateContext();
+        var notebookId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+
+        var files = new Dictionary<Guid, (byte[], string)>();
+        var created = new List<string>();
+        for (var i = 0; i < 7; i++)
+        {
+            var f = AddFile(db, notebookId, $"Runs/r1/img{i}.png");
+            files[f.Id] = (Encoding.UTF8.GetBytes($"img{i}"), "image/png");
+            created.Add($"img{i}.png");
+        }
+
+        // Duplicate reference to the first image should not double-count.
+        created.Add("img0.png");
+        AddTurn(db, conversationId, 1, created: created);
+        await db.SaveChangesAsync();
+
+        var fileService = CreateFileServiceMock(files);
+        var embedder = CreateEmbedder(db, fileService.Object, new McpImageEmbeddingOptions { MaxImagesPerResponse = 5 });
+
+        var blocks = await embedder.EmbedTurnImagesAsync(notebookId, conversationId, 1, CancellationToken.None);
+
+        blocks.Should().HaveCount(5);
+    }
+
+    [TestMethod]
+    public async Task EmbedTurnImagesAsync_Includes_modified_when_enabled()
+    {
+        await using var db = CreateContext();
+        var notebookId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+
+        var modified = AddFile(db, notebookId, "Runs/r1/updated.png");
+        AddTurn(db, conversationId, 1, created: [], modified: ["updated.png"]);
+        await db.SaveChangesAsync();
+
+        var fileService = CreateFileServiceMock(new Dictionary<Guid, (byte[], string)>
+        {
+            [modified.Id] = (Encoding.UTF8.GetBytes("png"), "image/png")
+        });
+
+        var withModified = CreateEmbedder(db, fileService.Object, new McpImageEmbeddingOptions { IncludeModifiedFiles = true });
+        var blocksWith = await withModified.EmbedTurnImagesAsync(notebookId, conversationId, 1, CancellationToken.None);
+        blocksWith.Should().HaveCount(1);
+
+        var withoutModified = CreateEmbedder(db, fileService.Object, new McpImageEmbeddingOptions { IncludeModifiedFiles = false });
+        var blocksWithout = await withoutModified.EmbedTurnImagesAsync(notebookId, conversationId, 1, CancellationToken.None);
+        blocksWithout.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task EmbedTurnImagesAsync_Returns_empty_when_disabled()
+    {
+        await using var db = CreateContext();
+        var notebookId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+
+        var file = AddFile(db, notebookId, "Runs/r1/dolphin.png");
+        AddTurn(db, conversationId, 1, created: ["dolphin.png"]);
+        await db.SaveChangesAsync();
+
+        var fileService = CreateFileServiceMock(new Dictionary<Guid, (byte[], string)>
+        {
+            [file.Id] = (Encoding.UTF8.GetBytes("png"), "image/png")
+        });
+
+        var embedder = CreateEmbedder(db, fileService.Object, new McpImageEmbeddingOptions { EmbedImages = false });
+
+        var blocks = await embedder.EmbedTurnImagesAsync(notebookId, conversationId, 1, CancellationToken.None);
+
+        blocks.Should().BeEmpty();
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/NotebookFileServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/NotebookFileServiceTests.cs
@@ -287,6 +287,51 @@ public class NotebookFileServiceTests
     }
 
     [TestMethod]
+    public async Task GetFileContentStreamAsync_ResolvesCwdRelativeFilenameInRunsFolder()
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), "wf_tests_" + Guid.NewGuid());
+        Directory.CreateDirectory(tmpDir);
+
+        try
+        {
+            await using var ctx = CreateContext();
+            var project = new Project { Id = Guid.NewGuid(), Title = "P" };
+            var notebook = new Notebook { Id = Guid.NewGuid(), ProjectId = project.Id, Title = "NB", NotebookTemplateId = Guid.NewGuid() };
+            ctx.Projects.Add(project);
+            ctx.Notebooks.Add(notebook);
+            await ctx.SaveChangesAsync();
+
+            var notebookRoot = Path.Combine(tmpDir, project.Id.ToString(), "notebooks", notebook.Id.ToString());
+            var runPath = Path.Combine(notebookRoot, "Runs", "ABC123");
+            Directory.CreateDirectory(runPath);
+            var filePath = Path.Combine(runPath, "friendly_duck.png");
+            await File.WriteAllBytesAsync(filePath, [0x89, 0x50, 0x4E, 0x47]);
+
+            ctx.NotebookFiles.Add(new NotebookFile
+            {
+                Id = Guid.NewGuid(),
+                NotebookId = notebook.Id,
+                RelativePath = "Runs/ABC123/friendly_duck.png",
+                FileSize = new FileInfo(filePath).Length,
+                LastModifiedUtc = DateTime.UtcNow,
+                FileHash = "abc",
+                Created = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+
+            var svc = CreateService(ctx, tmpDir);
+            var result = await svc.GetFileContentStreamAsync(project.Id, notebook.Id, "friendly_duck.png");
+
+            Assert.AreEqual("image/png", result.contentType);
+            await result.stream.DisposeAsync();
+        }
+        finally
+        {
+            if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, true);
+        }
+    }
+
+    [TestMethod]
     public async Task GetFileContentStreamAsync_AllowsLlmRelativePathResolution()
     {
         var tmpDir = Path.Combine(Path.GetTempPath(), "wf_tests_" + Guid.NewGuid());

--- a/src/server/GuideAntsApi/Configuration/StartupConfiguration.cs
+++ b/src/server/GuideAntsApi/Configuration/StartupConfiguration.cs
@@ -32,6 +32,7 @@ using GuideAntsApi.Services.LlamaCpp;
 using GuideAntsApi.Services.LlamaCpp.LocalModelOnboarding;
 using GuideAntsApi.Services.Routing;
 using GuideAntsApi.Services.NotebookHeaderToolbar;
+using GuideAntsApi.Services.Mcp;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GuideAntsApi.Configuration;
@@ -366,6 +367,20 @@ public static class StartupConfiguration
             client.Timeout = TimeSpan.FromMinutes(15);
         });
         services.AddScoped<INotebookPodcastService, NotebookPodcastService>();
+
+        // MCP (Model Context Protocol) server for published guides
+        services.Configure<McpImageEmbeddingOptions>(
+            configuration.GetSection(McpImageEmbeddingOptions.SectionName));
+        services.AddScoped<McpPublishedGuideContext>();
+        services.AddScoped<McpPublishedGuideInvokeService>();
+        services.AddScoped<McpPublishedRunImageEmbedder>();
+        services.AddMcpServer()
+            .WithHttpTransport(options =>
+            {
+                options.Stateless = true;
+            })
+            .WithListToolsHandler(McpPublishedGuideToolHandlers.ListToolsAsync)
+            .WithCallToolHandler(McpPublishedGuideToolHandlers.CallToolAsync);
 
     }
 

--- a/src/server/GuideAntsApi/Endpoints/GuidesPublishingEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/GuidesPublishingEndpoints.cs
@@ -38,7 +38,9 @@ public static class GuidesPublishingEndpoints
             Collapsible = pg.Collapsible,
             ShowConversationStarters = pg.ShowConversationStarters,
             ShowAttachments = pg.ShowAttachments,
-            HasApiKey = !string.IsNullOrWhiteSpace(pg.ApiKeyHash)
+            HasApiKey = !string.IsNullOrWhiteSpace(pg.ApiKeyHash),
+            McpEnabled = pg.McpEnabled,
+            McpDescription = pg.McpDescription
         };
     }
 
@@ -203,7 +205,9 @@ var guide = await db.Assistants
                 ShowTurnNavigation = dto.ShowTurnNavigation,
                 Collapsible = dto.Collapsible,
                 ShowConversationStarters = dto.ShowConversationStarters,
-                ShowAttachments = dto.ShowAttachments
+                ShowAttachments = dto.ShowAttachments,
+                McpEnabled = dto.McpEnabled,
+                McpDescription = dto.McpDescription
             };
 
             db.PublishedGuides.Add(publishedGuide);
@@ -324,6 +328,15 @@ var publishedGuide = await db.PublishedGuides
                 return Results.BadRequest(new { error = "Billing period cost limit must be >= 0", field = "billingPeriodChargeLimitUsd" });
             }
 
+            // McpEnabled requires an API key to be configured
+            if (dto.McpEnabled && string.IsNullOrWhiteSpace(publishedGuide.ApiKeyHash))
+            {
+                return Results.BadRequest(new {
+                    error = "MCP requires an API key. Generate one first via the API key endpoint.",
+                    field = "mcpEnabled"
+                });
+            }
+
             // Update fields
             publishedGuide.RetentionPeriod = dto.RetentionPeriod;
             publishedGuide.MaxUserMessageLength = dto.MaxUserMessageLength;
@@ -339,6 +352,8 @@ var publishedGuide = await db.PublishedGuides
             publishedGuide.Collapsible = dto.Collapsible;
             publishedGuide.ShowConversationStarters = dto.ShowConversationStarters;
             publishedGuide.ShowAttachments = dto.ShowAttachments;
+            publishedGuide.McpEnabled = dto.McpEnabled;
+            publishedGuide.McpDescription = dto.McpDescription;
 
             await db.SaveChangesAsync();
 
@@ -486,6 +501,7 @@ publishedGuide.Active = false;
             // Verify project access (must be contributor)
 
 publishedGuide.ApiKeyHash = null;
+            publishedGuide.McpEnabled = false;
             await db.SaveChangesAsync();
 
             return Results.NoContent();

--- a/src/server/GuideAntsApi/Endpoints/PublishedGuidesEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/PublishedGuidesEndpoints.cs
@@ -85,6 +85,10 @@ public static class PublishedGuidesEndpoints
                 collapsible = publishedGuide.Collapsible,
                 showConversationStarters = publishedGuide.ShowConversationStarters,
                 showAttachments = publishedGuide.ShowAttachments,
+                mcpEnabled = publishedGuide.McpEnabled,
+                mcpEndpoint = publishedGuide.McpEnabled
+                    ? $"/api/published/mcp?pubId={publishedGuide.Id}"
+                    : null,
                 conversationStarters = publishedGuide.Guide.ConversationStarters
                     .OrderBy(cs => cs.OrderIndex)
                     .Select(cs => cs.Prompt)
@@ -169,6 +173,10 @@ public static class PublishedGuidesEndpoints
                 collapsible = publishedGuide.Collapsible,
                 showConversationStarters = publishedGuide.ShowConversationStarters,
                 showAttachments = publishedGuide.ShowAttachments,
+                mcpEnabled = publishedGuide.McpEnabled,
+                mcpEndpoint = publishedGuide.McpEnabled
+                    ? $"/api/published/mcp?pubId={publishedGuide.Id}"
+                    : null,
                 conversationStarters = publishedGuide.Guide.ConversationStarters
                     .OrderBy(cs => cs.OrderIndex)
                     .Select(cs => cs.Prompt)

--- a/src/server/GuideAntsApi/Endpoints/PublishedNotebookConversationsEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/PublishedNotebookConversationsEndpoints.cs
@@ -241,24 +241,15 @@ public static class PublishedNotebookConversationsEndpoints
 			// Normalize relative path
 			var normalizedPath = path.Replace("\\", "/");
 
-			// Lookup file by notebook + relative path
-			var nf = await db.NotebookFiles
-				.AsNoTracking()
-				.Where(f => f.NotebookId == notebookId && f.RelativePath == normalizedPath)
-				.FirstOrDefaultAsync();
-			if (nf == null)
+			try
+			{
+				var res = await fileService.GetFileContentStreamAsync(projectId, notebookId, normalizedPath);
+				return Results.Stream(res.stream, res.contentType);
+			}
+			catch (FileNotFoundException)
 			{
 				return Results.NotFound();
 			}
-
-			// Stream through file service (overload by id does not require a user principal)
-			var res = await fileService.GetFileContentStreamAsync(nf.Id);
-			if (res == null)
-			{
-				return Results.NotFound();
-			}
-
-			return Results.Stream(res.Value.Stream, res.Value.ContentType);
 		})
 		.Produces(StatusCodes.Status200OK)
 		.Produces(StatusCodes.Status400BadRequest)

--- a/src/server/GuideAntsApi/GuideAntsApi.csproj
+++ b/src/server/GuideAntsApi/GuideAntsApi.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.10.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.22" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.22" />

--- a/src/server/GuideAntsApi/Models/Guides/PublishedGuideDto.cs
+++ b/src/server/GuideAntsApi/Models/Guides/PublishedGuideDto.cs
@@ -30,6 +30,16 @@ public class PublishedGuideDto
     /// The actual key is never returned - only shown once at creation/regeneration.
     /// </summary>
     public bool HasApiKey { get; set; }
+
+    /// <summary>
+    /// Whether MCP (Model Context Protocol) access is enabled for this published guide.
+    /// </summary>
+    public bool McpEnabled { get; set; }
+
+    /// <summary>
+    /// Client-facing description for MCP discovery. Describes what this guide does and how to use it.
+    /// </summary>
+    public string? McpDescription { get; set; }
 }
 
 public class PublishGuideDto
@@ -52,6 +62,9 @@ public class PublishGuideDto
     public bool Collapsible { get; set; }
     public bool ShowConversationStarters { get; set; }
     public bool ShowAttachments { get; set; }
+    public bool McpEnabled { get; set; }
+    [StringLength(2000)]
+    public string? McpDescription { get; set; }
 }
 
 public class UpdatePublishedGuideDto
@@ -73,6 +86,9 @@ public class UpdatePublishedGuideDto
     public bool Collapsible { get; set; }
     public bool ShowConversationStarters { get; set; }
     public bool ShowAttachments { get; set; }
+    public bool McpEnabled { get; set; }
+    [StringLength(2000)]
+    public string? McpDescription { get; set; }
 }
 
 /// <summary>

--- a/src/server/GuideAntsApi/Program.cs
+++ b/src/server/GuideAntsApi/Program.cs
@@ -1,6 +1,7 @@
 using GuideAntsApi.Configuration;
 using GuideAntsApi.Database;
 using GuideAntsApi.Services.Migrations;
+using GuideAntsApi.Services.Mcp;
 using GuideAntsApi.Endpoints;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http.Features;
@@ -247,6 +248,12 @@ public class Program
         app.UseAuthentication();
         app.UseAuthorization();
 
+        // MCP API key auth middleware — runs only on /api/published/mcp path
+        app.UseWhen(
+            ctx => ctx.Request.Path.StartsWithSegments("/api/published/mcp"),
+            branch => branch.UseMiddleware<McpApiKeyMiddleware>()
+        );
+
         app.MapGet("/api/startup", () => Results.Ok(new { status = "ready" }))
             // Startup readiness is a public host probe.
             .AllowAnonymous();
@@ -281,6 +288,25 @@ public class Program
         app.MapGuideUsageEndpoints();
         app.MapSettingsEndpoints();
         app.MapDocumentServerEndpoints();
+
+        app.MapMcp("/api/published/mcp")
+            .AllowAnonymous()
+            .RequireCors("PublicApiCors");
+
+        // Stateless Streamable HTTP does not map the GET (SSE) or DELETE endpoints. Without an
+        // explicit handler the SPA catch-all fallback answers GET /api/published/mcp with a 404,
+        // which clients such as Cursor treat as a fatal transport error and tombstone the server.
+        // The Streamable HTTP spec requires a 405 here to signal "no server-initiated SSE stream";
+        // compliant clients then operate POST-only. Registered before the SPA pipeline so it wins
+        // over the fallback.
+        app.MapMethods("/api/published/mcp", new[] { "GET", "DELETE" }, (HttpContext ctx) =>
+            {
+                ctx.Response.Headers.Allow = "POST";
+                return Results.StatusCode(StatusCodes.Status405MethodNotAllowed);
+            })
+            .AllowAnonymous()
+            .RequireCors("PublicApiCors");
+
         app.UseGuideAntsUiPipeline(builder.Configuration);
 
         app.Run();

--- a/src/server/GuideAntsApi/Services/Components/NotebookFileService.cs
+++ b/src/server/GuideAntsApi/Services/Components/NotebookFileService.cs
@@ -207,11 +207,11 @@ using var scope2 = CreateDbScope();
 
 using var scope = CreateDbScope();
         var context = GetDbContext(scope);
-        
-        var file = await context.NotebookFiles.FirstOrDefaultAsync(f => f.NotebookId == notebookId && f.RelativePath == relativePath);
+
+        var (file, resolvedPath) = await FindNotebookFileByRelativePathAsync(context, notebookId, relativePath);
         if (file == null) return null;
 
-        if (!TryResolveNotebookPath(projectId, notebookId, relativePath, out var physicalPath))
+        if (!TryResolveNotebookPath(projectId, notebookId, resolvedPath, out var physicalPath))
         {
             return null;
         }
@@ -229,27 +229,8 @@ using var scope = CreateDbScope();
 using var scope = CreateDbScope();
         var context = GetDbContext(scope);
 
-        var normalizedPath = relativePath.Replace("\\", "/");
-        
-        // Try to find the file with the exact path first
-        var file = await context.NotebookFiles.FirstOrDefaultAsync(f => f.NotebookId == notebookId && f.RelativePath == normalizedPath);
-        
-        // If not found, try alternative path resolutions
-        if (file == null)
-        {
-            var alternativePaths = GetAlternativePaths(normalizedPath);
-            foreach (var altPath in alternativePaths)
-            {
-                file = await context.NotebookFiles.FirstOrDefaultAsync(f => f.NotebookId == notebookId && f.RelativePath == altPath);
-                if (file != null)
-                {
-                    _logger.LogInformation("Resolved file path from '{OriginalPath}' to '{ResolvedPath}'", LogValueSanitizer.Sanitize(normalizedPath), LogValueSanitizer.Sanitize(altPath));
-                    normalizedPath = altPath;
-                    break;
-                }
-            }
-        }
-        
+        var (file, normalizedPath) = await FindNotebookFileByRelativePathAsync(context, notebookId, relativePath);
+
         if (file == null)
         {
             throw new FileNotFoundException("Database record not found for the specified file.", relativePath);
@@ -269,6 +250,63 @@ using var scope = CreateDbScope();
         var stream = new FileStream(physicalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         return (stream, contentType);
     }
+
+    private async Task<(NotebookFile? file, string normalizedPath)> FindNotebookFileByRelativePathAsync(
+        ApplicationDbContext context,
+        Guid notebookId,
+        string relativePath)
+    {
+        var normalizedPath = relativePath.Replace("\\", "/");
+
+        var file = await context.NotebookFiles.FirstOrDefaultAsync(
+            f => f.NotebookId == notebookId && f.RelativePath == normalizedPath);
+        if (file != null)
+        {
+            return (file, normalizedPath);
+        }
+
+        foreach (var altPath in GetAlternativePaths(normalizedPath))
+        {
+            file = await context.NotebookFiles.FirstOrDefaultAsync(
+                f => f.NotebookId == notebookId && f.RelativePath == altPath);
+            if (file != null)
+            {
+                _logger.LogInformation(
+                    "Resolved file path from '{OriginalPath}' to '{ResolvedPath}'",
+                    LogValueSanitizer.Sanitize(normalizedPath),
+                    LogValueSanitizer.Sanitize(altPath));
+                return (file, altPath);
+            }
+        }
+
+        if (ShouldTryCwdSuffixMatch(normalizedPath))
+        {
+            file = await context.NotebookFiles
+                .Where(f => f.NotebookId == notebookId)
+                .Where(f => f.RelativePath == normalizedPath || f.RelativePath.EndsWith("/" + normalizedPath))
+                .OrderByDescending(f => f.LastModifiedUtc)
+                .FirstOrDefaultAsync();
+            if (file != null)
+            {
+                _logger.LogInformation(
+                    "Resolved CWD-relative path '{OriginalPath}' to '{ResolvedPath}'",
+                    LogValueSanitizer.Sanitize(normalizedPath),
+                    LogValueSanitizer.Sanitize(file.RelativePath));
+                return (file, file.RelativePath);
+            }
+        }
+
+        return (null, normalizedPath);
+    }
+
+    /// <summary>
+    /// Whether to try suffix matching for CWD-relative paths (e.g. "duck.png" -> "Runs/{runId}/duck.png").
+    /// </summary>
+    private static bool ShouldTryCwdSuffixMatch(string path) =>
+        !string.IsNullOrWhiteSpace(path)
+        && !path.StartsWith("../", StringComparison.Ordinal)
+        && !path.StartsWith("Runs/", StringComparison.OrdinalIgnoreCase)
+        && !path.StartsWith("Output/", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Generates alternative paths to try when a relative file path is not found.

--- a/src/server/GuideAntsApi/Services/Conversations/PublishedAssistantHistoryBuilder.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/PublishedAssistantHistoryBuilder.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using AntRunner.Chat.Abstractions;
+using GuideAntsApi.DataModel.Models;
+using DataModelChatRole = GuideAntsApi.DataModel.Models.ChatRole;
+
+namespace GuideAntsApi.Services.Conversations;
+
+/// <summary>
+/// Filters notebook conversation messages when preparing history for a specific assistant,
+/// including assistant-switch handoff semantics (parity with <see cref="ConversationService"/>).
+/// </summary>
+public static class PublishedAssistantHistoryBuilder
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static bool IsAssistantSwitch(NotebookConversation conv, string assistantName)
+    {
+        var lastTurn = conv.Turns.OrderByDescending(t => t.TurnIndex).FirstOrDefault();
+        return lastTurn != null
+               && !string.Equals(lastTurn.AssistantName, assistantName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool IsNewConversation(NotebookConversation conv) => conv.Messages.Count == 0;
+
+    /// <summary>
+    /// Returns conversation messages in order, filtered for the target assistant.
+    /// When <paramref name="isAssistantSwitch"/> is true, a handoff system line should be appended by the caller.
+    /// </summary>
+    public static IReadOnlyList<NotebookConversationMessage> FilterMessages(
+        NotebookConversation conv,
+        string assistantName,
+        bool isAssistantSwitch)
+    {
+        if (IsNewConversation(conv))
+            return [];
+
+        var deduped = FilterDuplicateAssistantMessages(conv.Messages);
+
+        var validToolCallIds = CollectValidToolCallIds(deduped, assistantName);
+
+        var filtered = new List<NotebookConversationMessage>();
+        foreach (var m in deduped.OrderBy(x => x.TurnIndex).ThenBy(x => x.MessageSequence))
+        {
+            if (m.Role == DataModelChatRole.Tool)
+            {
+                if (string.IsNullOrEmpty(m.ToolCallId) || !validToolCallIds.Contains(m.ToolCallId))
+                    continue;
+            }
+            else if (m.Role == DataModelChatRole.Assistant && !string.IsNullOrEmpty(m.ToolCalls))
+            {
+                if (!string.Equals(m.AssistantName, assistantName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+            }
+            else if (m.Role != DataModelChatRole.User && m.Role != DataModelChatRole.Assistant)
+            {
+                continue;
+            }
+
+            filtered.Add(m);
+        }
+
+        return filtered;
+    }
+
+    public static string HandoffSystemMessage =>
+        "The previous messages between the user and assistant above are from a conversation with a different assistant. " +
+        "Use them to understand the conversation context, but follow the system messages that were provided at the start of this message sequence.";
+
+    private static HashSet<string> CollectValidToolCallIds(
+        IEnumerable<NotebookConversationMessage> messages,
+        string assistantName)
+    {
+        var validToolCallIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var m in messages.Where(m => m.Role == DataModelChatRole.Assistant && !string.IsNullOrEmpty(m.ToolCalls)))
+        {
+            if (!string.Equals(m.AssistantName, assistantName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            try
+            {
+                var toolCalls = JsonSerializer.Deserialize<List<ChatToolCall>>(m.ToolCalls!, JsonOptions);
+                if (toolCalls == null)
+                    continue;
+
+                foreach (var tc in toolCalls)
+                {
+                    if (!string.IsNullOrEmpty(tc.Id))
+                        validToolCallIds.Add(tc.Id);
+                }
+            }
+            catch (JsonException)
+            {
+                // ignore malformed tool call payloads
+            }
+        }
+
+        return validToolCallIds;
+    }
+
+    private static List<NotebookConversationMessage> FilterDuplicateAssistantMessages(
+        ICollection<NotebookConversationMessage> messages)
+    {
+        var turnContentWithToolCalls = new HashSet<(int turn, string content)>();
+        foreach (var m in messages.Where(m =>
+                     m.Role == DataModelChatRole.Assistant && !string.IsNullOrEmpty(m.ToolCalls)))
+        {
+            turnContentWithToolCalls.Add((m.TurnIndex, m.Content?.Trim() ?? string.Empty));
+        }
+
+        var result = new List<NotebookConversationMessage>();
+        foreach (var m in messages)
+        {
+            if (m.Role == DataModelChatRole.Assistant && string.IsNullOrEmpty(m.ToolCalls))
+            {
+                var key = (m.TurnIndex, m.Content?.Trim() ?? string.Empty);
+                if (turnContentWithToolCalls.Contains(key))
+                    continue;
+            }
+
+            result.Add(m);
+        }
+
+        return result;
+    }
+}

--- a/src/server/GuideAntsApi/Services/Conversations/PublishedConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/PublishedConversationService.cs
@@ -348,6 +348,7 @@ public class PublishedConversationService : IPublishedConversationService
 
             var assistantName = dbConversation!.Notebook.Guide?.Name
                 ?? throw new InvalidOperationException("Notebook Guide.Name is required for published conversations.");
+            var publishedAssistantId = dbConversation.Notebook.GuideId ?? dbConversation.Notebook.NotebookTemplateId;
 
             // Handlers mirroring SendMessageStreamAsync
             StreamingMessageProgressEventHandler onProgress = (_, e) =>
@@ -385,6 +386,7 @@ public class PublishedConversationService : IPublishedConversationService
                         TurnIndex = dbTurn!.TurnIndex,
                         MessageSequence = currentMessageSequence++,
                         Role = DataModelChatRole.Assistant,
+                        AssistantId = publishedAssistantId,
                         AssistantName = assistantName,
                         Content = sanitizedAssistant,
                         IsStreaming = false,
@@ -410,6 +412,7 @@ public class PublishedConversationService : IPublishedConversationService
                         TurnIndex = dbTurn!.TurnIndex,
                         MessageSequence = currentMessageSequence++,
                         Role = DataModelChatRole.Tool,
+                        AssistantId = publishedAssistantId,
                         Content = e.Message,
                         ToolCallId = e.ToolCallId,
                         FunctionName = e.FunctionName,
@@ -466,6 +469,7 @@ public class PublishedConversationService : IPublishedConversationService
                     ConversationId: dbConversation.Id,
                     OAuthUserAccessToken: null)
                 {
+                    TurnIndex = dbTurn!.TurnIndex,
                     AssistantId = invocationAssistantId,
                     NotebookConversationMessageId = notebookConversationMessageId
                 };
@@ -488,6 +492,7 @@ public class PublishedConversationService : IPublishedConversationService
                 ConversationId: dbConversation.Id,
                 OAuthUserAccessToken: null)
             {
+                TurnIndex = dbTurn!.TurnIndex,
                 AssistantId = resumeAssistantId,
                 NotebookConversationMessageId = notebookConversationMessageId
             };
@@ -783,9 +788,18 @@ public class PublishedConversationService : IPublishedConversationService
 				}
 			}
 
-			// Determine assistant strictly from the Guide (client does not send AssistantName)
-			var assistantName = dbConversation.Notebook.Guide?.Name
+			// Resolve assistant: guide default, or explicit AssistantName (guide or crew member).
+			var guideId = dbConversation.Notebook.GuideId
+				?? throw new InvalidOperationException("Notebook GuideId is required for published conversations.");
+			var guideName = dbConversation.Notebook.Guide?.Name
 				?? throw new InvalidOperationException("Notebook Guide.Name is required for published conversations.");
+
+			var (assistantName, runningAssistantId) = await ResolvePublishedAssistantAsync(
+				request,
+				guideId,
+				guideName,
+				cancellationToken);
+
 			string? modelDeploymentId = request.ModelDeploymentId;
 
 			if (string.IsNullOrWhiteSpace(modelDeploymentId))
@@ -833,6 +847,7 @@ public class PublishedConversationService : IPublishedConversationService
 					Role = DataModelChatRole.User,
 					Content = request.Instructions,
 					AssistantName = "user",
+					AssistantId = runningAssistantId,
 					ModelDeploymentId = modelDeploymentId,
 					UserId = null, // published has no user
 					ExternalUserIdentity = externalUserIdentity,
@@ -889,6 +904,7 @@ public class PublishedConversationService : IPublishedConversationService
 						TurnIndex = dbTurn!.TurnIndex,
 						MessageSequence = currentMessageSequence++,
 						Role = DataModelChatRole.Assistant,
+						AssistantId = runningAssistantId,
 						AssistantName = assistantName,
 						ModelDeploymentId = modelDeploymentId,
 						Content = string.Empty,
@@ -958,6 +974,7 @@ public class PublishedConversationService : IPublishedConversationService
 								TurnIndex = dbTurn!.TurnIndex,
 								MessageSequence = currentMessageSequence++,
 								Role = DataModelChatRole.Assistant,
+								AssistantId = runningAssistantId,
 								AssistantName = assistantName,
 								ModelDeploymentId = modelDeploymentId,
 								Content = toolCallAssistantText,
@@ -998,6 +1015,7 @@ public class PublishedConversationService : IPublishedConversationService
 							TurnIndex = dbTurn!.TurnIndex,
 							MessageSequence = currentMessageSequence++,
 							Role = DataModelChatRole.Assistant,
+							AssistantId = runningAssistantId,
 							AssistantName = assistantName,
 							ModelDeploymentId = modelDeploymentId,
 							Content = sanitizedAssistant,
@@ -1055,6 +1073,7 @@ public class PublishedConversationService : IPublishedConversationService
 						TurnIndex = dbTurn!.TurnIndex,
 						MessageSequence = currentMessageSequence++,
 						Role = DataModelChatRole.Tool,
+						AssistantId = runningAssistantId,
 						Content = sanitizedContent,
 						ToolCallId = e.ToolCallId,
 						FunctionName = e.FunctionName,
@@ -1095,7 +1114,6 @@ public class PublishedConversationService : IPublishedConversationService
 							}
 							
 							var publishedUrl = BuildPublishedFileUrl(
-								hostUrl,
 								dbConversation.Notebook.ProjectId,
 								dbConversation.NotebookId,
 								dbConversation.Id,
@@ -1144,14 +1162,14 @@ public class PublishedConversationService : IPublishedConversationService
 			};
 
 			// Build invocation context explicitly for published runs.
-			var publishedAssistantId = dbConversation.Notebook.GuideId ?? dbConversation.Notebook.NotebookTemplateId;
 			var ctx = new AntRunner.ToolCalling.InvocationContext(
 				ProjectId: dbConversation.Notebook.ProjectId,
 				NotebookId: dbConversation.NotebookId,
 				ConversationId: dbConversation.Id,
 				OAuthUserAccessToken: chatOptions.oAuthUserAccessToken)
 			{
-				AssistantId = publishedAssistantId,
+				TurnIndex = dbTurn!.TurnIndex,
+				AssistantId = runningAssistantId,
 				NotebookConversationMessageId = userMessageId
 			};
 
@@ -1597,7 +1615,12 @@ public class PublishedConversationService : IPublishedConversationService
 		{
 			var path = m.Groups["path"].Value;
 			var relativePath = NormalizeSandboxPath(path);
-			var publishedUrl = BuildPublishedFileUrl(hostUrl, projectId, notebookId, conversationId, relativePath, publisherId);
+			var publishedUrl = BuildPublishedFileUrl(
+								projectId,
+								notebookId,
+								conversationId,
+								relativePath,
+								publisherId);
 			return m.Groups["head"].Value + publishedUrl + m.Groups["tail"].Value;
 		});
 
@@ -1610,7 +1633,12 @@ public class PublishedConversationService : IPublishedConversationService
 		{
 			var path = m.Groups["path"].Value;
 			var relativePath = NormalizeSandboxPath(path);
-			var publishedUrl = BuildPublishedFileUrl(hostUrl, projectId, notebookId, conversationId, relativePath, publisherId);
+			var publishedUrl = BuildPublishedFileUrl(
+								projectId,
+								notebookId,
+								conversationId,
+								relativePath,
+								publisherId);
 			return $"{m.Groups["attr"].Value}=\"{publishedUrl}\"";
 		});
 
@@ -1623,7 +1651,12 @@ public class PublishedConversationService : IPublishedConversationService
 		{
 			var path = m.Groups["path"].Value;
 			var relativePath = NormalizeSandboxPath(path);
-			var publishedUrl = BuildPublishedFileUrl(hostUrl, projectId, notebookId, conversationId, relativePath, publisherId);
+			var publishedUrl = BuildPublishedFileUrl(
+								projectId,
+								notebookId,
+								conversationId,
+								relativePath,
+								publisherId);
 			return $"{m.Groups["attr"].Value}='{publishedUrl}'";
 		});
 
@@ -1788,7 +1821,7 @@ public class PublishedConversationService : IPublishedConversationService
 		return map;
 	}
 
-	private static string BuildPublishedFileUrl(string? hostUrl, Guid projectId, Guid notebookId, Guid conversationId, string relativePath, string? pubId)
+	private static string BuildPublishedFileUrl(Guid projectId, Guid notebookId, Guid conversationId, string relativePath, string? pubId)
 	{
 		var pathEncoded = Uri.EscapeDataString(relativePath);
 		var basePath = $"/api/published/projects/{projectId}/notebooks/{notebookId}/conversations/{conversationId}/files/content?path={pathEncoded}";
@@ -1797,13 +1830,7 @@ public class PublishedConversationService : IPublishedConversationService
 			basePath += $"&pubId={Uri.EscapeDataString(pubId)}";
 		}
 
-		if (!string.IsNullOrWhiteSpace(hostUrl))
-		{
-			var trimmed = hostUrl!.TrimEnd('/');
-			return $"{trimmed}{basePath}";
-		}
-
-		// No host configured: return path rooted at /api so client can resolve with api base
+		// Path-only URL: each client (browser, Electron, MCP) resolves against its own API origin.
 		return basePath;
 	}
 
@@ -1985,7 +2012,7 @@ public class PublishedConversationService : IPublishedConversationService
 				}
 
 				// Build published URL
-				var publishedBase = BuildPublishedFileUrl(hostUrl, projectId, notebookId, conversationId, relativeFilePath!, publisherId);
+				var publishedBase = BuildPublishedFileUrl(projectId, notebookId, conversationId, relativeFilePath!, publisherId);
 				if (!string.IsNullOrWhiteSpace(mValue))
 				{
 					publishedBase = AppendQueryParamIfMissing(publishedBase, "m", mValue!);
@@ -2025,49 +2052,43 @@ public class PublishedConversationService : IPublishedConversationService
 	private async Task<List<ChatMessage>> BuildMessagesForAssistantAsync(NotebookConversation conv, string assistantName, string? clientContext, CancellationToken ct)
 	{
 		var list = new List<ChatMessage>();
+		AntRunner.ToolCalling.AssistantDefinitions.AssistantDefinition? assistantDef = null;
 
 		// Assistant definition system messages
 		try
 		{
-			var assistantDef = await AssistantUtility.GetAssistantCreateRequest(assistantName);
+			assistantDef = await AssistantUtility.GetAssistantCreateRequest(assistantName);
 			if (assistantDef != null)
 			{
-				// 1. Assistant instructions (primary system prompt)
 				if (!string.IsNullOrWhiteSpace(assistantDef.Instructions))
 				{
 					list.Add(new ChatMessage(ChatMessageRole.System, assistantDef.Instructions));
 				}
 
-				// 2. Client-provided context (if any)
 				if (!string.IsNullOrWhiteSpace(clientContext))
 				{
 					list.Add(new ChatMessage(ChatMessageRole.System, clientContext));
-				}
-
-				// 3. Server-side context options come LAST to separate them clearly
-				var serverContextMsg = _contextOptionsService.BuildPublishedContextMessage(
-					assistantDef,
-					conv.Notebook?.ProjectId ?? Guid.Empty,
-					conv.Notebook?.Id ?? Guid.Empty);
-				if (!string.IsNullOrWhiteSpace(serverContextMsg))
-				{
-					list.Add(new ChatMessage(ChatMessageRole.System, serverContextMsg));
 				}
 			}
 		}
 		catch { /* ignore */ }
 
+		var isNewConversation = PublishedAssistantHistoryBuilder.IsNewConversation(conv);
+		var isAssistantSwitch = !isNewConversation && PublishedAssistantHistoryBuilder.IsAssistantSwitch(conv, assistantName);
+		var historyMessages = isNewConversation
+			? Array.Empty<NotebookConversationMessage>()
+			: PublishedAssistantHistoryBuilder.FilterMessages(conv, assistantName, isAssistantSwitch);
+
 		// Add conversation history with attachment support
 		using (var scope = _scopeFactory.CreateScope())
 		{
 			var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-			// Pre-index tool messages by toolCallId so we can place them immediately after their assistant tool_calls
-			var toolById = conv.Messages
+			var toolById = historyMessages
 				.Where(x => x.Role == DataModelChatRole.Tool && x.ToolCallId != null && x.FunctionName != null)
 				.ToDictionary(x => x.ToolCallId!, x => x, StringComparer.OrdinalIgnoreCase);
 			var emittedToolCallIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-			foreach (var m in conv.Messages.OrderBy(m => m.TurnIndex).ThenBy(m => m.MessageSequence))
+			foreach (var m in historyMessages)
 			{
 				// Tool response filtering: include only tool messages that belong to included assistant messages
 				// For simplicity, include all user/assistant messages and tool messages with IDs.
@@ -2173,7 +2194,55 @@ public class PublishedConversationService : IPublishedConversationService
 			}
 		}
 
+		if (isAssistantSwitch && conv.Messages.Count > 0)
+		{
+			list.Add(new ChatMessage(ChatMessageRole.System, PublishedAssistantHistoryBuilder.HandoffSystemMessage));
+		}
+
+		if (assistantDef != null)
+		{
+			var serverContextMsg = _contextOptionsService.BuildPublishedContextMessage(
+				assistantDef,
+				conv.Notebook?.ProjectId ?? Guid.Empty,
+				conv.Notebook?.Id ?? Guid.Empty);
+			if (!string.IsNullOrWhiteSpace(serverContextMsg))
+			{
+				list.Add(new ChatMessage(ChatMessageRole.System, serverContextMsg));
+			}
+		}
+
 		return list;
+	}
+
+	private async Task<(string Name, Guid Id)> ResolvePublishedAssistantAsync(
+		SendMessageRequest request,
+		Guid guideId,
+		string guideName,
+		CancellationToken cancellationToken)
+	{
+		var assistantName = string.IsNullOrWhiteSpace(request.AssistantName)
+			? guideName
+			: request.AssistantName.Trim();
+
+		if (string.Equals(assistantName, guideName, StringComparison.OrdinalIgnoreCase))
+			return (guideName, guideId);
+
+		using var scope = _scopeFactory.CreateScope();
+		var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+		var crewMember = await db.GuideMembers
+			.AsNoTracking()
+			.Where(gm => gm.GuideId == guideId && gm.Assistant.Name == assistantName)
+			.Select(gm => new { gm.AssistantId, Name = gm.Assistant.Name })
+			.FirstOrDefaultAsync(cancellationToken);
+
+		if (crewMember == null)
+		{
+			throw new InvalidOperationException(
+				$"Assistant '{assistantName}' is not a member of this published guide.");
+		}
+
+		return (crewMember.Name, crewMember.AssistantId);
 	}
 
 	private static IReadOnlyList<ChatThinkingBlock>? DeserializeThinkingBlocks(string? json)

--- a/src/server/GuideAntsApi/Services/Mcp/McpAddressableAssistant.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpAddressableAssistant.cs
@@ -1,0 +1,11 @@
+namespace GuideAntsApi.Services.Mcp;
+
+/// <summary>
+/// A guide or crew member exposed as an MCP tool for a published guide.
+/// </summary>
+public sealed record McpAddressableAssistant(
+    Guid AssistantId,
+    string Name,
+    string ToolName,
+    string Description,
+    bool IsGuide);

--- a/src/server/GuideAntsApi/Services/Mcp/McpApiKeyMiddleware.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpApiKeyMiddleware.cs
@@ -1,0 +1,135 @@
+using Microsoft.EntityFrameworkCore;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.Services.Auth;
+using GuideAntsApi.Services.PublishedGuides;
+
+namespace GuideAntsApi.Services.Mcp;
+
+/// <summary>
+/// Middleware that authenticates MCP requests on the <c>/api/published/mcp</c> path.
+/// Validates the <c>pubId</c> query parameter and the <c>x-guideants-apikey</c> header,
+/// checks that the published guide is active, MCP-enabled, and within cost limits,
+/// then populates <see cref="McpPublishedGuideContext"/> for downstream MCP tool methods.
+/// </summary>
+public class McpApiKeyMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<McpApiKeyMiddleware> _logger;
+
+    public McpApiKeyMiddleware(RequestDelegate next, ILogger<McpApiKeyMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var pubIdStr = context.Request.Query["pubId"].ToString();
+        if (string.IsNullOrWhiteSpace(pubIdStr) || !Guid.TryParse(pubIdStr, out var pubId))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsJsonAsync(new { error = "missing_pub_id", message = "The 'pubId' query parameter is required." });
+            return;
+        }
+
+        var apiKey = context.Request.Headers[PublishedGuideAuthService.ApiKeyHeaderName].ToString();
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsJsonAsync(new { error = "api_key_required", message = "MCP access requires an API key via the x-guideants-apikey header." });
+            return;
+        }
+
+        var db = context.RequestServices.GetRequiredService<ApplicationDbContext>();
+
+        var publishedGuide = await db.PublishedGuides
+            .AsNoTracking()
+            .Include(pg => pg.Notebook)
+            .Include(pg => pg.Guide)
+                .ThenInclude(g => g!.CrewMembers)
+                    .ThenInclude(cm => cm.Assistant)
+            .FirstOrDefaultAsync(pg => pg.Id == pubId && pg.Active);
+
+        if (publishedGuide == null)
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await context.Response.WriteAsJsonAsync(new { error = "not_found", message = "Published guide not found or inactive." });
+            return;
+        }
+
+        if (!publishedGuide.McpEnabled)
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsJsonAsync(new { error = "mcp_not_enabled", message = "MCP is not enabled for this published guide." });
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(publishedGuide.ApiKeyHash))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsJsonAsync(new { error = "mcp_requires_api_key", message = "MCP requires an API key to be configured on the published guide." });
+            return;
+        }
+
+        var providedHash = PublishedGuideAuthService.HashApiKey(apiKey);
+        if (!string.Equals(providedHash, publishedGuide.ApiKeyHash, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning("Invalid MCP API key for published guide {PubId}", pubId);
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsJsonAsync(new { error = "invalid_api_key", message = "The provided API key is invalid." });
+            return;
+        }
+
+        var costLimits = context.RequestServices.GetRequiredService<IPublishedGuideCostLimitService>();
+        var limitResult = await costLimits.EnsureWithinLimitsAsync(publishedGuide.NotebookId, context.RequestAborted);
+        if (!limitResult.Allowed)
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsJsonAsync(new
+            {
+                error = "published_guide_cost_limit_exceeded",
+                reason = limitResult.Reason,
+                dailyLimitUsd = limitResult.DailyLimitUsd,
+                dailyChargeUsd = limitResult.DailyChargeUsd,
+                billingPeriodLimitUsd = limitResult.BillingPeriodLimitUsd,
+                billingPeriodChargeUsd = limitResult.BillingPeriodChargeUsd
+            });
+            return;
+        }
+
+        var mcpContext = context.RequestServices.GetRequiredService<McpPublishedGuideContext>();
+        mcpContext.PubId = pubId;
+        mcpContext.ProjectId = publishedGuide.Notebook.ProjectId;
+        mcpContext.NotebookId = publishedGuide.NotebookId;
+        mcpContext.GuideId = publishedGuide.GuideId;
+        mcpContext.UserIdentity = "api-key-user";
+        mcpContext.IsValid = true;
+        mcpContext.GuideName = publishedGuide.Guide?.Name ?? string.Empty;
+        mcpContext.GuideDescription = publishedGuide.Guide?.Description;
+        mcpContext.McpDescription = publishedGuide.McpDescription;
+        mcpContext.PublicApiOrigin = ResolvePublicApiOrigin(context);
+        mcpContext.AddressableAssistants = await McpPublishedAssistantCatalog.LoadAsync(
+            db,
+            publishedGuide.GuideId,
+            publishedGuide.McpDescription,
+            context.RequestAborted);
+
+        await _next(context);
+    }
+
+    private static string ResolvePublicApiOrigin(HttpContext context)
+    {
+        var scheme = context.Request.Scheme?.Trim();
+        if (string.IsNullOrWhiteSpace(scheme))
+        {
+            throw new InvalidOperationException("Unable to resolve MCP public API origin because request scheme is missing.");
+        }
+
+        if (!context.Request.Host.HasValue)
+        {
+            throw new InvalidOperationException("Unable to resolve MCP public API origin because request host is missing.");
+        }
+
+        return $"{scheme}://{context.Request.Host.Value}".TrimEnd('/');
+    }
+}

--- a/src/server/GuideAntsApi/Services/Mcp/McpAssistantInvokeResult.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpAssistantInvokeResult.cs
@@ -1,0 +1,13 @@
+namespace GuideAntsApi.Services.Mcp;
+
+/// <summary>
+/// Structured result of an MCP assistant invocation. Carries the JSON payload returned to MCP
+/// clients plus the identifiers needed to embed the run's output images as <c>ImageContentBlock</c>s.
+/// </summary>
+/// <param name="Json">The serialized JSON payload (or a JSON error document on failure).</param>
+/// <param name="ConversationId">The conversation the turn belongs to; null on error.</param>
+/// <param name="TurnIndex">The index of the turn produced by this invocation; null on error.</param>
+public sealed record McpAssistantInvokeResult(
+    string Json,
+    Guid? ConversationId,
+    int? TurnIndex);

--- a/src/server/GuideAntsApi/Services/Mcp/McpAssistantToolNaming.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpAssistantToolNaming.cs
@@ -1,0 +1,63 @@
+using System.Text;
+
+namespace GuideAntsApi.Services.Mcp;
+
+/// <summary>
+/// Sanitizes assistant display names into MCP tool names (aligned with crew-bridge operation IDs).
+/// </summary>
+public static class McpAssistantToolNaming
+{
+    public static IReadOnlyList<McpAddressableAssistant> AssignToolNames(
+        IEnumerable<(Guid Id, string Name, string Description, bool IsGuide)> assistants)
+    {
+        var usedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<McpAddressableAssistant>();
+
+        foreach (var (id, name, description, isGuide) in assistants)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            var toolName = SanitizeOperationId(name.Trim(), usedIds);
+            var desc = string.IsNullOrWhiteSpace(description)
+                ? $"Invoke {name.Trim()}."
+                : description.Trim();
+
+            result.Add(new McpAddressableAssistant(id, name.Trim(), toolName, desc, isGuide));
+        }
+
+        return result;
+    }
+
+    public static string SanitizeOperationId(string name, ISet<string> used)
+    {
+        var sb = new StringBuilder(name.Length);
+        foreach (var ch in name)
+        {
+            if (char.IsLetterOrDigit(ch) || ch == '_' || ch == '-')
+                sb.Append(ch);
+            else
+                sb.Append('_');
+        }
+
+        var baseId = sb.ToString().Trim('_', '-');
+        if (string.IsNullOrEmpty(baseId))
+            baseId = "assistant";
+
+        if (baseId.Length > 64)
+            baseId = baseId[..64];
+
+        var candidate = baseId;
+        var i = 2;
+        while (used.Contains(candidate))
+        {
+            var suffix = "_" + i.ToString();
+            var limit = 64 - suffix.Length;
+            candidate = (baseId.Length > limit ? baseId[..limit] : baseId) + suffix;
+            i++;
+        }
+
+        used.Add(candidate);
+        return candidate;
+    }
+}

--- a/src/server/GuideAntsApi/Services/Mcp/McpImageEmbeddingOptions.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpImageEmbeddingOptions.cs
@@ -1,0 +1,22 @@
+namespace GuideAntsApi.Services.Mcp;
+
+/// <summary>
+/// Options controlling how run output images are embedded into MCP tool responses.
+/// Bound from the "Mcp" configuration section.
+/// </summary>
+public sealed class McpImageEmbeddingOptions
+{
+    public const string SectionName = "Mcp";
+
+    /// <summary>Whether to embed run output images as <c>ImageContentBlock</c>s.</summary>
+    public bool EmbedImages { get; set; } = true;
+
+    /// <summary>Maximum number of images embedded in a single tool response.</summary>
+    public int MaxImagesPerResponse { get; set; } = 5;
+
+    /// <summary>Maximum size (bytes) of an individual image to embed; larger files are skipped.</summary>
+    public long MaxImageBytes { get; set; } = 4L * 1024 * 1024;
+
+    /// <summary>Whether files modified during the turn (in addition to created) are eligible for embedding.</summary>
+    public bool IncludeModifiedFiles { get; set; } = true;
+}

--- a/src/server/GuideAntsApi/Services/Mcp/McpPublishedAssistantCatalog.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpPublishedAssistantCatalog.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+
+namespace GuideAntsApi.Services.Mcp;
+
+public static class McpPublishedAssistantCatalog
+{
+    public const string ConversationGetToolName = "conversation_get";
+
+    public static async Task<IReadOnlyList<McpAddressableAssistant>> LoadAsync(
+        ApplicationDbContext db,
+        Guid guideId,
+        string? mcpDescription,
+        CancellationToken cancellationToken = default)
+    {
+        var guide = await db.Assistants
+            .AsNoTracking()
+            .Include(a => a.CrewMembers)
+                .ThenInclude(cm => cm.Assistant)
+            .FirstOrDefaultAsync(a => a.Id == guideId, cancellationToken);
+
+        if (guide == null)
+            return [];
+
+        var entries = new List<(Guid Id, string Name, string Description, bool IsGuide)>
+        {
+            (
+                guide.Id,
+                guide.Name,
+                mcpDescription ?? guide.Description ?? string.Empty,
+                true
+            )
+        };
+
+        foreach (var member in guide.CrewMembers.OrderBy(cm => cm.DisplayOrder))
+        {
+            if (member.Assistant == null || string.IsNullOrWhiteSpace(member.Assistant.Name))
+                continue;
+
+            entries.Add((
+                member.AssistantId,
+                member.Assistant.Name,
+                member.Assistant.Description ?? string.Empty,
+                false));
+        }
+
+        return McpAssistantToolNaming.AssignToolNames(entries);
+    }
+
+    public static McpAddressableAssistant? FindByToolName(
+        IReadOnlyList<McpAddressableAssistant> roster,
+        string toolName)
+    {
+        return roster.FirstOrDefault(a =>
+            string.Equals(a.ToolName, toolName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static McpAddressableAssistant? FindByName(
+        IReadOnlyList<McpAddressableAssistant> roster,
+        string assistantName)
+    {
+        return roster.FirstOrDefault(a =>
+            string.Equals(a.Name, assistantName, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/server/GuideAntsApi/Services/Mcp/McpPublishedContentUrlRewriter.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpPublishedContentUrlRewriter.cs
@@ -1,0 +1,102 @@
+using System.Text.RegularExpressions;
+
+namespace GuideAntsApi.Services.Mcp;
+
+/// <summary>
+/// Rewrites published guide file URLs in assistant markdown so MCP clients receive
+/// links reachable from the caller's perspective (the incoming HTTP request origin).
+/// </summary>
+internal static class McpPublishedContentUrlRewriter
+{
+    private const string PublishedApiPrefix = "/api/published/";
+
+    // Markdown images/links: ![alt](url) or [text](url)
+    private static readonly Regex MarkdownUrlPattern = new(
+        @"(?<head>(!\[[^\]]*\]|\[[^\]]*\])\()(?<url>[^)]+)(?<tail>\))",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // HTML href="..." or src="..." (double-quoted)
+    private static readonly Regex HtmlDoubleQuotedUrlPattern = new(
+        @"(?<attr>href|src)\s*=\s*""(?<url>[^""]+)""",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // HTML href='...' or src='...' (single-quoted)
+    private static readonly Regex HtmlSingleQuotedUrlPattern = new(
+        @"(?<attr>href|src)\s*=\s*'(?<url>[^']+)'",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public static string Rewrite(string? content, string? publicApiOrigin)
+    {
+        if (string.IsNullOrEmpty(content) || string.IsNullOrWhiteSpace(publicApiOrigin))
+        {
+            return content ?? string.Empty;
+        }
+
+        var origin = publicApiOrigin.TrimEnd('/');
+
+        var result = MarkdownUrlPattern.Replace(content, m =>
+        {
+            var rewritten = RewriteUrl(m.Groups["url"].Value, origin);
+            return m.Groups["head"].Value + rewritten + m.Groups["tail"].Value;
+        });
+
+        result = HtmlDoubleQuotedUrlPattern.Replace(result, m =>
+        {
+            var rewritten = RewriteUrl(m.Groups["url"].Value, origin);
+            return $"{m.Groups["attr"].Value}=\"{rewritten}\"";
+        });
+
+        result = HtmlSingleQuotedUrlPattern.Replace(result, m =>
+        {
+            var rewritten = RewriteUrl(m.Groups["url"].Value, origin);
+            return $"{m.Groups["attr"].Value}='{rewritten}'";
+        });
+
+        return result;
+    }
+
+    private static string RewriteUrl(string url, string origin)
+    {
+        if (string.IsNullOrWhiteSpace(url) || !ContainsPublishedApiPath(url))
+        {
+            return url;
+        }
+
+        var publishedPathAndQuery = ExtractPublishedPathAndQuery(url);
+        if (publishedPathAndQuery == null)
+        {
+            return url;
+        }
+
+        return origin + publishedPathAndQuery;
+    }
+
+    private static bool ContainsPublishedApiPath(string url) =>
+        url.Contains(PublishedApiPrefix, StringComparison.OrdinalIgnoreCase);
+
+    private static string? ExtractPublishedPathAndQuery(string url)
+    {
+        if (url.StartsWith(PublishedApiPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return url;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var absolute))
+        {
+            return null;
+        }
+
+        var pathAndQuery = absolute.AbsolutePath;
+        if (!string.IsNullOrEmpty(absolute.Query))
+        {
+            pathAndQuery += absolute.Query;
+        }
+
+        if (!pathAndQuery.StartsWith(PublishedApiPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return pathAndQuery;
+    }
+}

--- a/src/server/GuideAntsApi/Services/Mcp/McpPublishedGuideContext.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpPublishedGuideContext.cs
@@ -1,0 +1,32 @@
+namespace GuideAntsApi.Services.Mcp;
+
+/// <summary>
+/// Scoped service populated by <see cref="McpApiKeyMiddleware"/> and consumed by MCP tool methods.
+/// Contains the resolved published-guide context for the current request.
+/// </summary>
+public class McpPublishedGuideContext
+{
+    public Guid PubId { get; set; }
+    public Guid ProjectId { get; set; }
+    public Guid NotebookId { get; set; }
+    public Guid GuideId { get; set; }
+    public string? UserIdentity { get; set; }
+    public bool IsValid { get; set; }
+
+    // Guide metadata for discovery
+    public string GuideName { get; set; } = string.Empty;
+    public string? GuideDescription { get; set; }
+    public string? McpDescription { get; set; }
+
+    /// <summary>
+    /// Public API origin for the current MCP request (scheme + host), used to rewrite
+    /// published file URLs before returning content to external MCP clients.
+    /// </summary>
+    public string? PublicApiOrigin { get; set; }
+
+    /// <summary>
+    /// Guide plus crew members exposed as MCP tools for this published guide.
+    /// Populated by <see cref="McpApiKeyMiddleware"/>.
+    /// </summary>
+    public IReadOnlyList<McpAddressableAssistant> AddressableAssistants { get; set; } = [];
+}

--- a/src/server/GuideAntsApi/Services/Mcp/McpPublishedGuideInvokeService.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpPublishedGuideInvokeService.cs
@@ -1,0 +1,180 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.Models.Conversations;
+using GuideAntsApi.Services.Conversations;
+
+namespace GuideAntsApi.Services.Mcp;
+
+public sealed class McpPublishedGuideInvokeService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly IPublishedConversationService _conversations;
+    private readonly ApplicationDbContext _db;
+
+    public McpPublishedGuideInvokeService(
+        IPublishedConversationService conversations,
+        ApplicationDbContext db)
+    {
+        _conversations = conversations;
+        _db = db;
+    }
+
+    public async Task<McpAssistantInvokeResult> InvokeAssistantAsync(
+        McpAddressableAssistant assistant,
+        string instructions,
+        string? conversationId,
+        string? title,
+        McpPublishedGuideContext mcpContext,
+        CancellationToken cancellationToken)
+    {
+        if (!mcpContext.IsValid)
+            return Failure(JsonError("unauthorized", "MCP context is not valid."));
+
+        if (string.IsNullOrWhiteSpace(instructions))
+            return Failure(JsonError("missing_instructions", "The instructions parameter is required."));
+
+        Guid convoId;
+        if (string.IsNullOrWhiteSpace(conversationId))
+        {
+            var convoTitle = string.IsNullOrWhiteSpace(title)
+                ? DateTime.UtcNow.ToString("f", System.Globalization.CultureInfo.InvariantCulture)
+                : title.Trim();
+
+            var conversation = await _conversations.CreateConversationAsync(mcpContext.NotebookId, convoTitle);
+            convoId = conversation.Id;
+        }
+        else
+        {
+            if (!Guid.TryParse(conversationId, out convoId))
+                return Failure(JsonError("invalid_conversation_id", "The conversationId is not a valid GUID."));
+
+            var belongs = await _db.NotebookConversations
+                .AsNoTracking()
+                .AnyAsync(c => c.Id == convoId && c.NotebookId == mcpContext.NotebookId, cancellationToken);
+            if (!belongs)
+                return Failure(JsonError("not_found", "Conversation not found in this published guide notebook."));
+        }
+
+        var request = new SendMessageRequest
+        {
+            Instructions = instructions.Trim(),
+            AssistantName = assistant.Name
+        };
+
+        string? errorMessage = null;
+        var pendingClientTool = false;
+
+        await foreach (var ev in _conversations.SendMessageStreamAsync(
+                           convoId,
+                           request,
+                           mcpContext.PubId.ToString(),
+                           mcpContext.UserIdentity,
+                           cancellationToken))
+        {
+            switch (ev.EventType)
+            {
+                case StreamingEventTypes.PendingClientTool:
+                case StreamingEventTypes.ExternalToolCall:
+                    pendingClientTool = true;
+                    break;
+                case StreamingEventTypes.Error:
+                    errorMessage = ev.Payload;
+                    break;
+            }
+        }
+
+        if (pendingClientTool)
+        {
+            return Failure(JsonError(
+                "client_tools_not_supported",
+                $"Assistant '{assistant.Name}' requires client-side tools, which are not available over MCP."));
+        }
+
+        if (errorMessage != null)
+            return Failure(JsonError("invoke_failed", errorMessage));
+
+        var assistantMessage = await _db.NotebookConversationMessages
+            .AsNoTracking()
+            .Where(m => m.NotebookConversationId == convoId
+                        && m.Role == ChatRole.Assistant
+                        && m.AssistantName == assistant.Name
+                        && m.IsStreaming != true)
+            .OrderByDescending(m => m.TurnIndex)
+            .ThenByDescending(m => m.MessageSequence)
+            .Select(m => new { m.Content })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        // The turn (with its tracked output files) is persisted by the time the stream completes.
+        var latestTurnIndex = await _db.ConversationTurns
+            .AsNoTracking()
+            .Where(t => t.NotebookConversationId == convoId)
+            .MaxAsync(t => (int?)t.TurnIndex, cancellationToken);
+
+        var json = JsonSerialize(new
+        {
+            assistantId = assistant.AssistantId,
+            assistantName = assistant.Name,
+            conversationId = convoId,
+            response = RewriteForMcpClient(assistantMessage?.Content, mcpContext)
+        });
+
+        return new McpAssistantInvokeResult(json, convoId, latestTurnIndex);
+    }
+
+    public async Task<string> GetConversationAsync(
+        string conversationId,
+        McpPublishedGuideContext mcpContext,
+        CancellationToken cancellationToken)
+    {
+        if (!mcpContext.IsValid)
+            return JsonError("unauthorized", "MCP context is not valid.");
+
+        if (!Guid.TryParse(conversationId, out var convoId))
+            return JsonError("invalid_conversation_id", "The conversationId is not a valid GUID.");
+
+        var belongs = await _db.NotebookConversations
+            .AsNoTracking()
+            .AnyAsync(c => c.Id == convoId && c.NotebookId == mcpContext.NotebookId, cancellationToken);
+        if (!belongs)
+            return JsonError("not_found", "Conversation not found.");
+
+        var convo = await _conversations.GetConversationWithMessagesAsync(convoId);
+        if (convo == null)
+            return JsonError("not_found", "Conversation not found.");
+
+        return JsonSerialize(new
+        {
+            conversationId = convo.Id,
+            title = convo.Title,
+            currentAssistant = convo.AssistantName,
+            created = convo.Created,
+            messages = convo.Messages.Select(m => new
+            {
+                role = m.Role.ToString().ToLowerInvariant(),
+                assistantName = m.AssistantName,
+                content = RewriteForMcpClient(m.Content, mcpContext),
+                created = m.Created,
+                turnIndex = m.TurnIndex
+            })
+        });
+    }
+
+    private static string RewriteForMcpClient(string? content, McpPublishedGuideContext mcpContext) =>
+        McpPublishedContentUrlRewriter.Rewrite(content, mcpContext.PublicApiOrigin);
+
+    private static string JsonSerialize(object value) =>
+        JsonSerializer.Serialize(value, JsonOptions);
+
+    private static McpAssistantInvokeResult Failure(string json) =>
+        new(json, null, null);
+
+    public static string JsonError(string code, string message) =>
+        JsonSerialize(new { error = code, message });
+}

--- a/src/server/GuideAntsApi/Services/Mcp/McpPublishedGuideToolHandlers.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpPublishedGuideToolHandlers.cs
@@ -1,0 +1,243 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace GuideAntsApi.Services.Mcp;
+
+public static class McpPublishedGuideToolHandlers
+{
+    private const string McpClientToolsNote =
+        " MCP invocations do not support client-side tool execution.";
+
+    private static readonly JsonElement AssistantInputSchema = ParseSchema("""
+        {
+          "type": "object",
+          "properties": {
+            "instructions": {
+              "type": "string",
+              "description": "What you want this assistant to do."
+            },
+            "conversationId": {
+              "type": "string",
+              "description": "Optional. Continue an existing conversation thread. Omit to start a new conversation."
+            },
+            "title": {
+              "type": "string",
+              "description": "Optional title when starting a new conversation (ignored when conversationId is set)."
+            }
+          },
+          "required": ["instructions"],
+          "additionalProperties": false
+        }
+        """);
+
+    private static readonly JsonElement ConversationGetInputSchema = ParseSchema("""
+        {
+          "type": "object",
+          "properties": {
+            "conversationId": {
+              "type": "string",
+              "description": "The conversation ID to retrieve."
+            }
+          },
+          "required": ["conversationId"],
+          "additionalProperties": false
+        }
+        """);
+
+    public static ValueTask<ListToolsResult> ListToolsAsync(
+        RequestContext<ListToolsRequestParams> request,
+        CancellationToken cancellationToken)
+    {
+        var mcpContext = request.Services?.GetService(typeof(McpPublishedGuideContext)) as McpPublishedGuideContext;
+        if (mcpContext is not { IsValid: true })
+        {
+            return ValueTask.FromResult(new ListToolsResult { Tools = [] });
+        }
+
+        var imageEmbeddingNote = BuildImageEmbeddingNote(
+            request.Services?.GetService<IOptions<McpImageEmbeddingOptions>>()?.Value);
+
+        var tools = new List<Tool>();
+
+        foreach (var assistant in mcpContext.AddressableAssistants)
+        {
+            tools.Add(new Tool
+            {
+                Name = assistant.ToolName,
+                Title = assistant.Name,
+                Description = assistant.Description + McpClientToolsNote + imageEmbeddingNote,
+                InputSchema = AssistantInputSchema
+            });
+        }
+
+        tools.Add(new Tool
+        {
+            Name = McpPublishedAssistantCatalog.ConversationGetToolName,
+            Title = "Get conversation",
+            Description =
+                "Retrieve conversation history for a thread shared across assistants." + McpClientToolsNote,
+            InputSchema = ConversationGetInputSchema
+        });
+
+        return ValueTask.FromResult(new ListToolsResult { Tools = tools });
+    }
+
+    public static async ValueTask<CallToolResult> CallToolAsync(
+        RequestContext<CallToolRequestParams> request,
+        CancellationToken cancellationToken)
+    {
+        var mcpContext = request.Services?.GetService(typeof(McpPublishedGuideContext)) as McpPublishedGuideContext;
+        if (mcpContext is not { IsValid: true })
+        {
+            return ErrorResult(McpPublishedGuideInvokeService.JsonError("unauthorized", "MCP context is not valid."));
+        }
+
+        var toolName = request.Params?.Name;
+        if (string.IsNullOrWhiteSpace(toolName))
+        {
+            return ErrorResult(McpPublishedGuideInvokeService.JsonError("missing_tool_name", "Tool name is required."));
+        }
+
+        var invokeService = request.Services!.GetRequiredService<McpPublishedGuideInvokeService>();
+        var args = request.Params?.Arguments;
+
+        if (string.Equals(toolName, McpPublishedAssistantCatalog.ConversationGetToolName, StringComparison.Ordinal))
+        {
+            if (!TryGetString(args, "conversationId", out var conversationId))
+            {
+                return ErrorResult(McpPublishedGuideInvokeService.JsonError(
+                    "missing_conversation_id",
+                    "The conversationId parameter is required."));
+            }
+
+            var conversationJson = await invokeService.GetConversationAsync(conversationId!, mcpContext, cancellationToken);
+            if (JsonHasError(conversationJson))
+                return ErrorResult(conversationJson);
+
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = conversationJson }]
+            };
+        }
+
+        var assistant = McpPublishedAssistantCatalog.FindByToolName(mcpContext.AddressableAssistants, toolName);
+        if (assistant == null)
+        {
+            return ErrorResult(McpPublishedGuideInvokeService.JsonError(
+                "unknown_tool",
+                $"Tool '{toolName}' is not available for this published guide."));
+        }
+
+        if (!TryGetString(args, "instructions", out var instructions))
+        {
+            return ErrorResult(McpPublishedGuideInvokeService.JsonError(
+                "missing_instructions",
+                "The instructions parameter is required."));
+        }
+
+        TryGetOptionalString(args, "conversationId", out var convoArg);
+        TryGetOptionalString(args, "title", out var title);
+
+        var invokeResult = await invokeService.InvokeAssistantAsync(
+            assistant,
+            instructions!,
+            convoArg,
+            title,
+            mcpContext,
+            cancellationToken);
+
+        if (JsonHasError(invokeResult.Json))
+            return ErrorResult(invokeResult.Json);
+
+        var content = new List<ContentBlock> { new TextContentBlock { Text = invokeResult.Json } };
+
+        if (invokeResult.ConversationId is Guid convId && invokeResult.TurnIndex is int turnIdx)
+        {
+            var embedder = request.Services!.GetRequiredService<McpPublishedRunImageEmbedder>();
+            var images = await embedder.EmbedTurnImagesAsync(
+                mcpContext.NotebookId,
+                convId,
+                turnIdx,
+                cancellationToken);
+            content.AddRange(images);
+        }
+
+        return new CallToolResult { Content = content };
+    }
+
+    private static string BuildImageEmbeddingNote(McpImageEmbeddingOptions? options)
+    {
+        if (options is null || !options.EmbedImages || options.MaxImagesPerResponse <= 0)
+        {
+            return string.Empty;
+        }
+
+        var sources = options.IncludeModifiedFiles ? "created or modified" : "created";
+        var maxMegabytes = options.MaxImageBytes / (1024.0 * 1024.0);
+        var sizeText = maxMegabytes >= 1
+            ? $"{maxMegabytes:0.#} MB"
+            : $"{options.MaxImageBytes / 1024.0:0.#} KB";
+
+        return $" Images {sources} during the run are returned inline as image content" +
+               $" (up to {options.MaxImagesPerResponse} image{(options.MaxImagesPerResponse == 1 ? string.Empty : "s")}," +
+               $" max {sizeText} each); any beyond those limits remain accessible via the URLs in the JSON response.";
+    }
+
+    private static CallToolResult ErrorResult(string json) =>
+        new()
+        {
+            IsError = true,
+            Content = [new TextContentBlock { Text = json }]
+        };
+
+    private static bool JsonHasError(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.String;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetString(IDictionary<string, JsonElement>? args, string key, out string? value)
+    {
+        value = null;
+        if (args == null || !args.TryGetValue(key, out var element))
+            return false;
+
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            value = element.GetString();
+            return !string.IsNullOrWhiteSpace(value);
+        }
+
+        value = element.ToString();
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static bool TryGetOptionalString(IDictionary<string, JsonElement>? args, string key, out string? value)
+    {
+        value = null;
+        if (args == null || !args.TryGetValue(key, out var element))
+            return false;
+
+        if (element.ValueKind == JsonValueKind.Null)
+            return false;
+
+        value = element.ValueKind == JsonValueKind.String ? element.GetString() : element.ToString();
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static JsonElement ParseSchema(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+}

--- a/src/server/GuideAntsApi/Services/Mcp/McpPublishedRunImageEmbedder.cs
+++ b/src/server/GuideAntsApi/Services/Mcp/McpPublishedRunImageEmbedder.cs
@@ -1,0 +1,171 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.Services.Components;
+
+namespace GuideAntsApi.Services.Mcp;
+
+/// <summary>
+/// Builds MCP <see cref="ImageContentBlock"/>s from the output files a published-guide run actually
+/// produced. The authoritative source is <c>ConversationTurn.FilesCreated</c>/<c>FilesModified</c>
+/// (CWD-relative paths tracked during the run) rather than URLs parsed from assistant markdown.
+/// </summary>
+public sealed class McpPublishedRunImageEmbedder
+{
+    private static readonly HashSet<string> ImageMimeWhitelist = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/png", "image/jpeg", "image/webp", "image/gif"
+    };
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly ApplicationDbContext _db;
+    private readonly INotebookFileService _fileService;
+    private readonly McpImageEmbeddingOptions _options;
+    private readonly ILogger<McpPublishedRunImageEmbedder> _logger;
+
+    public McpPublishedRunImageEmbedder(
+        ApplicationDbContext db,
+        INotebookFileService fileService,
+        IOptions<McpImageEmbeddingOptions> options,
+        ILogger<McpPublishedRunImageEmbedder> logger)
+    {
+        _db = db;
+        _fileService = fileService;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resolves the image files created (and optionally modified) during the given turn and returns
+    /// them as <see cref="ImageContentBlock"/>s, honoring the configured count and size caps.
+    /// </summary>
+    public async Task<IReadOnlyList<ImageContentBlock>> EmbedTurnImagesAsync(
+        Guid notebookId,
+        Guid conversationId,
+        int turnIndex,
+        CancellationToken cancellationToken)
+    {
+        if (!_options.EmbedImages || _options.MaxImagesPerResponse <= 0)
+        {
+            return [];
+        }
+
+        var turn = await _db.ConversationTurns
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                t => t.NotebookConversationId == conversationId && t.TurnIndex == turnIndex,
+                cancellationToken);
+        if (turn == null)
+        {
+            return [];
+        }
+
+        var cwdPaths = ParsePaths(turn.FilesCreated);
+        if (_options.IncludeModifiedFiles)
+        {
+            cwdPaths = cwdPaths.Concat(ParsePaths(turn.FilesModified));
+        }
+
+        var blocks = new List<ImageContentBlock>();
+        var seenFileIds = new HashSet<Guid>();
+
+        foreach (var cwdPath in cwdPaths.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (blocks.Count >= _options.MaxImagesPerResponse)
+            {
+                break;
+            }
+
+            if (string.IsNullOrWhiteSpace(cwdPath))
+            {
+                continue;
+            }
+
+            // Match CWD-relative path to a notebook file by suffix (same approach as TurnManager).
+            var notebookFile = await _db.NotebookFiles
+                .AsNoTracking()
+                .Where(f => f.NotebookId == notebookId && f.RelativePath.EndsWith(cwdPath))
+                .OrderByDescending(f => f.LastModifiedUtc)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (notebookFile == null || !seenFileIds.Add(notebookFile.Id))
+            {
+                continue;
+            }
+
+            var loaded = await _fileService.GetFileContentStreamAsync(notebookFile.Id, cancellationToken);
+            if (loaded == null)
+            {
+                continue;
+            }
+
+            var (stream, contentType, _) = loaded.Value;
+            await using (stream)
+            {
+                if (!ImageMimeWhitelist.Contains(contentType))
+                {
+                    continue;
+                }
+
+                var bytes = await ReadCappedAsync(stream, _options.MaxImageBytes, cancellationToken);
+                if (bytes == null)
+                {
+                    _logger.LogInformation(
+                        "Skipping oversized MCP image embed for notebook file {NotebookFileId} (limit {MaxImageBytes} bytes)",
+                        notebookFile.Id,
+                        _options.MaxImageBytes);
+                    continue;
+                }
+
+                blocks.Add(ImageContentBlock.FromBytes(bytes, contentType));
+            }
+        }
+
+        return blocks;
+    }
+
+    private static IEnumerable<string> ParsePaths(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json, JsonOptions) ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Reads the stream fully unless it would exceed <paramref name="maxBytes"/>, in which case null
+    /// is returned without buffering the whole payload.
+    /// </summary>
+    private static async Task<byte[]?> ReadCappedAsync(Stream stream, long maxBytes, CancellationToken cancellationToken)
+    {
+        using var buffer = new MemoryStream();
+        var chunk = new byte[81920];
+        int read;
+        while ((read = await stream.ReadAsync(chunk, cancellationToken)) > 0)
+        {
+            if (buffer.Length + read > maxBytes)
+            {
+                return null;
+            }
+
+            buffer.Write(chunk, 0, read);
+        }
+
+        return buffer.ToArray();
+    }
+}

--- a/src/server/GuideAntsApi/appsettings.json
+++ b/src/server/GuideAntsApi/appsettings.json
@@ -77,6 +77,12 @@
     "TimeoutSeconds": 600,
     "LocalOutputFormat": "png"
   },
+  "Mcp": {
+    "EmbedImages": true,
+    "MaxImagesPerResponse": 5,
+    "MaxImageBytes": 4194304,
+    "IncludeModifiedFiles": true
+  },
   "Embeddings": {
     "TimeoutSeconds": 300,
     "LocalMinIntervalMs": 5000


### PR DESCRIPTION
Add a stateless Streamable HTTP MCP endpoint at /api/published/mcp, authenticated with published-guide API keys. MCP-enabled guides advertise the guide and crew assistants as invokable tools plus conversation_get, with optional inline image embedding and published-content URL rewriting.

Includes publish UI (McpTab), PublishedGuide McpEnabled/McpDescription fields, crew-member routing in published conversations, and unit tests.