### PR TITLE
Fixed add model via settings ui and added guards for tool call output

### DIFF
--- a/src/client/src/components/home/addAiServicesWizard/__tests__/localOnboardingParity.test.ts
+++ b/src/client/src/components/home/addAiServicesWizard/__tests__/localOnboardingParity.test.ts
@@ -3,6 +3,46 @@ import { createEmptyAddModelWizardState, buildAddModelRequest as buildSettingsAd
 import { buildLocalAiModelRequest } from '../utils';
 
 describe('local onboarding cross-UI parity', () => {
+  it('builds identical payloads for minimal huggingface intent with blank optional fields', () => {
+    const settings = createEmptyAddModelWizardState('llama-cpp');
+    settings.llamaInstallSource = 'huggingface';
+    settings.runtimeProfileId = 'gemma4';
+    settings.llamaRouterModelId = 'gemma-4-12B-it-qat-GGUF';
+    settings.llamaHuggingFaceRepository = 'unsloth/gemma-4-12B-it-qat-GGUF';
+    settings.llamaHuggingFaceQuantIncludePattern = 'gemma-4-12B-it-qat-UD-Q4_K_XL.gguf';
+    settings.llamaHuggingFaceMmprojIncludePattern = 'mmproj-BF16.gguf';
+
+    const wizard = {
+      localId: 'draft-minimal',
+      persisted: false,
+      asyncOperationId: null,
+      asyncStatus: 'submitted' as const,
+      asyncProgress: null,
+      asyncError: null,
+      setAsGlobalDefault: false,
+      installSource: 'huggingface' as const,
+      routerModelId: 'gemma-4-12B-it-qat-GGUF',
+      runtimeProfileId: 'gemma4',
+      huggingFaceRepository: 'unsloth/gemma-4-12B-it-qat-GGUF',
+      huggingFaceQuantIncludePattern: 'gemma-4-12B-it-qat-UD-Q4_K_XL.gguf',
+      huggingFaceMmprojIncludePattern: 'mmproj-BF16.gguf',
+      huggingFaceTargetDirectory: '',
+      existingAliasRouterModelId: '',
+      routerContextSize: '',
+      routerCacheRamMib: '',
+      catalogModelId: '',
+      catalogDisplayName: '',
+    };
+
+    const fromSettings = buildSettingsAddModelRequest(settings);
+    const fromWizard = buildLocalAiModelRequest(wizard);
+
+    expect(fromSettings).toEqual({
+      ...fromWizard,
+      providerConfig: { onboardingUi: 'settings' },
+    });
+  });
+
   it('builds identical payloads for equivalent huggingface intent', () => {
     const settings = createEmptyAddModelWizardState('llama-cpp');
     settings.catalogModelId = 'qwen3.6-local';

--- a/src/client/src/components/home/addAiServicesWizard/steps/LocalAiModelsStep.tsx
+++ b/src/client/src/components/home/addAiServicesWizard/steps/LocalAiModelsStep.tsx
@@ -203,7 +203,6 @@ export function LocalAiModelsStep({
   };
 
   const handleInstall = async () => {
-    const effectiveCatalogModelId = catalogModelId.trim() || (installSource === 'existingAlias' ? existingAlias : routerModelId);
     const formData: LocalAiInstallFormData = {
       installSource,
       routerModelId: installSource === 'existingAlias' ? existingAlias : routerModelId,
@@ -211,12 +210,12 @@ export function LocalAiModelsStep({
       huggingFaceRepository: repository,
       huggingFaceQuantIncludePattern: quantPattern,
       huggingFaceMmprojIncludePattern: mmprojPattern,
-      huggingFaceTargetDirectory: targetDirectory || routerModelId,
+      huggingFaceTargetDirectory: targetDirectory,
       existingAliasRouterModelId: existingAlias,
       routerContextSize: contextSize,
       routerCacheRamMib: cacheRam,
-      catalogModelId: effectiveCatalogModelId,
-      catalogDisplayName: catalogDisplayName.trim() || effectiveCatalogModelId,
+      catalogModelId,
+      catalogDisplayName,
       setAsGlobalDefault: isFirstModel || setAsGlobalDefault,
     };
 

--- a/src/client/src/components/home/addAiServicesWizard/utils.ts
+++ b/src/client/src/components/home/addAiServicesWizard/utils.ts
@@ -73,8 +73,8 @@ import type {
   OptionalServiceKey,
   WizardLoadSnapshot,
 } from './types';
-import { buildLocalModelOnboardingRequest } from '../../../features/localModelOnboarding/buildCommand';
-import { validateLocalModelOnboardingDraft } from '../../../features/localModelOnboarding/validateDraft';
+import { buildLocalModelAddModelRequest } from '../../../features/localModelOnboarding/buildCommand';
+import { mapLocalAiModelDraftToOnboardingDraft } from '../../../features/localModelOnboarding/mapDraft';
 
 export function mapProviderLabelToModelProviderId(value: FoundryModelProviderLabel): string {
   return MODEL_PROVIDER_LABEL_TO_ID[value];
@@ -824,44 +824,7 @@ export function toExistingLocalModels(models: SettingsModelDto[]): SettingsModel
 }
 
 export function buildLocalAiModelRequest(draft: LocalAiModelDraft): AddModelRequest {
-  const onboardingDraft = {
-    installSource: draft.installSource,
-    runtimeProfileId: draft.runtimeProfileId,
-    routerModelId: draft.routerModelId,
-    huggingFaceRepository: draft.huggingFaceRepository,
-    huggingFaceQuantIncludePattern: draft.huggingFaceQuantIncludePattern,
-    huggingFaceMmprojIncludePattern: draft.huggingFaceMmprojIncludePattern,
-    huggingFaceTargetDirectory: draft.huggingFaceTargetDirectory,
-    existingAliasRouterModelId: draft.existingAliasRouterModelId,
-    routerContextSize: draft.routerContextSize,
-    routerCacheRamMib: draft.routerCacheRamMib,
-    catalogModelId: draft.catalogModelId,
-    catalogDisplayName: draft.catalogDisplayName,
-    catalogIsActive: true,
-  } as const;
-  const validationErrors = validateLocalModelOnboardingDraft(onboardingDraft, {
-    defaultCatalogModelId: draft.installSource === 'existingAlias'
-      ? draft.existingAliasRouterModelId
-      : draft.routerModelId,
-    defaultCatalogDisplayName: draft.installSource === 'existingAlias'
-      ? draft.existingAliasRouterModelId
-      : draft.routerModelId,
-    defaultTargetDirectory: draft.routerModelId,
-  });
-  if (validationErrors.length > 0) {
-    throw new Error(validationErrors[0]);
-  }
-  return buildLocalModelOnboardingRequest(onboardingDraft, {
-    onboardingUi: 'wizard',
-    defaultCatalogModelId: draft.installSource === 'existingAlias'
-      ? draft.existingAliasRouterModelId
-      : draft.routerModelId,
-    defaultCatalogDisplayName: draft.installSource === 'existingAlias'
-      ? draft.existingAliasRouterModelId
-      : draft.routerModelId,
-    defaultTargetDirectory: draft.routerModelId,
-    defaultCatalogIsActive: true,
-  });
+  return buildLocalModelAddModelRequest(mapLocalAiModelDraftToOnboardingDraft(draft), 'wizard');
 }
 
 function localAiOptionalServiceStatus(

--- a/src/client/src/components/notebook/conversations/LlamaRuntimeModal.tsx
+++ b/src/client/src/components/notebook/conversations/LlamaRuntimeModal.tsx
@@ -41,6 +41,11 @@ export const LlamaRuntimeModal: React.FC<LlamaRuntimeModalProps> = ({
             {isPolling && 'Please wait while the required models are loaded into the local runtime.'}
             {!isPolling && !isFailed && !isInvalid && 'The selected assistant requires local models that are not currently loaded.'}
           </p>
+          {isPolling && status.activeOperation?.operationId === '__external_loading__' && (
+            <p className="text-sm text-slate-500 mt-1">
+              Models are already loading from startup or another session — no action needed.
+            </p>
+          )}
         </div>
 
         <div className="px-6 pb-6">

--- a/src/client/src/features/localModelOnboarding/__tests__/localModelOnboarding.test.ts
+++ b/src/client/src/features/localModelOnboarding/__tests__/localModelOnboarding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildLocalModelOnboardingRequest } from '../buildCommand';
+import { buildLocalModelAddModelRequest, buildLocalModelOnboardingRequest } from '../buildCommand';
 import { selectAttachableAliases } from '../selectors';
 import { isLocalModelOnboardingInFlight, normalizeLocalModelOnboardingStatus } from '../status';
 
@@ -23,14 +23,8 @@ describe('buildLocalModelOnboardingRequest', () => {
       catalogIsActive: true,
     };
 
-    const fromSettings = buildLocalModelOnboardingRequest(base, { onboardingUi: 'settings' });
-    const fromWizard = buildLocalModelOnboardingRequest(base, {
-      onboardingUi: 'wizard',
-      defaultCatalogModelId: base.routerModelId,
-      defaultCatalogDisplayName: base.routerModelId,
-      defaultTargetDirectory: base.routerModelId,
-      defaultCatalogIsActive: true,
-    });
+    const fromSettings = buildLocalModelAddModelRequest(base, 'settings');
+    const fromWizard = buildLocalModelAddModelRequest(base, 'wizard');
 
     const { providerConfig: settingsProviderConfig, ...settingsWithoutUi } = fromSettings;
     const { providerConfig: wizardProviderConfig, ...wizardWithoutUi } = fromWizard;
@@ -38,6 +32,28 @@ describe('buildLocalModelOnboardingRequest', () => {
     expect(settingsProviderConfig).toEqual({ onboardingUi: 'settings' });
     expect(wizardProviderConfig).toEqual({ onboardingUi: 'wizard' });
     expect(settingsWithoutUi).toEqual(wizardWithoutUi);
+  });
+
+  it('defaults catalog and target directory from router alias when blank', () => {
+    const request = buildLocalModelOnboardingRequest({
+      installSource: 'huggingface',
+      runtimeProfileId: 'gemma4',
+      routerModelId: 'gemma-4-12B-it-qat-GGUF',
+      huggingFaceRepository: 'unsloth/gemma-4-12B-it-qat-GGUF',
+      huggingFaceQuantIncludePattern: 'gemma-4-12B-it-qat-UD-Q4_K_XL.gguf',
+      huggingFaceMmprojIncludePattern: 'mmproj-BF16.gguf',
+      huggingFaceTargetDirectory: '',
+      existingAliasRouterModelId: '',
+      routerContextSize: '',
+      routerCacheRamMib: '',
+      catalogModelId: '',
+      catalogDisplayName: '',
+      catalogIsActive: true,
+    });
+
+    expect(request.catalog.modelId).toBe('gemma-4-12B-it-qat-GGUF');
+    expect(request.catalog.displayName).toBe('gemma-4-12B-it-qat-GGUF');
+    expect(request.install?.huggingFace?.targetDirectory).toBe('gemma-4-12B-it-qat-GGUF');
   });
 
   it('allows text-only huggingface install without mmproj pattern', () => {

--- a/src/client/src/features/localModelOnboarding/buildCommand.ts
+++ b/src/client/src/features/localModelOnboarding/buildCommand.ts
@@ -1,6 +1,42 @@
 import type { AddModelRequest } from '../../types/settings';
 import type { LocalModelOnboardingDraft } from './contracts';
 
+export interface LocalModelOnboardingDefaultOptions {
+  defaultCatalogModelId: string;
+  defaultCatalogDisplayName: string;
+  defaultTargetDirectory: string;
+}
+
+export function resolveLocalModelOnboardingDefaults(
+  draft: LocalModelOnboardingDraft
+): LocalModelOnboardingDefaultOptions {
+  if (draft.installSource === 'existingAlias') {
+    const alias = draft.existingAliasRouterModelId.trim();
+    return {
+      defaultCatalogModelId: alias,
+      defaultCatalogDisplayName: alias,
+      defaultTargetDirectory: '',
+    };
+  }
+
+  const routerModelId = draft.routerModelId.trim();
+  return {
+    defaultCatalogModelId: routerModelId,
+    defaultCatalogDisplayName: routerModelId,
+    defaultTargetDirectory: routerModelId,
+  };
+}
+
+export function buildLocalModelAddModelRequest(
+  draft: LocalModelOnboardingDraft,
+  onboardingUi: 'settings' | 'wizard'
+): AddModelRequest {
+  return buildLocalModelOnboardingRequest(draft, {
+    onboardingUi,
+    defaultCatalogIsActive: draft.catalogIsActive ?? true,
+  });
+}
+
 function normalizeOptionalString(value: string | undefined): string | undefined {
   const trimmed = (value ?? '').trim();
   return trimmed.length > 0 ? trimmed : undefined;
@@ -70,13 +106,18 @@ export function buildLocalModelOnboardingRequest(
   }
 
   const source = draft.installSource;
-  const fallbackCatalogModelId = (options?.defaultCatalogModelId ?? '').trim();
+  const resolvedDefaults = resolveLocalModelOnboardingDefaults(draft);
+  const fallbackCatalogModelId = (
+    options?.defaultCatalogModelId ?? resolvedDefaults.defaultCatalogModelId
+  ).trim();
   const catalogModelId = draft.catalogModelId.trim() || fallbackCatalogModelId;
   if (!catalogModelId) {
     throw new Error('Catalog Model ID is required.');
   }
 
-  const fallbackCatalogDisplayName = (options?.defaultCatalogDisplayName ?? fallbackCatalogModelId).trim();
+  const fallbackCatalogDisplayName = (
+    options?.defaultCatalogDisplayName ?? resolvedDefaults.defaultCatalogDisplayName ?? fallbackCatalogModelId
+  ).trim();
   const catalogDisplayName = draft.catalogDisplayName.trim() || fallbackCatalogDisplayName || catalogModelId;
   if (!catalogDisplayName) {
     throw new Error('Catalog display name is required.');
@@ -122,11 +163,19 @@ export function buildLocalModelOnboardingRequest(
   const repository = draft.huggingFaceRepository.trim();
   const quantPattern = draft.huggingFaceQuantIncludePattern.trim();
   const mmprojPattern = draft.huggingFaceMmprojIncludePattern.trim();
-  const fallbackTargetDirectory = (options?.defaultTargetDirectory ?? '').trim();
+  const fallbackTargetDirectory = (
+    options?.defaultTargetDirectory ?? resolvedDefaults.defaultTargetDirectory
+  ).trim();
   const targetDirectory = draft.huggingFaceTargetDirectory.trim() || fallbackTargetDirectory;
 
-  if (!repository || !quantPattern || !targetDirectory) {
-    throw new Error('Repository, quant pattern, and target directory are required. mmproj pattern is optional.');
+  if (!repository) {
+    throw new Error('Hugging Face repository is required.');
+  }
+  if (!quantPattern) {
+    throw new Error('Model file (GGUF) is required. Browse the repository and select a quant file.');
+  }
+  if (!targetDirectory) {
+    throw new Error('Target directory is required. It defaults to the router alias when left blank.');
   }
 
   request.install = {

--- a/src/client/src/features/localModelOnboarding/mapDraft.ts
+++ b/src/client/src/features/localModelOnboarding/mapDraft.ts
@@ -1,0 +1,45 @@
+import type { LocalAiModelDraft } from '../../components/home/addAiServicesWizard/types';
+import type { AddModelWizardState } from '../../pages/settings/types';
+import type { LocalModelOnboardingDraft } from './contracts';
+
+export function mapSettingsAddModelStateToOnboardingDraft(
+  state: AddModelWizardState
+): LocalModelOnboardingDraft {
+  return {
+    installSource: state.llamaInstallSource,
+    runtimeProfileId: state.runtimeProfileId,
+    routerModelId: state.llamaRouterModelId,
+    huggingFaceRepository: state.llamaHuggingFaceRepository,
+    huggingFaceQuantIncludePattern: state.llamaHuggingFaceQuantIncludePattern,
+    huggingFaceMmprojIncludePattern: state.llamaHuggingFaceMmprojIncludePattern,
+    huggingFaceTargetDirectory: state.llamaHuggingFaceTargetDirectory,
+    existingAliasRouterModelId: state.llamaExistingAliasRouterModelId,
+    routerContextSize: state.llamaRouterContextSize,
+    routerCacheRamMib: state.llamaRouterCacheRamMib,
+    catalogModelId: state.catalogModelId,
+    catalogDisplayName: state.catalogDisplayName,
+    catalogDescription: state.catalogDescription,
+    catalogDisplayOrder: state.catalogDisplayOrder,
+    catalogIsActive: state.catalogIsActive,
+  };
+}
+
+export function mapLocalAiModelDraftToOnboardingDraft(
+  draft: LocalAiModelDraft
+): LocalModelOnboardingDraft {
+  return {
+    installSource: draft.installSource,
+    runtimeProfileId: draft.runtimeProfileId,
+    routerModelId: draft.routerModelId,
+    huggingFaceRepository: draft.huggingFaceRepository,
+    huggingFaceQuantIncludePattern: draft.huggingFaceQuantIncludePattern,
+    huggingFaceMmprojIncludePattern: draft.huggingFaceMmprojIncludePattern,
+    huggingFaceTargetDirectory: draft.huggingFaceTargetDirectory,
+    existingAliasRouterModelId: draft.existingAliasRouterModelId,
+    routerContextSize: draft.routerContextSize,
+    routerCacheRamMib: draft.routerCacheRamMib,
+    catalogModelId: draft.catalogModelId,
+    catalogDisplayName: draft.catalogDisplayName,
+    catalogIsActive: true,
+  };
+}

--- a/src/client/src/features/localModelOnboarding/validateDraft.ts
+++ b/src/client/src/features/localModelOnboarding/validateDraft.ts
@@ -1,19 +1,10 @@
 import type { LocalModelOnboardingDraft } from './contracts';
 import { buildLocalModelOnboardingRequest } from './buildCommand';
 
-export function validateLocalModelOnboardingDraft(
-  draft: LocalModelOnboardingDraft,
-  options?: {
-    defaultCatalogModelId?: string;
-    defaultCatalogDisplayName?: string;
-    defaultTargetDirectory?: string;
-  }
-): string[] {
+export function validateLocalModelOnboardingDraft(draft: LocalModelOnboardingDraft): string[] {
   try {
     buildLocalModelOnboardingRequest(draft, {
-      defaultCatalogModelId: options?.defaultCatalogModelId,
-      defaultCatalogDisplayName: options?.defaultCatalogDisplayName,
-      defaultTargetDirectory: options?.defaultTargetDirectory,
+      defaultCatalogIsActive: draft.catalogIsActive ?? true,
     });
     return [];
   } catch (error) {

--- a/src/client/src/pages/NotebookDetails.tsx
+++ b/src/client/src/pages/NotebookDetails.tsx
@@ -242,6 +242,36 @@ function NotebookDetailsContent() {
             });
     }, [projectId, notebookId, assistants, applyRuntimeStatus, showToast]);
 
+    // While the modal shows requires_load, keep polling runtime status so startup
+    // warmup / external router loads flip the UI into loading mode without a duplicate load.
+    useEffect(() => {
+        if (!runtimeModalOpen || !projectId || !notebookId) return;
+        if (runtimeStatus?.state !== 'requires_load' || isPolling) return;
+
+        let cancelled = false;
+        const recheck = async () => {
+            try {
+                const status = await api.projects.notebooks.conversations.checkLlamaRuntime(
+                    projectId,
+                    notebookId,
+                    targetAssistantId
+                );
+                if (!cancelled) {
+                    applyRuntimeStatus(status, targetAssistantId);
+                }
+            } catch {
+                // Transient failures are expected while the AI container is still starting.
+            }
+        };
+
+        void recheck();
+        const interval = setInterval(() => { void recheck(); }, 2000);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, [runtimeModalOpen, runtimeStatus?.state, isPolling, projectId, notebookId, targetAssistantId, applyRuntimeStatus]);
+
     useEffect(() => {
         const handleRequiresLoad = (e: Event) => {
             const customEvent = e as CustomEvent;
@@ -284,11 +314,25 @@ function NotebookDetailsContent() {
         if (isPolling && runtimeStatus?.activeOperation?.operationId && projectId && notebookId) {
             pollInterval = setInterval(async () => {
                 try {
-                    const op = await api.projects.notebooks.conversations.pollLlamaRuntimeOperation(
-                        projectId,
-                        notebookId,
-                        runtimeStatus.activeOperation.operationId
-                    );
+                    let op;
+                    try {
+                        op = await api.projects.notebooks.conversations.pollLlamaRuntimeOperation(
+                            projectId,
+                            notebookId,
+                            runtimeStatus.activeOperation.operationId
+                        );
+                    } catch (pollError: any) {
+                        if (pollError?.status !== 404) {
+                            throw pollError;
+                        }
+                        const status = await api.projects.notebooks.conversations.checkLlamaRuntime(
+                            projectId,
+                            notebookId,
+                            targetAssistantId
+                        );
+                        applyRuntimeStatus(status, targetAssistantId);
+                        return;
+                    }
                     
                     if (op.state === 'ready') {
                         setIsPolling(false);
@@ -330,7 +374,7 @@ function NotebookDetailsContent() {
         return () => {
             if (pollInterval) clearInterval(pollInterval);
         };
-    }, [isPolling, runtimeStatus?.activeOperation?.operationId, projectId, notebookId, showToast, refreshNotebookToolbar]);
+    }, [isPolling, runtimeStatus?.activeOperation?.operationId, projectId, notebookId, targetAssistantId, showToast, refreshNotebookToolbar, applyRuntimeStatus]);
 
     const handleStartLoad = async () => {
         if (!projectId || !notebookId) return;

--- a/src/client/src/pages/__tests__/NotebookDetails.test.tsx
+++ b/src/client/src/pages/__tests__/NotebookDetails.test.tsx
@@ -1103,7 +1103,7 @@ describe('NotebookDetails page', () => {
   });
 
   it('starts llama runtime load from modal and handles ready response', async () => {
-    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValueOnce({
+    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValue({
       state: 'requires_load',
     } as never);
     vi.mocked(api.projects.notebooks.conversations.loadLlamaRuntime).mockResolvedValueOnce({
@@ -1423,7 +1423,7 @@ describe('NotebookDetails page', () => {
   });
 
   it('shows toast when start load returns failed state', async () => {
-    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValueOnce({
+    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValue({
       state: 'requires_load',
     } as never);
     vi.mocked(api.projects.notebooks.conversations.loadLlamaRuntime).mockResolvedValueOnce({
@@ -1448,7 +1448,7 @@ describe('NotebookDetails page', () => {
 
   it('starts polling when start load returns loading state', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValueOnce({
+    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValue({
       state: 'requires_load',
     } as never);
     vi.mocked(api.projects.notebooks.conversations.loadLlamaRuntime).mockResolvedValueOnce({
@@ -1484,7 +1484,7 @@ describe('NotebookDetails page', () => {
   });
 
   it('shows toast when start load throws', async () => {
-    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValueOnce({
+    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValue({
       state: 'requires_load',
     } as never);
     vi.mocked(api.projects.notebooks.conversations.loadLlamaRuntime).mockRejectedValueOnce(
@@ -1507,7 +1507,7 @@ describe('NotebookDetails page', () => {
   });
 
   it('closes runtime modal when close is clicked and not polling', async () => {
-    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValueOnce({
+    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime).mockResolvedValue({
       state: 'requires_load',
     } as never);
 
@@ -1522,6 +1522,35 @@ describe('NotebookDetails page', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('llama-runtime-modal')).not.toBeInTheDocument();
     });
+  });
+
+  it('enters polling when requires_load recheck detects external startup loading', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(api.projects.notebooks.conversations.checkLlamaRuntime)
+      .mockResolvedValueOnce({ state: 'requires_load' } as never)
+      .mockResolvedValue({
+        state: 'loading',
+        activeOperation: { operationId: '__external_loading__', state: 'loading' },
+      } as never);
+    vi.mocked(api.projects.notebooks.conversations.pollLlamaRuntimeOperation).mockResolvedValue({
+      state: 'ready',
+      operationId: '__external_loading__',
+    } as never);
+
+    renderNotebook();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('llama-runtime-modal')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    await waitFor(() => {
+      expect(api.projects.notebooks.conversations.pollLlamaRuntimeOperation).toHaveBeenCalled();
+    });
+    vi.useRealTimers();
   });
 
   it('dismisses crash modal via onClose', async () => {

--- a/src/client/src/pages/settings/__tests__/utils.test.ts
+++ b/src/client/src/pages/settings/__tests__/utils.test.ts
@@ -50,6 +50,22 @@ describe('buildAddModelRequest', () => {
     expect(state.catalogIsActive).toBe(true);
   });
 
+  it('builds llama-cpp huggingface request with defaulted target directory', () => {
+    const state = createEmptyAddModelWizardState('llama-cpp');
+    state.llamaInstallSource = 'huggingface';
+    state.runtimeProfileId = 'gemma4';
+    state.llamaRouterModelId = 'gemma-4-12B-it-qat-GGUF';
+    state.llamaHuggingFaceRepository = 'unsloth/gemma-4-12B-it-qat-GGUF';
+    state.llamaHuggingFaceQuantIncludePattern = 'gemma-4-12B-it-qat-UD-Q4_K_XL.gguf';
+    state.llamaHuggingFaceMmprojIncludePattern = 'mmproj-BF16.gguf';
+
+    const request = buildAddModelRequest(state);
+
+    expect(request.catalog.modelId).toBe('gemma-4-12B-it-qat-GGUF');
+    expect(request.catalog.displayName).toBe('gemma-4-12B-it-qat-GGUF');
+    expect(request.install?.huggingFace?.targetDirectory).toBe('gemma-4-12B-it-qat-GGUF');
+  });
+
   it('builds llama-cpp huggingface request', () => {
     const state = createEmptyAddModelWizardState('llama-cpp');
     state.catalogModelId = 'qwen3.5-local';

--- a/src/client/src/pages/settings/components/catalog/AddModelWizard.tsx
+++ b/src/client/src/pages/settings/components/catalog/AddModelWizard.tsx
@@ -269,13 +269,16 @@ export function AddModelWizard({
 
   const canContinueFromProvider = value.provider.trim().length > 0;
   const canContinueFromCatalog = useMemo(() => {
+    if (value.provider === 'llama-cpp') {
+      return !modelIdError && !checkingModelId;
+    }
     return (
       value.catalogModelId.trim().length > 0 &&
       value.catalogDisplayName.trim().length > 0 &&
       !modelIdError &&
       !checkingModelId
     );
-  }, [checkingModelId, modelIdError, value.catalogDisplayName, value.catalogModelId]);
+  }, [checkingModelId, modelIdError, value.catalogDisplayName, value.catalogModelId, value.provider]);
 
   const validateModelId = async () => {
     const candidate = value.catalogModelId.trim();

--- a/src/client/src/pages/settings/components/catalog/providers/LlamaCppForm.tsx
+++ b/src/client/src/pages/settings/components/catalog/providers/LlamaCppForm.tsx
@@ -386,9 +386,10 @@ export function LlamaCppAddForm({
                 className="w-full rounded border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
                 autoComplete="off"
                 spellCheck={false}
+                placeholder={value.llamaRouterModelId.trim() || '(same as router alias)'}
               />
               <p className="text-[11px] text-gray-500">
-                Folder under <span className="font-mono">/models-local/llama</span> where the files will be written. Typically matches the Router Alias.
+                Folder under <span className="font-mono">/models-local/llama</span> where the files will be written. Defaults to the router alias.
               </p>
             </div>
           </div>

--- a/src/client/src/pages/settings/utils.ts
+++ b/src/client/src/pages/settings/utils.ts
@@ -13,8 +13,10 @@ import {
 } from '../../types/settings';
 import { AddModelWizardState, CanonicalLocalRuntimeConfig, CatalogEditState, ProfileFormState } from './types';
 import { getServiceProviderDisplayName } from './constants/displayLabels';
-import { buildLocalModelOnboardingRequest } from '../../features/localModelOnboarding/buildCommand';
-import { validateLocalModelOnboardingDraft } from '../../features/localModelOnboarding/validateDraft';
+import {
+  buildLocalModelAddModelRequest,
+} from '../../features/localModelOnboarding/buildCommand';
+import { mapSettingsAddModelStateToOnboardingDraft } from '../../features/localModelOnboarding/mapDraft';
 
 export const SECRET_MASK = '********';
 
@@ -432,38 +434,18 @@ export function buildAddModelRequest(state: AddModelWizardState): AddModelReques
     throw new Error('Pick a provider in Step 1.');
   }
   const modelId = state.catalogModelId.trim();
+  const displayName = state.catalogDisplayName.trim();
+  if (provider === 'llama-cpp') {
+    return buildLocalModelAddModelRequest(
+      mapSettingsAddModelStateToOnboardingDraft(state),
+      'settings'
+    );
+  }
   if (!modelId) {
     throw new Error('Catalog Model ID is required.');
   }
-  const displayName = state.catalogDisplayName.trim();
   if (!displayName) {
     throw new Error('Catalog display name is required.');
-  }
-  if (provider === 'llama-cpp') {
-    const draft = {
-      installSource: state.llamaInstallSource,
-      runtimeProfileId: state.runtimeProfileId,
-      routerModelId: state.llamaRouterModelId,
-      huggingFaceRepository: state.llamaHuggingFaceRepository,
-      huggingFaceQuantIncludePattern: state.llamaHuggingFaceQuantIncludePattern,
-      huggingFaceMmprojIncludePattern: state.llamaHuggingFaceMmprojIncludePattern,
-      huggingFaceTargetDirectory: state.llamaHuggingFaceTargetDirectory,
-      existingAliasRouterModelId: state.llamaExistingAliasRouterModelId,
-      routerContextSize: state.llamaRouterContextSize,
-      routerCacheRamMib: state.llamaRouterCacheRamMib,
-      catalogModelId: state.catalogModelId,
-      catalogDisplayName: state.catalogDisplayName,
-      catalogDescription: state.catalogDescription,
-      catalogDisplayOrder: state.catalogDisplayOrder,
-      catalogIsActive: state.catalogIsActive,
-    } as const;
-    const validationErrors = validateLocalModelOnboardingDraft(draft);
-    if (validationErrors.length > 0) {
-      throw new Error(validationErrors[0]);
-    }
-    return buildLocalModelOnboardingRequest(draft, {
-      onboardingUi: 'settings',
-    });
   }
   let providerConfig: Record<string, unknown> | undefined;
   if (state.runtimeProfileId.trim()) {

--- a/src/server/AntRunner.Chat/AntRunner.Chat.Abstractions/ChatContextOverflowClassifier.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.Abstractions/ChatContextOverflowClassifier.cs
@@ -1,0 +1,215 @@
+using System.Text;
+using System.Text.Json;
+
+namespace AntRunner.Chat.Abstractions;
+
+/// <summary>
+/// Provider-agnostic detection of "prompt exceeds the model context window" errors. Every chat
+/// provider reports this differently (llama.cpp <c>exceed_context_size_error</c>, OpenAI
+/// <c>context_length_exceeded</c>, Anthropic "prompt is too long", Gemini token-count messages),
+/// so the marker knowledge lives here once instead of being duplicated per client. Raw-HTTP clients
+/// classify from the response body; the execution engine classifies thrown exceptions from SDK-based
+/// clients. Both paths converge on <see cref="ChatContextOverflowException"/>.
+/// </summary>
+public static class ChatContextOverflowClassifier
+{
+    // Specific phrases only — broad words like "context window" are intentionally excluded so a
+    // generic bad request is never misclassified as an overflow.
+    private static readonly string[] Markers =
+    [
+        // llama.cpp / llama-server
+        "exceed_context_size_error",
+        "exceeds the available context size",
+        "exceeds the available context",
+        // OpenAI / Azure OpenAI
+        "context_length_exceeded",
+        "maximum context length",
+        "reduce the length of the messages",
+        // Anthropic
+        "prompt is too long",
+        "exceed context limit",
+        "input length and max_tokens exceed context limit",
+        // Google Gemini / Vertex
+        "exceeds the maximum number of tokens",
+        "input token count",
+        "the input token count",
+    ];
+
+    /// <summary>
+    /// Classifies a raw provider error body. Returns true only for 4xx-class responses whose body
+    /// matches a known overflow marker. Best-effort token counts are extracted when present.
+    /// </summary>
+    public static bool TryClassifyBody(int? statusCode, string? body, out int? promptTokens, out int? contextSize)
+    {
+        promptTokens = null;
+        contextSize = null;
+
+        // Context overflow is always a client-side request-shaping rejection (4xx). 5xx is a crash.
+        if (statusCode is < 400 or >= 500)
+        {
+            return false;
+        }
+
+        if (!ContainsMarker(body))
+        {
+            return false;
+        }
+
+        TryExtractTokenCounts(body, out promptTokens, out contextSize);
+        return true;
+    }
+
+    /// <summary>
+    /// Classifies an exception thrown by a provider/SDK by scanning its message chain for a known
+    /// overflow marker. Used by the engine as the single normalization point across all providers.
+    /// </summary>
+    public static bool Matches(Exception? exception)
+    {
+        if (exception == null)
+        {
+            return false;
+        }
+
+        return ContainsMarker(CollectMessages(exception));
+    }
+
+    /// <summary>Short, user-safe excerpt of the provider error for diagnostics.</summary>
+    public static string? Excerpt(Exception? exception)
+    {
+        if (exception == null)
+        {
+            return null;
+        }
+
+        var message = exception.Message?.Trim();
+        if (string.IsNullOrEmpty(message))
+        {
+            return null;
+        }
+
+        const int maxLength = 500;
+        return message.Length <= maxLength ? message : message[..maxLength] + "…";
+    }
+
+    private static bool ContainsMarker(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        foreach (var marker in Markers)
+        {
+            if (text.Contains(marker, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string CollectMessages(Exception exception)
+    {
+        var builder = new StringBuilder();
+        var current = exception;
+        var depth = 0;
+        while (current != null && depth < 10)
+        {
+            // Message is the common case, but provider SDKs vary: some surface the upstream error
+            // body only in a property (e.g. ResponseBody/Content) or in Data rather than Message.
+            // Append the message plus those well-known carriers so detection is robust to unknown
+            // exception shapes without coupling to any specific SDK type.
+            builder.Append(current.Message);
+            builder.Append('\n');
+            AppendKnownBodyCarriers(current, builder);
+            current = current.InnerException;
+            depth++;
+        }
+
+        return builder.ToString();
+    }
+
+    private static readonly string[] BodyCarrierPropertyNames =
+    [
+        "ResponseBody",
+        "Content",
+        "Body",
+        "ResponseContent",
+        "ResponseMessage",
+        "Error",
+    ];
+
+    private static void AppendKnownBodyCarriers(Exception exception, StringBuilder builder)
+    {
+        foreach (var propertyName in BodyCarrierPropertyNames)
+        {
+            try
+            {
+                var property = exception.GetType().GetProperty(propertyName);
+                if (property?.GetValue(exception) is string value && !string.IsNullOrEmpty(value))
+                {
+                    builder.Append(value);
+                    builder.Append('\n');
+                }
+            }
+            catch
+            {
+                // Reflection over an arbitrary SDK exception is best-effort; ignore property failures.
+            }
+        }
+
+        foreach (var entry in exception.Data.Values)
+        {
+            if (entry is string value && !string.IsNullOrEmpty(value))
+            {
+                builder.Append(value);
+                builder.Append('\n');
+            }
+        }
+    }
+
+    private static void TryExtractTokenCounts(string? body, out int? promptTokens, out int? contextSize)
+    {
+        promptTokens = null;
+        contextSize = null;
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+
+            // llama.cpp shape: { "error": { "n_prompt_tokens": N, "n_ctx": M } }
+            var scope = root.TryGetProperty("error", out var errorEl) && errorEl.ValueKind == JsonValueKind.Object
+                ? errorEl
+                : root;
+
+            if (scope.TryGetProperty("n_prompt_tokens", out var promptEl)
+                && promptEl.ValueKind == JsonValueKind.Number
+                && promptEl.TryGetInt32(out var promptValue))
+            {
+                promptTokens = promptValue;
+            }
+
+            if (scope.TryGetProperty("n_ctx", out var ctxEl)
+                && ctxEl.ValueKind == JsonValueKind.Number
+                && ctxEl.TryGetInt32(out var ctxValue))
+            {
+                contextSize = ctxValue;
+            }
+        }
+        catch (JsonException)
+        {
+            // Markers matched but body is not parseable JSON; token counts simply stay null.
+        }
+    }
+}

--- a/src/server/AntRunner.Chat/AntRunner.Chat.Abstractions/ChatContextOverflowException.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.Abstractions/ChatContextOverflowException.cs
@@ -1,0 +1,32 @@
+namespace AntRunner.Chat.Abstractions;
+
+/// <summary>
+/// Thrown when a chat provider rejects a request because the assembled prompt exceeds the model's
+/// context window (e.g. llama.cpp's <c>exceed_context_size_error</c>). Unlike a transport failure
+/// or a runtime crash this is a recoverable, request-shaping problem: the execution engine can
+/// unwind the oversized message from the turn and retry with a smaller request.
+/// </summary>
+public sealed class ChatContextOverflowException : Exception
+{
+    /// <summary>Prompt token count reported by the provider, when available.</summary>
+    public int? PromptTokens { get; }
+
+    /// <summary>Context window size reported by the provider, when available.</summary>
+    public int? ContextSize { get; }
+
+    /// <summary>Short, user-safe excerpt from the provider error body.</summary>
+    public string? UpstreamDetail { get; }
+
+    public ChatContextOverflowException(
+        string message,
+        int? promptTokens = null,
+        int? contextSize = null,
+        string? upstreamDetail = null,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        PromptTokens = promptTokens;
+        ContextSize = contextSize;
+        UpstreamDetail = upstreamDetail;
+    }
+}

--- a/src/server/AntRunner.Chat/AntRunner.Chat.LlamaCpp/LlamaCppChatClient.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.LlamaCpp/LlamaCppChatClient.cs
@@ -299,6 +299,19 @@ public sealed class LlamaCppChatClient : IChatCompletionClient
                 upstreamExcerpt);
         }
 
+        // Prompt exceeds the loaded model's context window. This is a request-shaping problem, not a
+        // caller bug or crash, so it gets the recoverable exception type the execution engine catches
+        // to unwind the oversized message and retry. llama-server strips its (huge) body from the
+        // thrown message, so this client must classify at the source — see ChatContextOverflowClassifier.
+        if (ChatContextOverflowClassifier.TryClassifyBody((int)response.StatusCode, responseBody, out var promptTokens, out var contextSize))
+        {
+            throw new ChatContextOverflowException(
+                "The request exceeded the local model's context window.",
+                promptTokens,
+                contextSize,
+                upstreamExcerpt);
+        }
+
         throw new HttpRequestException(
             $"llama.cpp chat completion failed with HTTP {(int)response.StatusCode} ({response.ReasonPhrase ?? "<none>"}).",
             null,
@@ -334,6 +347,7 @@ public sealed class LlamaCppChatClient : IChatCompletionClient
 
         return false;
     }
+
 
     // CUDA / llama.cpp OOM markers observed across upstream builds. Matching is case-insensitive
     // and the body is already capped to ~8KB by the diagnostic path above, so this is safe to run

--- a/src/server/AntRunner.Chat/AntRunner.Chat/ThreadRun.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat/ThreadRun.cs
@@ -280,6 +280,10 @@ namespace AntRunner.Chat
             var accumulatedNewFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var accumulatedModifiedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+            // Messages already replaced by an abort notice after a context-overflow rejection.
+            // Tracked so each retry targets a different (next-largest) message and the loop converges.
+            var unwoundMessages = new HashSet<ChatMessage>();
+
             try
             {
                 while (continueChat)
@@ -293,13 +297,21 @@ namespace AntRunner.Chat
                         samplingParameters: samplingParams);
 
                     ChatCompletionResponse response;
-                    if (onStream != null)
+                    try
                     {
-                        response = await GetCompletionAndStreamAsync(api, chatRequest, onStream, token);
+                        response = await InvokeCompletionAsync(api, chatRequest, onStream, token);
                     }
-                    else
+                    catch (ChatContextOverflowException overflowEx)
                     {
-                        response = await api.GetCompletionAsync(chatRequest, token);
+                        // Unwind the largest offending message in this turn, replace it with a short
+                        // abort notice, and retry. If nothing can be unwound the request is
+                        // irreducible (e.g. the system prompt alone overflows) so we rethrow.
+                        if (TryUnwindOversizedMessage(messages, unwoundMessages, overflowEx, onMessage))
+                        {
+                            continue;
+                        }
+
+                        throw;
                     }
 
                     messages.Add(response.FirstChoice!.Message);
@@ -644,6 +656,130 @@ namespace AntRunner.Chat
             }
 
             return response;
+        }
+
+        /// <summary>
+        /// Single provider-agnostic chokepoint for issuing a completion. Normalizes any provider's
+        /// "context window exceeded" failure into <see cref="ChatContextOverflowException"/> so the
+        /// engine's unwind/retry path is identical regardless of which chat provider is in use.
+        /// Raw-HTTP clients that strip their body (e.g. llama-server) already throw the typed
+        /// exception; SDK-based clients (OpenAI, Anthropic) surface the marker text in their thrown
+        /// exception and are translated here.
+        /// </summary>
+        private static async Task<ChatCompletionResponse> InvokeCompletionAsync(
+            IChatCompletionClient api,
+            ChatCompletionRequest chatRequest,
+            StreamingMessageProgressEventHandler? onStream,
+            CancellationToken token)
+        {
+            try
+            {
+                return onStream != null
+                    ? await GetCompletionAndStreamAsync(api, chatRequest, onStream, token)
+                    : await api.GetCompletionAsync(chatRequest, token);
+            }
+            catch (ChatContextOverflowException)
+            {
+                // Already classified at the source (e.g. llama client) — let it flow to the unwinder.
+                throw;
+            }
+            catch (Exception ex) when (ChatContextOverflowClassifier.Matches(ex))
+            {
+                throw new ChatContextOverflowException(
+                    "The request exceeded the model's context window.",
+                    upstreamDetail: ChatContextOverflowClassifier.Excerpt(ex),
+                    innerException: ex);
+            }
+        }
+
+        /// <summary>
+        /// Replaces the largest non-system message in the turn with a short "aborted for size" notice
+        /// after a context-overflow rejection, preserving tool-call pairing so the retried request
+        /// stays structurally valid. Returns false when there is nothing left to unwind.
+        /// </summary>
+        private static bool TryUnwindOversizedMessage(
+            List<ChatMessage> messages,
+            HashSet<ChatMessage> alreadyUnwound,
+            ChatContextOverflowException overflowEx,
+            MessageAddedEventHandler? onMessage)
+        {
+            var targetIndex = -1;
+            var targetLength = -1;
+            for (var i = 0; i < messages.Count; i++)
+            {
+                var candidate = messages[i];
+                if (candidate.Role == ChatRole.System || candidate.Role == ChatRole.Developer)
+                {
+                    continue;
+                }
+
+                if (alreadyUnwound.Contains(candidate))
+                {
+                    continue;
+                }
+
+                var length = candidate.GetText().Length;
+                if (length > targetLength)
+                {
+                    targetLength = length;
+                    targetIndex = i;
+                }
+            }
+
+            if (targetIndex < 0)
+            {
+                return false;
+            }
+
+            var original = messages[targetIndex];
+            var notice = BuildContextOverflowNotice(overflowEx);
+            var replacement = BuildAbortReplacement(original, notice);
+            messages[targetIndex] = replacement;
+            alreadyUnwound.Add(replacement);
+
+            Logger.LogWarning(
+                "Chat request exceeded the model context window; unwound oversized {Role} message at index {Index} ({OriginalChars} chars) and retrying. PromptTokens={PromptTokens}, ContextSize={ContextSize}.",
+                original.Role,
+                targetIndex,
+                targetLength,
+                overflowEx.PromptTokens,
+                overflowEx.ContextSize);
+
+            // Surface the substitution so the abort notice is persisted in place of the dropped content.
+            onMessage?.Invoke(null, new MessageAddedEventArgs(
+                replacement.Role.ToString(),
+                replacement.GetText(),
+                replacement.ToolCallId,
+                replacement.FunctionName,
+                null));
+
+            return true;
+        }
+
+        private static ChatMessage BuildAbortReplacement(ChatMessage original, string notice)
+        {
+            var content = new List<ChatContent> { new(notice) };
+
+            if (original.Role == ChatRole.Tool)
+            {
+                // Preserve tool_call_id / name so the assistant tool_call ↔ tool result pairing holds.
+                return new ChatMessage(original.ToolCallId ?? string.Empty, original.FunctionName ?? string.Empty, content);
+            }
+
+            // Preserve any tool_calls on an assistant message so following tool results stay valid.
+            return new ChatMessage(original.Role, content, original.ToolCalls, original.ThinkingBlocks);
+        }
+
+        private static string BuildContextOverflowNotice(ChatContextOverflowException overflowEx)
+        {
+            var detail = overflowEx.PromptTokens.HasValue && overflowEx.ContextSize.HasValue
+                ? $" (prompt was ~{overflowEx.PromptTokens.Value:N0} tokens vs the {overflowEx.ContextSize.Value:N0} token limit)"
+                : string.Empty;
+
+            return
+                $"[Message aborted due to size restrictions{detail}. The original content was too large for the model " +
+                "context window and has been removed. Retry with a different approach that limits the message size — " +
+                "for example, write large output to a file and return only a short summary instead of the full content.]";
         }
 
         private static ChatRunOutput? BuildRunResults(List<ChatMessage> messages, ChatCompletionResponse response)
@@ -1002,7 +1138,17 @@ namespace AntRunner.Chat
                     if (!toolCall.IsFunction) continue;
                     var id = toolCall.Id;
                     var toolOutput = toolOutputs.FirstOrDefault(to => to.ToolCallId == id) ?? throw new Exception("No match");
-                    messages.Add(new ChatMessage(id, toolCall.Function.Name, [new ChatContent(toolOutput.Output!)]));
+                    var truncation = ToolOutputTruncator.Truncate(toolOutput.Output);
+                    if (truncation.WasTruncated)
+                    {
+                        Logger.LogWarning(
+                            "Tool output truncated before sending to model. Function={Function}, ToolCallId={ToolCallId}, OriginalChars={OriginalChars}, LimitChars={LimitChars}.",
+                            toolCall.Function.Name,
+                            toolCall.Id,
+                            truncation.OriginalLength,
+                            ToolOutputTruncator.MaxCharacters);
+                    }
+                    messages.Add(new ChatMessage(id, toolCall.Function.Name, [new ChatContent(truncation.Output ?? string.Empty)]));
                     messageAdded?.Invoke(null, new MessageAddedEventArgs(messages.Last().Role.ToString(), messages.Last().GetText(), toolCall.Id, toolCall.Function.Name, toolCall.Function.Arguments.ToString()));
                 }
 

--- a/src/server/AntRunner.Chat/AntRunner.Chat/ToolOutputTruncator.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat/ToolOutputTruncator.cs
@@ -1,0 +1,153 @@
+using System.Text;
+using System.Text.Json;
+using AntRunner.ToolCalling.Functions;
+
+namespace AntRunner.Chat;
+
+/// <summary>
+/// Outcome of a <see cref="ToolOutputTruncator.Truncate"/> call. Carries enough metadata for the
+/// caller to emit a single, structured log line when a tool result is shortened.
+/// </summary>
+public readonly record struct ToolOutputTruncationResult(string? Output, bool WasTruncated, int OriginalLength);
+
+/// <summary>
+/// Caps a single tool result to a hard character limit before it is added to the next LLM request,
+/// so one runaway script output cannot blow past the model context window. When truncation occurs
+/// the result is wrapped in a <see cref="ScriptExecutionResult"/> envelope whose <c>standardError</c>
+/// explains that the response was shortened for length.
+/// </summary>
+public static class ToolOutputTruncator
+{
+    public const int MaxCharacters = 25_000;
+    private const string StdoutTruncationSuffix = "\n[... output truncated for length ...]";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static ToolOutputTruncationResult Truncate(string? output)
+    {
+        if (string.IsNullOrEmpty(output) || output.Length <= MaxCharacters)
+        {
+            return new ToolOutputTruncationResult(output, false, output?.Length ?? 0);
+        }
+
+        var originalLength = output.Length;
+
+        var truncated = TryDeserializeScriptExecutionResult(output, out var parsed)
+            ? TruncateScriptExecutionResult(parsed, originalLength)
+            : TruncatePlainOutput(output, originalLength);
+
+        return new ToolOutputTruncationResult(Serialize(truncated), true, originalLength);
+    }
+
+    private static bool TryDeserializeScriptExecutionResult(string output, out ScriptExecutionResult result)
+    {
+        result = new ScriptExecutionResult();
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<ScriptExecutionResult>(output, JsonOptions);
+            if (parsed == null)
+            {
+                return false;
+            }
+
+            result = parsed;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static ScriptExecutionResult TruncateScriptExecutionResult(ScriptExecutionResult source, int originalLength)
+    {
+        var notice = BuildTruncationNotice(originalLength);
+        var result = new ScriptExecutionResult
+        {
+            StandardOutput = source.StandardOutput ?? string.Empty,
+            StandardError = AppendStderr(source.StandardError, notice),
+            NewFiles = source.NewFiles,
+            ModifiedFiles = source.ModifiedFiles
+        };
+
+        if (Serialize(result).Length <= MaxCharacters)
+        {
+            return result;
+        }
+
+        result.StandardOutput = FitStdoutToBudget(source.StandardOutput ?? string.Empty, result);
+        return result;
+    }
+
+    private static ScriptExecutionResult TruncatePlainOutput(string output, int originalLength)
+    {
+        var notice = BuildTruncationNotice(originalLength);
+        var result = new ScriptExecutionResult
+        {
+            StandardOutput = string.Empty,
+            StandardError = notice
+        };
+
+        result.StandardOutput = FitStdoutToBudget(output, result);
+        return result;
+    }
+
+    private static string FitStdoutToBudget(string stdout, ScriptExecutionResult envelope)
+    {
+        if (string.IsNullOrEmpty(stdout))
+        {
+            return string.Empty;
+        }
+
+        var low = 0;
+        var high = stdout.Length;
+        var best = string.Empty;
+
+        while (low <= high)
+        {
+            var mid = low + (high - low) / 2;
+            var candidateStdout = mid >= stdout.Length
+                ? stdout
+                : stdout[..mid] + StdoutTruncationSuffix;
+
+            envelope.StandardOutput = candidateStdout;
+            var length = Serialize(envelope).Length;
+            if (length <= MaxCharacters)
+            {
+                best = candidateStdout;
+                low = mid + 1;
+            }
+            else
+            {
+                high = mid - 1;
+            }
+        }
+
+        return best;
+    }
+
+    private static string AppendStderr(string? existing, string notice)
+    {
+        if (string.IsNullOrWhiteSpace(existing))
+        {
+            return notice;
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine(notice);
+        builder.Append(existing.Trim());
+        return builder.ToString();
+    }
+
+    private static string BuildTruncationNotice(int originalLength) =>
+        $"Response truncated for length. Tool output exceeded the maximum of {MaxCharacters:N0} characters " +
+        $"(original output was approximately {originalLength:N0} characters). " +
+        "Write large results to a file and return a summary instead of full content.";
+
+    private static string Serialize(ScriptExecutionResult result) =>
+        JsonSerializer.Serialize(result, JsonOptions);
+}

--- a/src/server/GuideAntsApi.IntegrationTests/Infrastructure/SettingsRoutingTestWebApplicationFactory.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Infrastructure/SettingsRoutingTestWebApplicationFactory.cs
@@ -53,6 +53,8 @@ public sealed class SettingsRoutingTestWebApplicationFactory : TestWebApplicatio
 
     private sealed class NoOpLocalAiStartupWarmupService : ILocalAiStartupWarmupService
     {
+        public bool IsWarmupInProgress => false;
+
         public Task WarmupAllAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         public Task EnsureDefaultLlamaLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/src/server/GuideAntsApi.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -153,6 +153,8 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncD
 
     private sealed class NoOpLocalAiStartupWarmupService : ILocalAiStartupWarmupService
     {
+        public bool IsWarmupInProgress => false;
+
         public Task WarmupAllAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         public Task EnsureDefaultLlamaLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/src/server/GuideAntsApi.Tests/Services/LlamaCpp/NotebookModelRuntimeServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/LlamaCpp/NotebookModelRuntimeServiceTests.cs
@@ -55,6 +55,9 @@ public class NotebookModelRuntimeServiceTests
         _mockLocalAiWarmupService
             .Setup(s => s.EnsureAuxiliaryServicesLoadedAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+        _mockLocalAiWarmupService
+            .Setup(s => s.IsWarmupInProgress)
+            .Returns(false);
         _mockLogger = new Mock<ILogger<NotebookModelRuntimeService>>();
         _cache = new MemoryCache(new MemoryCacheOptions());
 
@@ -185,6 +188,104 @@ public class NotebookModelRuntimeServiceTests
         Assert.AreEqual("ready", status.State);
         Assert.AreEqual(1, status.RequiredModels.Count);
         Assert.AreEqual(1, status.LoadedModels.Count);
+    }
+
+    [TestMethod]
+    public async Task GetRuntimeStatusAsync_RouterModelLoading_ReturnsLoadingWithExternalOperation()
+    {
+        var notebookId = Guid.NewGuid();
+        var guide = new Assistant { Id = Guid.NewGuid(), Kind = AssistantKind.Guide, ModelId = "qwen-local" };
+        var notebook = new Notebook { Id = notebookId, GuideId = guide.Id, Guide = guide };
+
+        _context.Assistants.Add(guide);
+        _context.Notebooks.Add(notebook);
+
+        var model = new Model
+        {
+            ModelId = "qwen-local",
+            Provider = "llama-cpp",
+            IsActive = true,
+            RuntimeConfigJson = "{\"routerModelId\":\"qwen-model\",\"runtimeProfileId\":\"qwen3_5\",\"loadParams\":{\"model\":\"qwen-model\"}}"
+        };
+        _context.Models.Add(model);
+        await _context.SaveChangesAsync();
+
+        _mockLlamaClient.Setup(c => c.ListModelsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlamaModelsResponse
+            {
+                Data = new List<LlamaModelData>
+                {
+                    new() { Id = "qwen-model", Status = new LlamaModelStatus { Value = "loading" } }
+                }
+            });
+
+        var status = await _service.GetRuntimeStatusAsync(notebookId);
+
+        Assert.AreEqual("loading", status.State);
+        Assert.IsNotNull(status.ActiveOperation);
+        Assert.AreEqual(NotebookModelRuntimeService.ExternalLoadingOperationId, status.ActiveOperation!.OperationId);
+        Assert.AreEqual("loading", status.ActiveOperation.State);
+    }
+
+    [TestMethod]
+    public async Task GetRuntimeStatusAsync_StartupWarmupInProgress_ReturnsLoadingWithExternalOperation()
+    {
+        var notebookId = Guid.NewGuid();
+        var guide = new Assistant { Id = Guid.NewGuid(), Kind = AssistantKind.Guide, ModelId = "qwen-local" };
+        var notebook = new Notebook { Id = notebookId, GuideId = guide.Id, Guide = guide };
+
+        _context.Assistants.Add(guide);
+        _context.Notebooks.Add(notebook);
+
+        var model = new Model
+        {
+            ModelId = "qwen-local",
+            Provider = "llama-cpp",
+            IsActive = true,
+            RuntimeConfigJson = "{\"routerModelId\":\"qwen-model\",\"runtimeProfileId\":\"qwen3_5\",\"loadParams\":{\"model\":\"qwen-model\"}}"
+        };
+        _context.Models.Add(model);
+        await _context.SaveChangesAsync();
+
+        _mockLocalAiWarmupService.Setup(s => s.IsWarmupInProgress).Returns(true);
+        _mockLlamaClient.Setup(c => c.ListModelsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlamaModelsResponse { Data = new List<LlamaModelData>() });
+
+        var status = await _service.GetRuntimeStatusAsync(notebookId);
+
+        Assert.AreEqual("loading", status.State);
+        Assert.AreEqual(NotebookModelRuntimeService.ExternalLoadingOperationId, status.ActiveOperation?.OperationId);
+    }
+
+    [TestMethod]
+    public async Task StartLoadOperationAsync_WhenExternalLoadInProgress_ReturnsExistingOperation()
+    {
+        var notebookId = Guid.NewGuid();
+        var guide = new Assistant { Id = Guid.NewGuid(), Kind = AssistantKind.Guide, ModelId = "qwen-local" };
+        var notebook = new Notebook { Id = notebookId, GuideId = guide.Id, Guide = guide };
+
+        _context.Assistants.Add(guide);
+        _context.Notebooks.Add(notebook);
+
+        var model = new Model
+        {
+            ModelId = "qwen-local",
+            Provider = "llama-cpp",
+            IsActive = true,
+            RuntimeConfigJson = "{\"routerModelId\":\"qwen-model\",\"runtimeProfileId\":\"qwen3_5\",\"loadParams\":{\"model\":\"qwen-model\"}}"
+        };
+        _context.Models.Add(model);
+        await _context.SaveChangesAsync();
+
+        _mockLocalAiWarmupService.Setup(s => s.IsWarmupInProgress).Returns(true);
+        _mockLlamaClient.Setup(c => c.ListModelsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlamaModelsResponse { Data = new List<LlamaModelData>() });
+
+        var op = await _service.StartLoadOperationAsync(notebookId);
+
+        Assert.AreEqual("loading", op.State);
+        Assert.AreEqual(NotebookModelRuntimeService.ExternalLoadingOperationId, op.OperationId);
+        _mockLocalAiWarmupService.Verify(s => s.UnloadAuxiliaryServicesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [TestMethod]

--- a/src/server/GuideAntsApi.Tests/Services/Providers/ChatContextOverflowClassifierTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Providers/ChatContextOverflowClassifierTests.cs
@@ -1,0 +1,108 @@
+using AntRunner.Chat.Abstractions;
+using FluentAssertions;
+
+namespace GuideAntsApi.Tests.Services.Providers;
+
+[TestClass]
+public sealed class ChatContextOverflowClassifierTests
+{
+    [TestMethod]
+    public void TryClassifyBody_LlamaCppOverflow_DetectsAndExtractsTokenCounts()
+    {
+        const string body =
+            "{\"error\":{\"code\":400,\"message\":\"request (552039 tokens) exceeds the available context size (262144 tokens), try increasing it\",\"type\":\"exceed_context_size_error\",\"n_prompt_tokens\":552039,\"n_ctx\":262144}}";
+
+        var matched = ChatContextOverflowClassifier.TryClassifyBody(400, body, out var promptTokens, out var contextSize);
+
+        matched.Should().BeTrue();
+        promptTokens.Should().Be(552039);
+        contextSize.Should().Be(262144);
+    }
+
+    [TestMethod]
+    public void TryClassifyBody_OpenAiOverflow_Detects()
+    {
+        const string body =
+            "{\"error\":{\"message\":\"This model's maximum context length is 128000 tokens.\",\"type\":\"invalid_request_error\",\"code\":\"context_length_exceeded\"}}";
+
+        ChatContextOverflowClassifier.TryClassifyBody(400, body, out _, out _).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void TryClassifyBody_FivexxStatus_NotOverflow()
+    {
+        const string body = "{\"error\":{\"type\":\"exceed_context_size_error\"}}";
+
+        ChatContextOverflowClassifier.TryClassifyBody(500, body, out _, out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TryClassifyBody_UnrelatedBadRequest_NotOverflow()
+    {
+        const string body = "{\"error\":{\"message\":\"invalid tool schema\",\"type\":\"invalid_request_error\"}}";
+
+        ChatContextOverflowClassifier.TryClassifyBody(400, body, out _, out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Matches_AnthropicPromptTooLong_DetectsThroughExceptionChain()
+    {
+        var inner = new InvalidOperationException("prompt is too long: 250000 tokens > 200000 maximum");
+        var outer = new Exception("Anthropic request failed", inner);
+
+        ChatContextOverflowClassifier.Matches(outer).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Matches_GeminiTokenCountMessage_Detects()
+    {
+        var ex = new InvalidOperationException(
+            "Google Gemini chat request failed (400): The input token count (1200000) exceeds the maximum number of tokens allowed (1048576).");
+
+        ChatContextOverflowClassifier.Matches(ex).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Matches_AnthropicSdkResponseBodyProperty_DetectsWithoutMarkerInMessage()
+    {
+        // Mirrors Anthropic.Exceptions.AnthropicBadRequestException: a generic Message with the
+        // actual upstream error carried only in a ResponseBody property.
+        var ex = new FakeSdkException(
+            message: "Response status code does not indicate success: 400 (Bad Request).",
+            responseBody: "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"prompt is too long: 250000 tokens > 200000 maximum\"}}");
+
+        ChatContextOverflowClassifier.Matches(ex).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Matches_ResponseBodyUnrelated_NotOverflow()
+    {
+        var ex = new FakeSdkException(
+            message: "Response status code does not indicate success: 400 (Bad Request).",
+            responseBody: "{\"error\":{\"type\":\"invalid_request_error\",\"message\":\"unknown field 'foo'\"}}");
+
+        ChatContextOverflowClassifier.Matches(ex).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Matches_GenericFailure_NotOverflow()
+    {
+        ChatContextOverflowClassifier.Matches(new Exception("connection reset by peer")).Should().BeFalse();
+    }
+
+    private sealed class FakeSdkException : Exception
+    {
+        public FakeSdkException(string message, string responseBody) : base(message)
+        {
+            ResponseBody = responseBody;
+        }
+
+        public string ResponseBody { get; }
+    }
+
+    [TestMethod]
+    public void Matches_Null_NotOverflow()
+    {
+        ChatContextOverflowClassifier.Matches(null).Should().BeFalse();
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Providers/ToolOutputTruncatorTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Providers/ToolOutputTruncatorTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using AntRunner.Chat;
+using AntRunner.ToolCalling.Functions;
+using FluentAssertions;
+
+namespace GuideAntsApi.Tests.Services.Providers;
+
+[TestClass]
+public sealed class ToolOutputTruncatorTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    [TestMethod]
+    public void Truncate_NullOutput_ReturnsNotTruncated()
+    {
+        var result = ToolOutputTruncator.Truncate(null);
+        result.WasTruncated.Should().BeFalse();
+        result.Output.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Truncate_SmallOutput_ReturnsOriginal()
+    {
+        const string output = "{\"standardOutput\":\"hello\"}";
+        var result = ToolOutputTruncator.Truncate(output);
+        result.WasTruncated.Should().BeFalse();
+        result.Output.Should().Be(output);
+    }
+
+    [TestMethod]
+    public void Truncate_OutputAtLimit_ReturnsOriginal()
+    {
+        var output = new string('x', ToolOutputTruncator.MaxCharacters);
+        var result = ToolOutputTruncator.Truncate(output);
+        result.WasTruncated.Should().BeFalse();
+        result.Output.Should().Be(output);
+    }
+
+    [TestMethod]
+    public void Truncate_LargeScriptExecutionResult_TruncatesStdoutAndAddsStderrNotice()
+    {
+        var largeStdout = new string('x', 80_000);
+        var original = new ScriptExecutionResult
+        {
+            StandardOutput = largeStdout,
+            StandardError = "existing stderr"
+        };
+        var serialized = JsonSerializer.Serialize(original, JsonOptions);
+
+        var result = ToolOutputTruncator.Truncate(serialized);
+
+        result.WasTruncated.Should().BeTrue();
+        result.OriginalLength.Should().Be(serialized.Length);
+        result.Output.Should().NotBeNull();
+        result.Output!.Length.Should().BeLessThanOrEqualTo(ToolOutputTruncator.MaxCharacters);
+
+        using var doc = JsonDocument.Parse(result.Output);
+        var stderr = doc.RootElement.GetProperty("standardError").GetString();
+        stderr.Should().Contain("Response truncated for length");
+        stderr.Should().Contain("existing stderr");
+
+        var stdout = doc.RootElement.GetProperty("standardOutput").GetString();
+        stdout.Should().Contain("[... output truncated for length ...]");
+        stdout!.Length.Should().BeLessThan(largeStdout.Length);
+    }
+
+    [TestMethod]
+    public void Truncate_LargeScriptExecutionResult_PreservesFileLists()
+    {
+        var original = new ScriptExecutionResult
+        {
+            StandardOutput = new string('x', 80_000),
+            NewFiles = new List<string> { "a.txt", "b.txt" },
+            ModifiedFiles = new List<string> { "c.txt" }
+        };
+        var serialized = JsonSerializer.Serialize(original, JsonOptions);
+
+        var result = ToolOutputTruncator.Truncate(serialized);
+
+        result.WasTruncated.Should().BeTrue();
+        using var doc = JsonDocument.Parse(result.Output!);
+        doc.RootElement.GetProperty("newFiles").EnumerateArray().Should().HaveCount(2);
+        doc.RootElement.GetProperty("modifiedFiles").EnumerateArray().Should().HaveCount(1);
+    }
+
+    [TestMethod]
+    public void Truncate_LargePlainOutput_WrapsInScriptExecutionEnvelope()
+    {
+        var largeOutput = new string('y', 80_000);
+
+        var result = ToolOutputTruncator.Truncate(largeOutput);
+
+        result.WasTruncated.Should().BeTrue();
+        result.Output!.Length.Should().BeLessThanOrEqualTo(ToolOutputTruncator.MaxCharacters);
+
+        using var doc = JsonDocument.Parse(result.Output);
+        doc.RootElement.GetProperty("standardError").GetString().Should().Contain("Response truncated for length");
+        doc.RootElement.GetProperty("standardOutput").GetString().Should().Contain("[... output truncated for length ...]");
+    }
+}


### PR DESCRIPTION
… overflowing context in one shot.

Now truncates and adds error to individual responses and rolls-back turns that cause context overflows in one shot