### PR TITLE
Feature/local model onboarding followup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -440,3 +440,4 @@ docker-compose.rocm-runtime.generated.yml
 /docker/volumes/rocm-wsl/
 *.cli-auth-token
 /src/client/GuideAnts.code-workspace
+/recordings

--- a/docker/build/guideants-ai/lib/guideants_hf/exact_download.py
+++ b/docker/build/guideants-ai/lib/guideants_hf/exact_download.py
@@ -166,6 +166,25 @@ def verify_file_integrity(path: str, *, expected_size: int | None, digest: str |
                 )
 
 
+def artifact_is_installed(spec: ArtifactSpec) -> bool:
+    try:
+        verify_file_integrity(spec.destination_abs, expected_size=spec.expected_size, digest=spec.digest)
+        return True
+    except ExactDownloadError:
+        return False
+
+
+def staged_artifact_path(staging_dir: str, spec: ArtifactSpec) -> str | None:
+    staged_name = destination_name(spec.repository_path)
+    staged_src = os.path.abspath(os.path.join(staging_dir, staged_name))
+    try:
+        ensure_inside_root(staging_dir, staged_src)
+        verify_file_integrity(staged_src, expected_size=spec.expected_size, digest=spec.digest)
+        return staged_src
+    except (PathSafetyError, ExactDownloadError):
+        return None
+
+
 def build_artifact_specs(
     *,
     model_files: list[str],
@@ -223,6 +242,8 @@ def stage_download_file(
 ) -> str:
     ensure_inside_root(staging_dir, staging_dir)
     os.makedirs(staging_dir, exist_ok=True)
+    if artifact_is_installed(spec):
+        return spec.destination_abs
     staged_name = destination_name(spec.repository_path)
     staged_dest = os.path.abspath(os.path.join(staging_dir, staged_name))
     ensure_inside_root(staging_dir, staged_dest)
@@ -275,12 +296,14 @@ def activate_staged_files(
     activated: list[str] = []
     for spec in specs:
         staged_name = destination_name(spec.repository_path)
-        staged_src = os.path.abspath(os.path.join(staging_dir, staged_name))
         final_dest = spec.destination_abs
         ensure_inside_root(store_root, final_dest)
-        if not os.path.isfile(staged_src):
+        if artifact_is_installed(spec):
+            activated.append(final_dest)
+            continue
+        staged_src = staged_artifact_path(staging_dir, spec)
+        if staged_src is None:
             raise ExactDownloadError("STAGING_MISSING", f"Staged artifact missing: {staged_name}")
-        verify_file_integrity(staged_src, expected_size=spec.expected_size, digest=spec.digest)
         if os.path.exists(final_dest):
             # Phase 2 does not delete prior active artifacts; overwrite only when activating the same path.
             os.remove(final_dest)

--- a/docker/build/guideants-ai/llama-admin-service/catalog/manifest.json
+++ b/docker/build/guideants-ai/llama-admin-service/catalog/manifest.json
@@ -84,8 +84,8 @@
       "id": "qwen3.6-35b-a3b-mtp",
       "display": {
         "name": "Qwen 3.6 35B A3B (MTP)",
-        "description": "Text-first faster inference using llama.cpp draft-mtp.",
-        "labels": ["Text", "Reasoning", "Tool use", "MTP"],
+        "description": "Faster inference with llama.cpp draft-mtp and vision support.",
+        "labels": ["Text", "Vision", "Reasoning", "Tool use", "MTP"],
         "license": "Apache-2.0",
         "documentationUrl": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF"
       },
@@ -98,9 +98,10 @@
         "routerModelId": "Qwen3.6-35B-A3B-MTP-GGUF",
         "runtimeProfileId": "qwen3_6",
         "targetDirectory": "Qwen3.6-35B-A3B-MTP-GGUF",
-        "mmproj": null,
+        "mmproj": { "path": "mmproj-F16.gguf" },
         "routerPreset": {
           "ctx-size": "131072",
+          "image-min-tokens": "1024",
           "spec-type": "draft-mtp",
           "spec-draft-n-max": "2"
         }
@@ -112,7 +113,7 @@
         }
       },
       "hardwareNotes": {
-        "summary": "Requires recent llama.cpp MTP support. Text-only in v1; do not enable vision on this row.",
+        "summary": "Requires recent llama.cpp draft-mtp support. Vision via mmproj-F16.gguf.",
         "contextClass": "large"
       }
     },
@@ -120,8 +121,8 @@
       "id": "qwen3.6-27b-mtp",
       "display": {
         "name": "Qwen 3.6 27B (MTP)",
-        "description": "Dense Qwen 3.6 MTP variant for faster text-only inference.",
-        "labels": ["Text", "Reasoning", "Tool use", "MTP"],
+        "description": "Dense Qwen 3.6 MTP variant with draft-mtp and vision support.",
+        "labels": ["Text", "Vision", "Reasoning", "Tool use", "MTP"],
         "license": "Apache-2.0",
         "documentationUrl": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF"
       },
@@ -134,9 +135,10 @@
         "routerModelId": "Qwen3.6-27B-MTP-GGUF",
         "runtimeProfileId": "qwen3_6",
         "targetDirectory": "Qwen3.6-27B-MTP-GGUF",
-        "mmproj": null,
+        "mmproj": { "path": "mmproj-F16.gguf" },
         "routerPreset": {
           "ctx-size": "131072",
+          "image-min-tokens": "1024",
           "spec-type": "draft-mtp",
           "spec-draft-n-max": "2"
         }
@@ -148,7 +150,7 @@
         }
       },
       "hardwareNotes": {
-        "summary": "Dense MTP model. Text-only; requires llama.cpp draft-mtp support.",
+        "summary": "Dense MTP model with vision via mmproj-F16.gguf; requires llama.cpp draft-mtp support.",
         "contextClass": "large"
       }
     },

--- a/docker/build/guideants-ai/llama-admin-service/llama_admin_service.py
+++ b/docker/build/guideants-ai/llama-admin-service/llama_admin_service.py
@@ -18,9 +18,11 @@ from typing import Any, Callable
 from guideants_hf.exact_download import (
     ExactDownloadError,
     activate_staged_files,
+    artifact_is_installed,
     build_artifact_specs,
     build_immutable_input,
     stage_download_file,
+    staged_artifact_path,
 )
 from guideants_hf.path_safety import PathSafetyError, delete_obsolete_repository_paths
 from guideants_hf.operation_journal import OperationJournalError, OperationJournalStore
@@ -1035,6 +1037,70 @@ def _exact_download_request_identity(request: ExactDownloadRequest) -> dict[str,
     )
 
 
+def _journal_has_download_step(record, repository_path: str) -> bool:
+    return any(
+        step.step == "downloadModelFile" and step.path == repository_path
+        for step in record.journal
+    )
+
+
+def _ensure_journal_download_step(operation_id: str, repository_path: str) -> None:
+    record = OPERATION_JOURNAL.get(operation_id)
+    if record is None or _journal_has_download_step(record, repository_path):
+        return
+    OPERATION_JOURNAL.append_step(operation_id, "downloadModelFile", repository_path)
+
+
+def _exact_download_request_from_journal(journal_record) -> ExactDownloadRequest:
+    immutable_input = journal_record.immutable_input
+    artifact_metadata: list[ArtifactMetadataDto] | None = None
+    raw_metadata = immutable_input.get("artifactMetadata")
+    if isinstance(raw_metadata, list):
+        artifact_metadata = [
+            ArtifactMetadataDto.model_validate(item)
+            for item in raw_metadata
+            if isinstance(item, dict)
+        ]
+    return ExactDownloadRequest(
+        operationId=journal_record.operation_id,
+        repository=str(immutable_input.get("repository") or ""),
+        resolvedRevision=str(immutable_input.get("resolvedRevision") or ""),
+        modelFiles=[str(path) for path in (immutable_input.get("modelFiles") or [])],
+        mmprojFiles=[str(path) for path in (immutable_input.get("mmprojFiles") or [])],
+        alias=normalize_alias(
+            str(immutable_input.get("routerModelId") or immutable_input.get("alias") or journal_record.alias)
+        ),
+        targetDirectory=str(immutable_input.get("targetDirectory") or ""),
+        preset=dict(immutable_input.get("routerPreset") or immutable_input.get("preset") or {}),
+        presetMode=str(immutable_input.get("presetMode") or "replace"),
+        artifactMetadata=artifact_metadata,
+        hfToken=None,
+    )
+
+
+def _maybe_resume_exact_download_from_journal(journal_record) -> None:
+    if journal_record.status not in {"queued", "resolvingFiles", "downloading", "validating", "registeringAlias"}:
+        return
+    if _download_worker_active(journal_record.operation_id):
+        return
+    request = _exact_download_request_from_journal(journal_record)
+    with OPERATIONS_LOCK:
+        state = OPERATIONS.get(journal_record.operation_id)
+        if state is None:
+            OPERATIONS[journal_record.operation_id] = DownloadOperationState(
+                operation_id=journal_record.operation_id,
+                router_model_id=journal_record.alias,
+                status=journal_record.status,
+                progress=journal_record.progress,
+                log_line=journal_record.log_line,
+            )
+    _start_download_worker(
+        journal_record.operation_id,
+        run_exact_download_operation,
+        (journal_record.operation_id, request),
+    )
+
+
 def run_exact_download_operation(operation_id: str, request: ExactDownloadRequest) -> None:
     alias = normalize_alias(request.alias)
     alias_lock = get_alias_lock(alias)
