### PR TITLE
Fix/windows rocm wsl detection

### DIFF
--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
@@ -322,9 +322,9 @@ public sealed class LocalAiStartupWarmupServiceTests
                 return new HttpResponseMessage(HttpStatusCode.OK);
             }
 
-            if (request.Method == HttpMethod.Get && path.EndsWith("/sd/ready", StringComparison.Ordinal))
+            if (request.Method == HttpMethod.Get && path.EndsWith("/sd/health", StringComparison.Ordinal))
             {
-                return new HttpResponseMessage(HttpStatusCode.OK);
+                return Json(HttpStatusCode.OK, """{"engine":{"processAlive":true,"healthy":true}}""");
             }
 
             return new HttpResponseMessage(HttpStatusCode.NotFound);


### PR DESCRIPTION
Makes the rocm backend work on native Linux (/dev/kfd + /dev/dri) and Windows Docker Desktop / WSL2 (ROCDXG via /dev/dxg), by probing the host at install/launch time and generating a runtime compose override instead of hardcoding GPU binds in static compose files.

Add rocm-probe scripts (PowerShell + bash) to detect native Linux vs WSL ROCDXG and locate required libraries
Generate docker-compose.rocm-runtime.generated.yml at launch with the correct device mounts, caps, and env for the detected path
Update installer launchers (guideants.ps1 / guideants.sh) with WSL2 checks, ROCm library staging, and runtime override wiring
Refactor container AI services (ASR, TTS, embeddings, SD, llama-admin) around shared guideants_hf library for HuggingFace catalog/download
Add SD bundle seeding for offline/stable-diffusion startup
Improve local AI bootstrap/warmup and llama runtime client integration
Document setup and troubleshooting in docs/rocm-container-runtime-and-wsl-setup.md