@@ -1093,13 +1159,10 @@ def run_exact_download_operation(operation_id: str, request: ExactDownloadReques
         token = (request.hfToken or "").strip() or None
         all_specs = model_specs + mmproj_specs
         total = len(all_specs)
-        existing = OPERATION_JOURNAL.get(operation_id)
-        completed_files = 0
-        if existing is not None:
-            completed_files = sum(1 for step in existing.journal if step.step == "downloadModelFile")
 
         for idx, spec in enumerate(all_specs):
-            if idx < completed_files:
+            if artifact_is_installed(spec) or staged_artifact_path(staging_dir, spec) is not None:
+                _ensure_journal_download_step(operation_id, spec.repository_path)
                 continue
 
             def report(bytes_read: int, *, file_idx: int = idx) -> None:
@@ -1472,14 +1535,15 @@ def _start_exact_download(request: ExactDownloadRequest) -> dict[str, Any]:
             )
         if _download_worker_active(operation_id):
             return existing_journal.to_dto()
-        if existing_journal.status == "failed":
-            OPERATION_JOURNAL.update(
-                operation_id,
-                status="queued",
-                error_message=None,
-                completed_at=None,
-                log_line="Retrying interrupted download.",
-            )
+        if existing_journal.status != "failed":
+            return existing_journal.to_dto()
+        OPERATION_JOURNAL.update(
+            operation_id,
+            status="queued",
+            error_message=None,
+            completed_at=None,
+            log_line="Retrying interrupted download.",
+        )
 
     with OPERATIONS_LOCK:
         existing = next(
@@ -1584,6 +1648,8 @@ def _start_legacy_download(request: StartDownloadRequest) -> dict[str, Any]:
 def get_download_status(operation_id: str) -> dict[str, Any]:
     journal_record = OPERATION_JOURNAL.get(operation_id)
     if journal_record is not None:
+        _maybe_resume_exact_download_from_journal(journal_record)
+        journal_record = OPERATION_JOURNAL.get(operation_id) or journal_record
         return journal_record.to_dto()
     with OPERATIONS_LOCK:
         state = OPERATIONS.get(operation_id)

--- a/docker/build/guideants-ai/llama-admin-service/llama_catalog.py
+++ b/docker/build/guideants-ai/llama-admin-service/llama_catalog.py
@@ -124,12 +124,16 @@ def validate_manifest_instance(manifest: dict[str, Any]) -> None:
         has_mtp = any(key in preset for key in _MTP_PRESET_KEYS)
 
         if has_mtp:
-            if has_projector:
-                raise CatalogValidationError(f"MTP model '{model_id}' must not declare mmproj.")
-            if has_vision:
-                raise CatalogValidationError(f"MTP model '{model_id}' must not declare vision preset keys.")
             if preset.get("spec-type") != "draft-mtp":
                 raise CatalogValidationError(f"MTP model '{model_id}' must set spec-type=draft-mtp.")
+            if has_projector and not has_vision:
+                raise CatalogValidationError(
+                    f"MTP model '{model_id}' with mmproj must declare image-min-tokens in routerPreset."
+                )
+            if not has_projector and has_vision:
+                raise CatalogValidationError(
+                    f"MTP model '{model_id}' declares image-min-tokens without mmproj."
+                )
         elif has_projector and not has_vision:
             raise CatalogValidationError(
                 f"Vision model '{model_id}' with mmproj must declare image-min-tokens in routerPreset."

--- a/docker/build/guideants-ai/llama-admin-service/tests/test_exact_download.py
+++ b/docker/build/guideants-ai/llama-admin-service/tests/test_exact_download.py
@@ -9,6 +9,7 @@ from support import CONTRACTS_ROOT
 from guideants_hf.exact_download import (
     ExactDownloadError,
     activate_staged_files,
+    artifact_is_installed,
     build_artifact_specs,
     build_immutable_input,
     resume_metadata_matches,
@@ -122,6 +123,39 @@ class ExactDownloadTests(unittest.TestCase):
         self.assertTrue(os.path.isfile(final_path))
         self.assertEqual(os.path.getsize(final_path), 4)
 
+    def test_activate_skips_already_installed_artifacts(self) -> None:
+        _, model_specs, mmproj_specs = build_artifact_specs(
+            model_files=["model.gguf"],
+            mmproj_files=["mmproj-F16.gguf"],
+            store_root=self._root,
+            target_subdir="vision-model",
+            artifact_metadata=[
+                {"path": "model.gguf", "size": 6},
+                {"path": "mmproj-F16.gguf", "size": 4},
+            ],
+        )
+        target_dir = os.path.join(self._root, "vision-model")
+        os.makedirs(target_dir, exist_ok=True)
+        installed_model = os.path.join(target_dir, "model.gguf")
+        with open(installed_model, "wb") as handle:
+            handle.write(b"model!")
+
+        staging_dir = os.path.join(self._root, ".staging", "op-vision")
+        os.makedirs(staging_dir, exist_ok=True)
+        staged_mmproj = os.path.join(staging_dir, "mmproj-F16.gguf")
+        with open(staged_mmproj, "wb") as handle:
+            handle.write(b"proj")
+
+        activated = activate_staged_files(
+            staging_dir=staging_dir,
+            target_dir=target_dir,
+            store_root=self._root,
+            specs=model_specs + mmproj_specs,
+        )
+        self.assertEqual(activated, [installed_model, os.path.join(target_dir, "mmproj-F16.gguf")])
+        self.assertTrue(artifact_is_installed(model_specs[0]))
+        self.assertTrue(artifact_is_installed(mmproj_specs[0]))
+
     def test_journal_survives_restart(self) -> None:
         journal_root = os.path.join(self._root, ".llama-operations")
         store = OperationJournalStore(journal_root)
@@ -186,6 +220,32 @@ class ExactDownloadTests(unittest.TestCase):
             operation_id="op-2",
         )
         self.assertTrue(os.path.isfile(os.path.join(staging_dir, "a.gguf")))
+
+    @mock.patch("guideants_hf.exact_download.download_hf_file")
+    def test_stage_download_skips_when_already_installed(self, download_mock: mock.Mock) -> None:
+        _, model_specs, _ = build_artifact_specs(
+            model_files=["a.gguf"],
+            mmproj_files=[],
+            store_root=self._root,
+            target_subdir="alias",
+            artifact_metadata=[{"path": "a.gguf", "size": 4}],
+        )
+        target_dir = os.path.join(self._root, "alias")
+        os.makedirs(target_dir, exist_ok=True)
+        with open(os.path.join(target_dir, "a.gguf"), "wb") as handle:
+            handle.write(b"1234")
+
+        staging_dir = os.path.join(self._root, ".staging", "op-3")
+        result = stage_download_file(
+            repository="org/repo",
+            resolved_revision="rev",
+            spec=model_specs[0],
+            staging_dir=staging_dir,
+            token=None,
+            operation_id="op-3",
+        )
+        self.assertEqual(result, model_specs[0].destination_abs)
+        download_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/docker/build/guideants-ai/llama-admin-service/tests/test_llama_catalog.py
+++ b/docker/build/guideants-ai/llama-admin-service/tests/test_llama_catalog.py
@@ -46,10 +46,12 @@ class LlamaCatalogServiceTests(unittest.TestCase):
     ) -> None:
         list_files.return_value = [
             {"type": "file", "path": "Qwen3.6-35B-A3B-MTP-UD-Q4_K_XL.gguf", "size": 100},
+            {"type": "file", "path": "mmproj-F16.gguf", "size": 900_000_000},
         ]
         payload = llama_catalog.resolve_definition_quants("qwen3.6-35b-a3b-mtp", None)
         self.assertEqual("abc123", payload["resolvedRevision"])
-        self.assertIsNone(payload["projector"])
+        self.assertIsNotNone(payload["projector"])
+        self.assertEqual("mmproj-F16.gguf", payload["projector"]["path"])
         self.assertEqual("ud_q4_k_xl", payload["quants"][0]["id"])
         self.assertIn("guidance", payload["quants"][0])
 

--- a/docker/build/guideants-ai/llama-admin-service/tests/test_llama_schema.py
+++ b/docker/build/guideants-ai/llama-admin-service/tests/test_llama_schema.py
@@ -81,17 +81,19 @@ class LlamaSchemaTests(unittest.TestCase):
         with self.assertRaises(CatalogValidationError):
             validate_manifest_instance(bad)
 
-    def test_rejects_mtp_with_projector(self) -> None:
+    def test_mtp_with_projector_requires_image_min_tokens(self) -> None:
         bad = copy.deepcopy(self.manifest)
         mtp = next(m for m in bad["models"] if m["id"] == "qwen3.6-35b-a3b-mtp")
-        mtp["defaults"]["mmproj"] = {"path": "mmproj-F16.gguf"}
+        del mtp["defaults"]["routerPreset"]["image-min-tokens"]
         with self.assertRaises(CatalogValidationError):
             validate_manifest_instance(bad)
 
-    def test_rejects_mtp_with_image_min_tokens(self) -> None:
+    def test_mtp_without_projector_rejects_image_min_tokens(self) -> None:
         bad = copy.deepcopy(self.manifest)
-        mtp = next(m for m in bad["models"] if m["id"] == "qwen3.6-35b-a3b-mtp")
-        mtp["defaults"]["routerPreset"]["image-min-tokens"] = "1024"
+        text_only = next(m for m in bad["models"] if m["id"] == "gpt-oss-20b")
+        text_only["defaults"]["routerPreset"]["spec-type"] = "draft-mtp"
+        text_only["defaults"]["routerPreset"]["spec-draft-n-max"] = "2"
+        text_only["defaults"]["routerPreset"]["image-min-tokens"] = "1024"
         with self.assertRaises(CatalogValidationError):
             validate_manifest_instance(bad)
 

--- a/docs/llama-router-preset-ui-execution/contracts/Program.cs
+++ b/docs/llama-router-preset-ui-execution/contracts/Program.cs
@@ -42,18 +42,24 @@ if (File.Exists(d12Path))
     using var stream = File.OpenRead(d12Path);
     using var doc = JsonDocument.Parse(stream);
     var root = doc.RootElement;
-    if (root.TryGetProperty("mmprojFiles", out var mmprojFiles) && mmprojFiles.GetArrayLength() > 0)
+    if (root.TryGetProperty("definitionId", out var definitionId)
+        && definitionId.GetString()?.EndsWith("-mtp", StringComparison.Ordinal) == true)
     {
-        failures.Add("immutable-operation-input.fixture.json: D12 requires empty mmprojFiles for MTP");
-    }
-
-    if (root.TryGetProperty("routerPreset", out var preset) && preset.ValueKind == JsonValueKind.Object)
-    {
-        foreach (var forbidden in new[] { "image-min-tokens", "mmproj", "projector" })
+        if (!root.TryGetProperty("mmprojFiles", out var mmprojFiles) || mmprojFiles.GetArrayLength() == 0)
         {
-            if (preset.TryGetProperty(forbidden, out _))
+            failures.Add("immutable-operation-input.fixture.json: MTP vision rows require mmprojFiles");
+        }
+
+        if (root.TryGetProperty("routerPreset", out var preset) && preset.ValueKind == JsonValueKind.Object)
+        {
+            if (!preset.TryGetProperty("image-min-tokens", out _))
             {
-                failures.Add($"immutable-operation-input.fixture.json: D12 forbids routerPreset key '{forbidden}'");
+                failures.Add("immutable-operation-input.fixture.json: MTP vision rows require routerPreset.image-min-tokens");
+            }
+
+            if (!preset.TryGetProperty("spec-type", out var specType) || specType.GetString() != "draft-mtp")
+            {
+                failures.Add("immutable-operation-input.fixture.json: MTP rows require routerPreset.spec-type=draft-mtp");
             }
         }
     }

--- a/docs/llama-router-preset-ui-execution/contracts/admin-catalog-get-response.fixture.json
+++ b/docs/llama-router-preset-ui-execution/contracts/admin-catalog-get-response.fixture.json
@@ -8,7 +8,7 @@
       "display": {
         "name": "Qwen 3.6 35B A3B MTP",
         "description": "Curated local Qwen model with MTP configuration.",
-        "labels": ["Text", "Reasoning", "Tool use"],
+        "labels": ["Text", "Vision", "Reasoning", "Tool use", "MTP"],
         "license": "Apache-2.0",
         "documentationUrl": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF"
       },
@@ -21,9 +21,10 @@
         "routerModelId": "Qwen3.6-35B-A3B-MTP-GGUF",
         "runtimeProfileId": "qwen3_6",
         "targetDirectory": "Qwen3.6-35B-A3B-MTP-GGUF",
-        "mmproj": null,
+        "mmproj": { "path": "mmproj-F16.gguf" },
         "routerPreset": {
           "ctx-size": "131072",
+          "image-min-tokens": "1024",
           "spec-type": "draft-mtp",
           "spec-draft-n-max": "2"
         }

--- a/docs/llama-router-preset-ui-execution/contracts/admin-quants-get-response.fixture.json
+++ b/docs/llama-router-preset-ui-execution/contracts/admin-quants-get-response.fixture.json
@@ -24,5 +24,8 @@
       ]
     }
   ],
-  "projector": null
+  "projector": {
+    "path": "mmproj-F16.gguf",
+    "size": 1234567890
+  }
 }

--- a/docs/llama-router-preset-ui-execution/contracts/catalog-get-response.fixture.json
+++ b/docs/llama-router-preset-ui-execution/contracts/catalog-get-response.fixture.json
@@ -8,7 +8,7 @@
       "display": {
         "name": "Qwen 3.6 35B A3B MTP",
         "description": "Curated local Qwen model with MTP configuration.",
-        "labels": ["Text", "Reasoning", "Tool use"],
+        "labels": ["Text", "Vision", "Reasoning", "Tool use", "MTP"],
         "license": "Apache-2.0",
         "documentationUrl": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF"
       },
@@ -21,9 +21,10 @@
         "routerModelId": "Qwen3.6-35B-A3B-MTP-GGUF",
         "runtimeProfileId": "qwen3_6",
         "targetDirectory": "Qwen3.6-35B-A3B-MTP-GGUF",
-        "mmproj": null,
+        "mmproj": { "path": "mmproj-F16.gguf" },
         "routerPreset": {
           "ctx-size": "131072",
+          "image-min-tokens": "1024",
           "spec-type": "draft-mtp",
           "spec-draft-n-max": "2"
         }

--- a/docs/llama-router-preset-ui-execution/contracts/immutable-operation-input.fixture.json
+++ b/docs/llama-router-preset-ui-execution/contracts/immutable-operation-input.fixture.json
@@ -7,11 +7,14 @@
     "Qwen3.6-35B-A3B-Q6_K_XL-00001-of-00002.gguf",
     "Qwen3.6-35B-A3B-Q6_K_XL-00002-of-00002.gguf"
   ],
-  "mmprojFiles": [],
+  "mmprojFiles": [
+    "mmproj-F16.gguf"
+  ],
   "routerModelId": "Qwen3.6-35B-A3B-MTP-GGUF",
   "runtimeProfileId": "qwen3_6",
   "routerPreset": {
     "ctx-size": "131072",
+    "image-min-tokens": "1024",
     "spec-type": "draft-mtp",
     "spec-draft-n-max": "2"
   }

--- a/docs/llama-router-preset-ui-execution/contracts/manifest.catalog.fixture.json
+++ b/docs/llama-router-preset-ui-execution/contracts/manifest.catalog.fixture.json
@@ -36,7 +36,7 @@
       "display": {
         "name": "Qwen 3.6 35B A3B MTP",
         "description": "Curated local Qwen model with MTP configuration.",
-        "labels": ["Text", "Reasoning", "Tool use"],
+        "labels": ["Text", "Vision", "Reasoning", "Tool use", "MTP"],
         "license": "Apache-2.0",
         "documentationUrl": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF"
       },
@@ -49,9 +49,10 @@
         "routerModelId": "Qwen3.6-35B-A3B-MTP-GGUF",
         "runtimeProfileId": "qwen3_6",
         "targetDirectory": "Qwen3.6-35B-A3B-MTP-GGUF",
-        "mmproj": null,
+        "mmproj": { "path": "mmproj-F16.gguf" },
         "routerPreset": {
           "ctx-size": "131072",
+          "image-min-tokens": "1024",
           "spec-type": "draft-mtp",
           "spec-draft-n-max": "2"
         }

--- a/docs/llama-router-preset-ui-execution/contracts/quant-group-response.fixture.json
+++ b/docs/llama-router-preset-ui-execution/contracts/quant-group-response.fixture.json
@@ -35,5 +35,8 @@
       ]
     }
   ],
-  "projector": null
+  "projector": {
+    "path": "mmproj-F16.gguf",
+    "size": 1234567890
+  }
 }

--- a/docs/llama-router-preset-ui-execution/contracts/validate-contracts.py
+++ b/docs/llama-router-preset-ui-execution/contracts/validate-contracts.py
@@ -33,15 +33,20 @@ def main() -> int:
     if d12_path.exists():
         mtp = load_json(d12_path)
         assert isinstance(mtp, dict)
-        if mtp.get("mmprojFiles"):
-            failures.append("immutable-operation-input.fixture.json: D12 requires empty mmprojFiles for MTP")
-        forbidden = {"image-min-tokens", "mmproj", "projector"}
-        preset = mtp.get("routerPreset") or {}
-        if isinstance(preset, dict):
-            for key in forbidden:
-                if key in preset:
+        if str(mtp.get("definitionId", "")).endswith("-mtp"):
+            if not mtp.get("mmprojFiles"):
+                failures.append(
+                    "immutable-operation-input.fixture.json: MTP rows require mmprojFiles when vision is enabled"
+                )
+            preset = mtp.get("routerPreset") or {}
+            if isinstance(preset, dict):
+                if "image-min-tokens" not in preset:
                     failures.append(
-                        f"immutable-operation-input.fixture.json: D12 forbids routerPreset key '{key}'"
+                        "immutable-operation-input.fixture.json: MTP vision rows require routerPreset.image-min-tokens"
+                    )
+                if preset.get("spec-type") != "draft-mtp":
+                    failures.append(
+                        "immutable-operation-input.fixture.json: MTP rows require routerPreset.spec-type=draft-mtp"
                     )
 
     if failures:

--- a/docs/llama-router-preset-ui-execution/contracts/validate-contracts.ts
+++ b/docs/llama-router-preset-ui-execution/contracts/validate-contracts.ts
@@ -52,12 +52,15 @@ if (catalog.schemaVersion !== 1 || catalog.task !== 'llama') {
 const mtp = JSON.parse(
   readFileSync(join(contractsDir, 'immutable-operation-input.fixture.json'), 'utf8'),
 ) as ImmutableOperationInput;
-if (mtp.mmprojFiles.length > 0) {
-  failures.push('immutable-operation-input.fixture.json: D12 requires empty mmprojFiles for MTP');
-}
-for (const forbidden of ['image-min-tokens', 'mmproj', 'projector']) {
-  if (forbidden in mtp.routerPreset) {
-    failures.push(`immutable-operation-input.fixture.json: D12 forbids routerPreset key '${forbidden}'`);
+if (mtp.definitionId.endsWith('-mtp')) {
+  if (mtp.mmprojFiles.length === 0) {
+    failures.push('immutable-operation-input.fixture.json: MTP vision rows require mmprojFiles');
+  }
+  if (!('image-min-tokens' in mtp.routerPreset)) {
+    failures.push('immutable-operation-input.fixture.json: MTP vision rows require routerPreset.image-min-tokens');
+  }
+  if (mtp.routerPreset['spec-type'] !== 'draft-mtp') {
+    failures.push('immutable-operation-input.fixture.json: MTP rows require routerPreset.spec-type=draft-mtp');
   }
 }
 

--- a/src/client/src/features/localModelOnboarding/__tests__/useOperationPolling.test.ts
+++ b/src/client/src/features/localModelOnboarding/__tests__/useOperationPolling.test.ts
@@ -98,6 +98,28 @@ describe('useOperationPolling', () => {
       window.clearInterval(timerId);
     });
 
+    it('stops polling after a terminal status so onTerminal fires once', async () => {
+      (api.settings.getDownloadStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+        operationId: 'op-term',
+        status: 'completed',
+      });
+      const onUpdate = vi.fn();
+      const onTerminal = vi.fn();
+
+      const timerId = createLocalModelOnboardingPoller({
+        operationId: 'op-term',
+        onUpdate,
+        onTerminal,
+        intervalMs: 100,
+      });
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(onTerminal).toHaveBeenCalledTimes(1);
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      window.clearInterval(timerId);
+    });
+
     it('calls onPollFailureThreshold after repeated failures', async () => {
       (api.settings.getDownloadStatus as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('offline'));
       const onPollFailureThreshold = vi.fn();

--- a/src/client/src/features/localModelOnboarding/curated/LlamaCuratedOnboardingFlow.tsx
+++ b/src/client/src/features/localModelOnboarding/curated/LlamaCuratedOnboardingFlow.tsx
@@ -136,6 +136,19 @@ export function LlamaCuratedOnboardingFlow({
         />
       ) : null}
 
+      {state.submitError && state.step !== 'progress' ? (
+        <div
+          role="alert"
+          className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+        >
+          <div className="font-medium">{state.submitError.code}</div>
+          <div>{state.submitError.message}</div>
+          {state.submitError.remediation ? (
+            <div className="mt-1 text-xs">{state.submitError.remediation}</div>
+          ) : null}
+        </div>
+      ) : null}
+
       {state.step === 'completed' ? (
         <LlamaCuratedCompletion
           catalogModel={state.completedCatalogModel}

--- a/src/client/src/features/localModelOnboarding/curated/__tests__/LlamaCuratedModelPicker.test.tsx
+++ b/src/client/src/features/localModelOnboarding/curated/__tests__/LlamaCuratedModelPicker.test.tsx
@@ -34,7 +34,7 @@ describe('LlamaCuratedModelPicker', () => {
     render(
       <LlamaCuratedModelPicker
         models={models}
-        searchQuery="vision"
+        searchQuery="MTP-GGUF"
         selectedDefinitionId={null}
         loading={false}
         error={null}
@@ -44,7 +44,7 @@ describe('LlamaCuratedModelPicker', () => {
       />
     );
 
-    expect(screen.getByText(/Qwen 3.6 35B A3B/i)).toBeInTheDocument();
-    expect(screen.queryByText(/MTP/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Qwen 3.6 35B A3B MTP/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Qwen 3.6 35B A3B$/i)).not.toBeInTheDocument();
   });
 });

--- a/src/client/src/features/localModelOnboarding/curated/fixtures.ts
+++ b/src/client/src/features/localModelOnboarding/curated/fixtures.ts
@@ -41,8 +41,8 @@ export const catalogFixture: LlamaCatalogResponseDto = {
       id: 'qwen3.6-35b-a3b-mtp',
       display: {
         name: 'Qwen 3.6 35B A3B MTP',
-        description: 'Curated local Qwen model with MTP configuration.',
-        labels: ['Text', 'Reasoning', 'Tool use'],
+        description: 'Curated local Qwen model with MTP and vision configuration.',
+        labels: ['Text', 'Vision', 'Reasoning', 'Tool use', 'MTP'],
         license: 'Apache-2.0',
         documentationUrl: 'https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF',
       },
@@ -55,9 +55,10 @@ export const catalogFixture: LlamaCatalogResponseDto = {
         routerModelId: 'Qwen3.6-35B-A3B-MTP-GGUF',
         runtimeProfileId: 'qwen3_6',
         targetDirectory: 'Qwen3.6-35B-A3B-MTP-GGUF',
-        mmproj: null,
+        mmproj: { path: 'mmproj-F16.gguf' },
         routerPreset: {
           'ctx-size': '131072',
+          'image-min-tokens': '1024',
           'spec-type': 'draft-mtp',
           'spec-draft-n-max': '2',
         },
@@ -95,7 +96,7 @@ export const quantFixture: LlamaCatalogQuantsResponseDto = {
       ],
     },
   ],
-  projector: null,
+  projector: { path: 'mmproj-F16.gguf', size: 900_000_000 },
 };
 
 export const curatedRequestFixture = {

--- a/src/client/src/features/localModelOnboarding/useOperationPolling.ts
+++ b/src/client/src/features/localModelOnboarding/useOperationPolling.ts
@@ -40,16 +40,28 @@ export function createLocalModelOnboardingPoller({
   failureThreshold = DEFAULT_FAILURE_THRESHOLD,
 }: CreateLocalModelOnboardingPollerOptions): number {
   let consecutivePollFailures = 0;
+  let stopped = false;
+  let timerId = 0;
 
-  return window.setInterval(() => {
+  timerId = window.setInterval(() => {
     void (async () => {
+      if (stopped) {
+        return;
+      }
       try {
         const operation = await fetchOperationStatus(operationId, pollRoute);
         consecutivePollFailures = 0;
-        onUpdate(operation);
         if (isLocalModelOnboardingTerminal(operation.status)) {
+          // Stop before invoking callbacks so a terminal status fires onUpdate/onTerminal
+          // exactly once. Otherwise the interval keeps re-firing terminal side effects
+          // (e.g. catalog refetch) every tick.
+          stopped = true;
+          window.clearInterval(timerId);
+          onUpdate(operation);
           onTerminal?.(operation);
+          return;
         }
+        onUpdate(operation);
       } catch {
         consecutivePollFailures += 1;
         if (consecutivePollFailures >= failureThreshold) {
@@ -58,6 +70,8 @@ export function createLocalModelOnboardingPoller({
       }
     })();
   }, intervalMs);
+
+  return timerId;
 }
 
 interface UseLocalModelOnboardingOperationOptions {
@@ -127,15 +141,24 @@ export function useCuratedOperationPolling({
     }
 
     let consecutivePollFailures = 0;
-    const timerId = window.setInterval(() => {
+    let stopped = false;
+    let timerId = 0;
+    timerId = window.setInterval(() => {
       void (async () => {
+        if (stopped) {
+          return;
+        }
         try {
           const operation = await api.settings.getLlamaOperationStatus(operationId);
           consecutivePollFailures = 0;
-          onUpdate(operation);
           if (isLocalModelOnboardingTerminal(operation.status)) {
+            stopped = true;
+            window.clearInterval(timerId);
+            onUpdate(operation);
             onTerminal?.(operation);
+            return;
           }
+          onUpdate(operation);
         } catch {
           consecutivePollFailures += 1;
           if (consecutivePollFailures >= (failureThreshold ?? DEFAULT_FAILURE_THRESHOLD)) {
@@ -146,6 +169,7 @@ export function useCuratedOperationPolling({
     }, intervalMs ?? DEFAULT_POLL_INTERVAL_MS);
 
     return () => {
+      stopped = true;
       window.clearInterval(timerId);
     };
   }, [enabled, failureThreshold, intervalMs, onPollFailureThreshold, onTerminal, onUpdate, operationId]);

--- a/src/server/AntRunner.Chat/AntRunner.Chat/ThreadRun.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat/ThreadRun.cs
@@ -1245,7 +1245,7 @@ namespace AntRunner.Chat
                                     assistantDef.Name!,
                                     isolatedCtx);
                                 
-                                output = JsonSerializer.Serialize(sandboxResult);
+                                output = SerializeToolResult(sandboxResult);
                             }
                             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                             {
@@ -1263,7 +1263,7 @@ namespace AntRunner.Chat
                                 var toolResult = await builder.ExecuteLocalFunctionAsync(cancellationToken);
                                 if (toolResult != null)
                                 {
-                                    output = JsonSerializer.Serialize(toolResult);
+                                    output = SerializeToolResult(toolResult);
                                 }
                                 else
                                 {
@@ -1634,6 +1634,11 @@ namespace AntRunner.Chat
         {
             PropertyNameCaseInsensitive = true
         };
+
+        private static string SerializeToolResult(object toolResult) =>
+            toolResult is ScriptExecutionResult scriptResult
+                ? JsonSerializer.Serialize(scriptResult.ForToolCall(), ScriptExecutionResultJsonOptions)
+                : JsonSerializer.Serialize(toolResult);
 
         private static IReadOnlyDictionary<string, JsonElement> ResolveExecutionParameters(
             ResolvedExecutionPolicy policy)

--- a/src/server/AntRunner.Chat/AntRunner.Chat/ToolOutputTruncator.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat/ToolOutputTruncator.cs
@@ -28,15 +28,29 @@ public static class ToolOutputTruncator
 
     public static ToolOutputTruncationResult Truncate(string? output)
     {
-        if (string.IsNullOrEmpty(output) || output.Length <= MaxCharacters)
+        if (string.IsNullOrEmpty(output))
         {
-            return new ToolOutputTruncationResult(output, false, output?.Length ?? 0);
+            return new ToolOutputTruncationResult(output, false, 0);
         }
 
         var originalLength = output.Length;
 
-        var truncated = TryDeserializeScriptExecutionResult(output, out var parsed)
-            ? TruncateScriptExecutionResult(parsed, originalLength)
+        if (TryDeserializeScriptExecutionResult(output, out var parsed))
+        {
+            var forToolCall = parsed.ForToolCall();
+            if (!ReferenceEquals(forToolCall, parsed))
+            {
+                output = Serialize(forToolCall);
+            }
+        }
+
+        if (output.Length <= MaxCharacters)
+        {
+            return new ToolOutputTruncationResult(output, false, originalLength);
+        }
+
+        var truncated = TryDeserializeScriptExecutionResult(output, out parsed)
+            ? TruncateScriptExecutionResult(parsed.ForToolCall(), originalLength)
             : TruncatePlainOutput(output, originalLength);
 
         return new ToolOutputTruncationResult(Serialize(truncated), true, originalLength);

--- a/src/server/AntRunner.Chat/AntRunner.ToolCalling/Functions/DockerExecTool.cs
+++ b/src/server/AntRunner.Chat/AntRunner.ToolCalling/Functions/DockerExecTool.cs
@@ -33,6 +33,27 @@ namespace AntRunner.ToolCalling.Functions
         /// Used by ThreadRun to inject a system message so the assistant is aware of modified files.
         /// </summary>
         public List<string>? ModifiedFiles { get; set; }
+
+        /// <summary>
+        /// Shape returned to the model for a tool call. Successful runs (exit code 0) omit
+        /// <see cref="StandardError"/> — that stream is progress/diagnostics, not actionable errors.
+        /// </summary>
+        public ScriptExecutionResult ForToolCall()
+        {
+            if (ExitCode is not 0 || string.IsNullOrEmpty(StandardError))
+            {
+                return this;
+            }
+
+            return new ScriptExecutionResult
+            {
+                StandardOutput = StandardOutput,
+                StandardError = string.Empty,
+                ExitCode = ExitCode,
+                NewFiles = NewFiles,
+                ModifiedFiles = ModifiedFiles
+            };
+        }
     }
 
     public class DockerScriptService

--- a/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LlamaCatalogContractTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LlamaCatalogContractTests.cs
@@ -43,7 +43,9 @@ public sealed class LlamaCatalogContractTests
         dto.CatalogVersion.Should().Be("2026-07-10");
         dto.Models.Should().HaveCount(1);
         dto.Models[0].Defaults.RouterPreset.Should().ContainKey("ctx-size");
-        dto.Models[0].Defaults.Mmproj.Should().BeNull();
+        dto.Models[0].Defaults.RouterPreset.Should().ContainKey("image-min-tokens");
+        dto.Models[0].Defaults.Mmproj.Should().NotBeNull();
+        dto.Models[0].Defaults.Mmproj!.Path.Should().Be("mmproj-F16.gguf");
     }
 
     [TestMethod]
@@ -64,7 +66,8 @@ public sealed class LlamaCatalogContractTests
         dto!.Quants.Should().HaveCount(2);
         dto.Quants[1].Files.Should().HaveCount(2);
         dto.Quants[1].Files[0].ShardIndex.Should().Be(1);
-        dto.Projector.Should().BeNull();
+        dto.Projector.Should().NotBeNull();
+        dto.Projector!.Path.Should().Be("mmproj-F16.gguf");
     }
 
     [TestMethod]

--- a/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LocalModelOnboarding/CuratedInstallTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LocalModelOnboarding/CuratedInstallTests.cs
@@ -38,6 +38,76 @@ public sealed class CuratedInstallTests
     }
 
     [TestMethod]
+    public async Task ValidateAsync_CuratedSameTargetAlreadyInstalled_DoesNotThrow()
+    {
+        // A prior (e.g. text-only) install of the same curated definition exists and its catalog row
+        // owns the router alias. Re-installing the current definition must reconcile, not throw.
+        var runtimeConfigJson = LocalRuntimeConfigurationParser.SerializeCanonical(
+            new LocalRuntimeConfiguration("Qwen3.6-35B-A3B-MTP-GGUF", "qwen3_6"));
+        var validator = CreateValidator(
+            models:
+            [
+                new SettingsModelDto(
+                    "qwen3.6-35b-a3b-mtp-local", "Qwen 3.6 35B A3B MTP", "llama-cpp", null, null,
+                    runtimeConfigJson, true, null, DateTime.UtcNow, null),
+            ],
+            inventory:
+            [
+                new LlamaRuntimeInventoryItemDto(
+                    "Qwen3.6-35B-A3B-MTP-GGUF", "unloaded", "/models/model.gguf", null, true, false,
+                    ["qwen3.6-35b-a3b-mtp-local"], 0),
+            ]);
+
+        var request = CreateCuratedRequest();
+        var command = LocalModelOnboardingCommand.FromAddModelRequest(request);
+
+        var act = async () => await validator.ValidateAsync(request, command, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    [TestMethod]
+    public async Task ValidateAsync_CuratedModelIdReusedForDifferentTarget_ThrowsModelIdTaken()
+    {
+        // Same catalogModelId but a different runtime configuration (different alias) is a genuine
+        // conflict, not a reconcile.
+        var runtimeConfigJson = LocalRuntimeConfigurationParser.SerializeCanonical(
+            new LocalRuntimeConfiguration("some-other-alias", "qwen3_6"));
+        var validator = CreateValidator(
+            models:
+            [
+                new SettingsModelDto(
+                    "qwen3.6-35b-a3b-mtp-local", "Different", "llama-cpp", null, null,
+                    runtimeConfigJson, true, null, DateTime.UtcNow, null),
+            ]);
+
+        var request = CreateCuratedRequest();
+        var command = LocalModelOnboardingCommand.FromAddModelRequest(request);
+
+        var act = async () => await validator.ValidateAsync(request, command, CancellationToken.None);
+        var ex = await act.Should().ThrowAsync<AddModelException>();
+        ex.Which.Code.Should().Be("MODEL_ID_TAKEN");
+    }
+
+    [TestMethod]
+    public async Task ValidateAsync_CuratedAliasOwnedByDifferentCatalogRow_ThrowsRouterAliasTaken()
+    {
+        var validator = CreateValidator(
+            inventory:
+            [
+                new LlamaRuntimeInventoryItemDto(
+                    "Qwen3.6-35B-A3B-MTP-GGUF", "unloaded", "/models/model.gguf", null, true, false,
+                    ["some-other-model"], 0),
+            ]);
+
+        var request = CreateCuratedRequest();
+        var command = LocalModelOnboardingCommand.FromAddModelRequest(request);
+
+        var act = async () => await validator.ValidateAsync(request, command, CancellationToken.None);
+        var ex = await act.Should().ThrowAsync<AddModelException>();
+        ex.Which.Code.Should().Be("ROUTER_ALIAS_TAKEN");
+    }
+
+    [TestMethod]
     public async Task Resolver_CatalogVersionMismatch_Throws()
     {
         var adminClient = CreateAdminClient(catalogVersion: "2026-01-01");
@@ -167,6 +237,73 @@ public sealed class CuratedInstallTests
     }
 
     [TestMethod]
+    public async Task OperationService_ReconcileExistingInstall_UpdatesProjectorProvenance()
+    {
+        await using var db = CreateDbContext();
+        SeedRuntimeProfile(db);
+        var input = CreateImmutableInput(singleGguf: true);
+        var now = DateTime.UtcNow;
+
+        // Prior text-only install: catalog row + provenance with NO projector recorded.
+        db.Models.Add(new Model
+        {
+            ModelId = input.CatalogModelId,
+            DisplayName = input.CatalogDisplayName,
+            Provider = "llama-cpp",
+            RuntimeConfigJson = LocalRuntimeConfigurationParser.SerializeCanonical(
+                new LocalRuntimeConfiguration(input.RouterModelId, input.RuntimeProfileId)),
+            IsActive = true,
+            Created = now,
+            Updated = now,
+        });
+        db.LocalModelInstallations.Add(new LocalModelInstallation
+        {
+            ModelId = input.CatalogModelId,
+            ManagementMode = "curated",
+            CatalogId = input.DefinitionId,
+            CatalogVersion = input.DefinitionVersion,
+            Repository = input.Repository,
+            ResolvedRevision = input.ResolvedRevision,
+            QuantId = input.QuantId,
+            QuantLabel = input.QuantLabel,
+            RouterModelId = input.RouterModelId,
+            RuntimeProfileId = input.RuntimeProfileId,
+            TargetDirectory = input.TargetDirectory,
+            ModelArtifactsJson = "[]",
+            ProjectorArtifactsJson = "[]",
+            RouterPresetSnapshotJson = "{}",
+            CreatedUtc = now,
+            UpdatedUtc = now,
+            RowVersion = DefaultRowVersion,
+        });
+
+        var operationId = Guid.Parse("66666666-6666-6666-6666-666666666666");
+        db.LocalModelOperations.Add(new LocalModelOperation
+        {
+            OperationId = operationId,
+            OperationKind = "curatedInstall",
+            ModelId = input.CatalogModelId,
+            RouterModelId = input.RouterModelId,
+            ImmutableInputJson = input.ToJson(),
+            Status = "catalogFinalization",
+            CurrentStep = "catalogFinalization",
+            CompletedSideEffectsJson = """{"downloadStarted":true,"artifactsActivated":true,"aliasRegistered":true}""",
+            RowVersion = DefaultRowVersion,
+        });
+        await db.SaveChangesAsync();
+
+        var adminClient = new Mock<ILlamaRuntimeAdminClient>(MockBehavior.Strict);
+        var service = CreateOperationService(db, adminClient.Object);
+        var status = await service.ReconcileAndGetStatusAsync(operationId, CancellationToken.None);
+
+        status.Status.Should().Be("completed");
+        (await db.Models.CountAsync()).Should().Be(1);
+        var installation = await db.LocalModelInstallations.SingleAsync(x => x.ModelId == input.CatalogModelId);
+        installation.ProjectorArtifactsJson.Should().Contain("mmproj-F16.gguf");
+        installation.ModelArtifactsJson.Should().Contain("Qwen3.6-35B-A3B-Q6_K_XL.gguf");
+    }
+
+    [TestMethod]
     public async Task OperationService_ApiRestart_ResumesFromCatalogFinalization()
     {
         await using var db = CreateDbContext();
@@ -288,7 +425,7 @@ public sealed class CuratedInstallTests
     }
 
     [TestMethod]
-    public async Task OperationService_StaleDownloading_RestartsLlamaAdminWorker()
+    public async Task OperationService_Downloading_DoesNotRestartLlamaAdminWorker()
     {
         await using var db = CreateDbContext();
         SeedRuntimeProfile(db);
@@ -310,16 +447,6 @@ public sealed class CuratedInstallTests
 
         var adminClient = new Mock<ILlamaRuntimeAdminClient>(MockBehavior.Strict);
         adminClient
-            .Setup(x => x.StartExactDownloadAsync(It.IsAny<ExactStartModelDownloadRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ModelDownloadOperationDto(
-                OperationId: operationId.ToString("D"),
-                Status: "downloading",
-                RouterModelId: input.RouterModelId,
-                Progress: 0.34,
-                ErrorMessage: null,
-                LogLine: "Resuming gemma-4-E4B-it-UD-Q8_K_XL.gguf",
-                ImmutableInputHash: input.ComputeHash()));
-        adminClient
             .Setup(x => x.GetDownloadStatusAsync(operationId.ToString("D"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ModelDownloadOperationDto(
                 OperationId: operationId.ToString("D"),
@@ -337,10 +464,16 @@ public sealed class CuratedInstallTests
         status.Progress.Should().Be(0.42);
         adminClient.Verify(
             x => x.StartExactDownloadAsync(It.IsAny<ExactStartModelDownloadRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        adminClient.Verify(
+            x => x.GetDownloadStatusAsync(operationId.ToString("D"), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
-    private static LocalModelOnboardingValidator CreateValidator(ICuratedInstallResolver? resolver = null)
+    private static LocalModelOnboardingValidator CreateValidator(
+        ICuratedInstallResolver? resolver = null,
+        IReadOnlyList<SettingsModelDto>? models = null,
+        IReadOnlyList<LlamaRuntimeInventoryItemDto>? inventory = null)
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -350,13 +483,15 @@ public sealed class CuratedInstallTests
             .Build();
 
         var settingsService = new Mock<IApplicationSettingsService>();
-        settingsService.Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<SettingsModelDto>());
+        settingsService.Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(models ?? Array.Empty<SettingsModelDto>());
 
         var chatTargetValidator = new Mock<IChatTargetValidator>();
         chatTargetValidator.Setup(x => x.Validate(It.IsAny<ChatTarget>()));
 
         var inventoryService = new Mock<ILlamaRuntimeInventoryService>();
-        inventoryService.Setup(x => x.GetInventoryAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<LlamaRuntimeInventoryItemDto>());
+        inventoryService.Setup(x => x.GetInventoryAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(inventory ?? Array.Empty<LlamaRuntimeInventoryItemDto>());
 
         var tokenResolver = new Mock<IHuggingFaceTokenResolver>();
         tokenResolver.Setup(x => x.Resolve()).Returns("hf_token");
@@ -451,7 +586,7 @@ public sealed class CuratedInstallTests
                     Display: new LlamaCatalogDisplayDto(
                         Name: "Qwen 3.6 35B A3B MTP",
                         Description: "Curated",
-                        Labels: ["Text"],
+                        Labels: ["Text", "Vision", "MTP"],
                         License: "Apache-2.0",
                         DocumentationUrl: "https://example.com"),
                     Source: new LlamaCatalogSourceDto("unsloth/Qwen3.6-35B-A3B-MTP-GGUF", "main"),
@@ -460,10 +595,11 @@ public sealed class CuratedInstallTests
                         RouterModelId: "Qwen3.6-35B-A3B-MTP-GGUF",
                         RuntimeProfileId: "qwen3_6",
                         TargetDirectory: "Qwen3.6-35B-A3B-MTP-GGUF",
-                        Mmproj: null,
+                        Mmproj: new LlamaCatalogMmprojDto("mmproj-F16.gguf"),
                         RouterPreset: new Dictionary<string, string>
                         {
                             ["ctx-size"] = "131072",
+                            ["image-min-tokens"] = "1024",
                             ["spec-type"] = "draft-mtp",
                             ["spec-draft-n-max"] = "2",
                         }),
@@ -504,7 +640,7 @@ public sealed class CuratedInstallTests
             RequestedRevision: "main",
             ResolvedRevision: revision,
             Quants: quants,
-            Projector: null);
+            Projector: new LlamaProjectorArtifactDto("mmproj-F16.gguf", 900_000_000));
     }
 
     private static CuratedImmutableOperationInput CreateImmutableInput(bool singleGguf) =>
@@ -528,13 +664,14 @@ public sealed class CuratedInstallTests
                     "Qwen3.6-35B-A3B-Q6_K_XL-00001-of-00002.gguf",
                     "Qwen3.6-35B-A3B-Q6_K_XL-00002-of-00002.gguf",
                 ],
-            MmprojFiles: [],
+            MmprojFiles: ["mmproj-F16.gguf"],
             RouterModelId: "Qwen3.6-35B-A3B-MTP-GGUF",
             RuntimeProfileId: "qwen3_6",
             TargetDirectory: "Qwen3.6-35B-A3B-MTP-GGUF",
             RouterPreset: new Dictionary<string, string>
             {
                 ["ctx-size"] = "131072",
+                ["image-min-tokens"] = "1024",
                 ["spec-type"] = "draft-mtp",
                 ["spec-draft-n-max"] = "2",
             });

--- a/src/server/GuideAntsApi.Tests/Services/Providers/ToolOutputTruncatorTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Providers/ToolOutputTruncatorTests.cs
@@ -43,6 +43,61 @@ public sealed class ToolOutputTruncatorTests
     }
 
     [TestMethod]
+    public void Truncate_SuccessfulScriptExecutionResult_OmitsStderr()
+    {
+        var original = new ScriptExecutionResult
+        {
+            StandardOutput = "SUCCESS! Video created: out.mp4",
+            StandardError = CreateOversizedOutput('e'),
+            ExitCode = 0,
+            NewFiles = new List<string> { "out.mp4" }
+        };
+        var serialized = JsonSerializer.Serialize(original, JsonOptions);
+
+        var result = ToolOutputTruncator.Truncate(serialized);
+
+        result.WasTruncated.Should().BeFalse();
+        using var doc = JsonDocument.Parse(result.Output!);
+        doc.RootElement.GetProperty("standardError").GetString().Should().BeEmpty();
+        doc.RootElement.GetProperty("standardOutput").GetString().Should().Contain("SUCCESS");
+        doc.RootElement.GetProperty("newFiles").EnumerateArray().Should().ContainSingle()
+            .Which.GetString().Should().Be("out.mp4");
+    }
+
+    [TestMethod]
+    public void ForToolCall_NonZeroExitCode_PreservesStderr()
+    {
+        var original = new ScriptExecutionResult
+        {
+            StandardOutput = string.Empty,
+            StandardError = "actual failure",
+            ExitCode = 1
+        };
+
+        var toolCall = original.ForToolCall();
+
+        toolCall.Should().BeSameAs(original);
+        toolCall.StandardError.Should().Be("actual failure");
+    }
+
+    [TestMethod]
+    public void ForToolCall_ZeroExitCode_ClearsStderr()
+    {
+        var original = new ScriptExecutionResult
+        {
+            StandardOutput = "done",
+            StandardError = "progress spam",
+            ExitCode = 0
+        };
+
+        var toolCall = original.ForToolCall();
+
+        toolCall.Should().NotBeSameAs(original);
+        toolCall.StandardError.Should().BeEmpty();
+        toolCall.StandardOutput.Should().Be("done");
+    }
+
+    [TestMethod]
     public void Truncate_LargeScriptExecutionResult_TruncatesStdoutAndAddsStderrNotice()
     {
         var largeStdout = CreateOversizedOutput('x');

--- a/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelLifecycleOperationService.cs
+++ b/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelLifecycleOperationService.cs
@@ -60,14 +60,6 @@ public sealed class LocalModelLifecycleOperationService : ILocalModelLifecycleOp
         "registeringAlias",
     };
 
-    private static readonly HashSet<string> StaleDownloadRestartStatuses = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "queued",
-        "resolvingFiles",
-        "downloading",
-        "validating",
-    };
-
     private readonly ApplicationDbContext _db;
     private readonly ILlamaRuntimeAdminClient _adminClient;
     private readonly IHuggingFaceTokenResolver _tokenResolver;
@@ -231,11 +223,6 @@ public sealed class LocalModelLifecycleOperationService : ILocalModelLifecycleOp
         {
             await BeginQueuedOperationAsync(operation, sideEffects, cancellationToken).ConfigureAwait(false);
             return null;
-        }
-
-        if (sideEffects.DownloadStarted && StaleDownloadRestartStatuses.Contains(operation.Status))
-        {
-            await BeginQueuedOperationAsync(operation, sideEffects, cancellationToken).ConfigureAwait(false);
         }
 
         var journal = await _adminClient

--- a/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelOnboardingValidator.cs
+++ b/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelOnboardingValidator.cs
@@ -178,13 +178,21 @@ public sealed class LocalModelOnboardingValidator : ILocalModelOnboardingValidat
             .ResolveAsync(request, command, cancellationToken)
             .ConfigureAwait(false);
 
+        // Re-installing the same curated definition is a reconcile, not a conflict. When a model row
+        // with this catalogModelId already exists AND it targets the same router alias + runtime
+        // profile, allow the install to proceed: the operation is idempotent (already-downloaded
+        // artifacts are skipped) and will fetch any artifacts the current definition now requires
+        // (e.g. a projector added to the catalog after the original text-only install).
         var existingModels = await _settingsService.GetModelsAsync(cancellationToken).ConfigureAwait(false);
-        if (existingModels.Any(model => string.Equals(model.ModelId, immutableInput.CatalogModelId, StringComparison.Ordinal)))
+        var existingModel = existingModels.FirstOrDefault(model =>
+            string.Equals(model.ModelId, immutableInput.CatalogModelId, StringComparison.Ordinal));
+        var isReconcile = existingModel is not null && IsSameCuratedTarget(existingModel, immutableInput);
+        if (existingModel is not null && !isReconcile)
         {
             throw new AddModelException(
                 code: "MODEL_ID_TAKEN",
                 step: "validation",
-                message: $"Model '{immutableInput.CatalogModelId}' already exists.",
+                message: $"Model '{immutableInput.CatalogModelId}' already exists and targets a different runtime configuration.",
                 remediation: "Choose a different catalog definition or remove the existing model.");
         }
 
@@ -206,13 +214,36 @@ public sealed class LocalModelOnboardingValidator : ILocalModelOnboardingValidat
         var inventory = await _inventoryService.GetInventoryAsync(cancellationToken).ConfigureAwait(false);
         var existingAlias = inventory.FirstOrDefault(item =>
             string.Equals(item.RouterModelId, immutableInput.RouterModelId, StringComparison.Ordinal));
-        if (existingAlias is not null && existingAlias.CatalogModelIds.Count > 0)
+        var conflictingCatalogRows = existingAlias?.CatalogModelIds
+            .Where(id => !string.Equals(id, immutableInput.CatalogModelId, StringComparison.Ordinal))
+            .ToList() ?? [];
+        if (conflictingCatalogRows.Count > 0)
         {
             throw new AddModelException(
                 code: "ROUTER_ALIAS_TAKEN",
                 step: "validation",
-                message: $"Router alias '{existingAlias.RouterModelId}' is already referenced by catalog rows: {string.Join(", ", existingAlias.CatalogModelIds)}.",
+                message: $"Router alias '{existingAlias!.RouterModelId}' is already referenced by catalog rows: {string.Join(", ", conflictingCatalogRows)}.",
                 remediation: "Remove the existing catalog row or choose another curated definition.");
+        }
+    }
+
+    private static bool IsSameCuratedTarget(SettingsModelDto existing, CuratedImmutableOperationInput immutableInput)
+    {
+        if (!string.Equals(existing.Provider, "llama-cpp", StringComparison.OrdinalIgnoreCase)
+            || string.IsNullOrWhiteSpace(existing.RuntimeConfigJson))
+        {
+            return false;
+        }
+
+        try
+        {
+            var parsed = LocalRuntimeConfigurationParser.Parse(existing.ModelId, existing.RuntimeConfigJson);
+            return string.Equals(parsed.RouterModelId, immutableInput.RouterModelId, StringComparison.Ordinal)
+                && string.Equals(parsed.RuntimeProfileId, immutableInput.RuntimeProfileId, StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelOperationService.cs
+++ b/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelOperationService.cs
@@ -47,14 +47,6 @@ public sealed class LocalModelOperationService : ILocalModelOperationService
         "catalogFinalization",
     };
 
-    private static readonly HashSet<string> StaleDownloadRestartStatuses = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "queued",
-        "resolvingFiles",
-        "downloading",
-        "validating",
-    };
-
     private readonly ApplicationDbContext _db;
     private readonly ILlamaRuntimeAdminClient _adminClient;
     private readonly IHuggingFaceTokenResolver _tokenResolver;
@@ -210,11 +202,6 @@ public sealed class LocalModelOperationService : ILocalModelOperationService
             return null;
         }
 
-        if (sideEffects.DownloadStarted && StaleDownloadRestartStatuses.Contains(operation.Status))
-        {
-            await StartDownloadAsync(operation, immutableInput, sideEffects, cancellationToken).ConfigureAwait(false);
-        }
-
         var journal = await _adminClient
             .GetDownloadStatusAsync(operation.OperationId.ToString("D"), cancellationToken)
             .ConfigureAwait(false);
@@ -340,11 +327,11 @@ public sealed class LocalModelOperationService : ILocalModelOperationService
             .ConfigureAwait(false);
         if (existingModel)
         {
-            operation.Status = "completed";
-            operation.CurrentStep = "completed";
-            operation.CompletedUtc = DateTime.UtcNow;
-            operation.UpdatedUtc = DateTime.UtcNow;
-            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            // Reconcile: the catalog row already exists (e.g. a prior text-only install). The download
+            // step above fetched any newly-required artifacts (projector) and re-registered the alias.
+            // Refresh the installation provenance so it reflects what is actually on disk now.
+            await ReconcileExistingInstallationAsync(operation, immutableInput, sideEffects, cancellationToken)
+                .ConfigureAwait(false);
             return;
         }
 
@@ -380,6 +367,48 @@ public sealed class LocalModelOperationService : ILocalModelOperationService
         {
             await MarkFinalizationFailureAsync(operation, ex, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private async Task ReconcileExistingInstallationAsync(
+        LocalModelOperation operation,
+        CuratedImmutableOperationInput immutableInput,
+        CompletedSideEffects sideEffects,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+
+        var installation = await _db.LocalModelInstallations
+            .SingleOrDefaultAsync(i => i.ModelId == immutableInput.CatalogModelId, cancellationToken)
+            .ConfigureAwait(false);
+        if (installation is not null)
+        {
+            installation.ManagementMode = "curated";
+            installation.CatalogId = immutableInput.DefinitionId;
+            installation.CatalogVersion = immutableInput.DefinitionVersion;
+            installation.Repository = immutableInput.Repository;
+            installation.RequestedRevision = immutableInput.RequestedRevision;
+            installation.ResolvedRevision = immutableInput.ResolvedRevision;
+            installation.QuantId = immutableInput.QuantId;
+            installation.QuantLabel = immutableInput.QuantLabel;
+            installation.RouterModelId = immutableInput.RouterModelId;
+            installation.RuntimeProfileId = immutableInput.RuntimeProfileId;
+            installation.TargetDirectory = immutableInput.TargetDirectory;
+            installation.ModelArtifactsJson = BuildModelArtifactsJson(immutableInput);
+            installation.ProjectorArtifactsJson = BuildProjectorArtifactsJson(immutableInput);
+            installation.RouterPresetSnapshotJson = JsonSerializer.Serialize(immutableInput.RouterPreset);
+            installation.UpdatedUtc = now;
+        }
+
+        operation.Status = "completed";
+        operation.CurrentStep = "completed";
+        operation.ErrorCode = null;
+        operation.ErrorMessage = null;
+        operation.Remediation = null;
+        operation.CompletedUtc = now;
+        operation.UpdatedUtc = now;
+        sideEffects.CatalogFinalized = true;
+        operation.CompletedSideEffectsJson = SerializeSideEffects(sideEffects);
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task CommitFinalizationAsync(


### PR DESCRIPTION
## Summary

Follow-up hardening for curated local llama.cpp onboarding after #67. Makes reinstall/repair idempotent, resumes interrupted downloads reliably, fixes onboarding polling/completion UX, and stops sandbox stderr from bloating tool context.

- **Curated install resilience:** Allow idempotent reconciles when the same catalog model, router alias, and runtime profile are reinstalled (e.g. adding `mmproj` to an existing text-only Qwen MTP row). Skip already-valid artifacts during exact download, resume interrupted operations from the llama-admin journal, and remove the API-side stale-download restart path.
- **Onboarding UX:** Stop operation polling after a terminal status so completion handlers fire once; surface curated validation errors in the install UI. Update catalog manifest for MTP+vision rows.
- **Sandbox tool output:** Strip stderr from successful `ScriptExecutionResult` payloads before tool-output truncation so progress noise does not inflate chat context.

## What changed (operator-visible)

| Before | After |
|--------|-------|
| Reinstalling to add vision/mmproj could fail or duplicate work | Same identity can reconcile in place; valid artifacts are skipped |
| Interrupted downloads relied on API restart heuristics | Operations resume from llama-admin journal state |
| Onboarding progress could poll past completion | Polling stops at terminal status; errors show in the install UI |
| Successful sandbox scripts still sent stderr into the model | Stderr stripped from successful tool results before truncation |

