### PR TITLE
Bugs/warmup

### DIFF
--- a/docker/build/build_guideants_ai.ps1
+++ b/docker/build/build_guideants_ai.ps1
@@ -2,7 +2,9 @@ param(
     [switch]$RebuildBase,
     [switch]$All,
     [ValidateSet('cpu', 'cuda13', 'rocm', 'slim', 'vulkan')]
-    [string]$Backend
+    [string]$Backend,
+  # Git branch or tag cloned during the Docker audiocpp-*-builder stage (see Dockerfile.* AUDIOCPP_REF).
+    [string]$AudioCppRef = 'release-0.2'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -276,6 +278,7 @@ Write-Host "Image tag:     $imageTag"
 Write-Host "Latest alias:  $latestImageTag"
 Write-Host "Deps target:   $depsTarget"
 Write-Host "Rebuild base:  $RebuildBase"
+Write-Host "audio.cpp ref: $AudioCppRef"
 Write-Host ""
 
 if (-not (Test-Path $requirementsSrc)) {
@@ -354,12 +357,16 @@ Copy-Item -Path $requirementsSrc -Destination $reqDest -Force
 
 Write-Host "Build context staged." -ForegroundColor Green
 
+$audioCppRefFile = Join-Path $buildStateDir 'audio-cpp-ref.txt'
+Set-Content -Path $audioCppRefFile -Value $AudioCppRef -Encoding UTF8 -NoNewline
+
 $depsHashInputs = @(
     $dockerfilePath,
     (Join-Path $buildContext 'asr-requirements.txt'),
     (Join-Path $buildContext 'tts-requirements.txt'),
     (Join-Path $buildContext 'emb-requirements.txt'),
-    $reqDest
+    $reqDest,
+    $audioCppRefFile
 )
 $depsHash = (Get-CombinedHash -Paths $depsHashInputs).Substring(0, 12)
 $depsTag = "guideants-ai-deps:${Backend}-${depsHash}"
@@ -392,6 +399,7 @@ try {
             }
         }
         $depsBuildArgs += @(
+            '--build-arg', "AUDIOCPP_REF=$AudioCppRef",
             '--target', $depsTarget,
             '-t', $depsTag,
             '-t', $depsCacheTag,
@@ -426,6 +434,7 @@ try {
     $dockerArgs += @(
         '--cache-from', "type=local,src=$depsCachePath",
         '--cache-from', "type=local,src=$finalCachePath",
+        '--build-arg', "AUDIOCPP_REF=$AudioCppRef",
         '--build-arg', "$depsImageArg=$depsTag",
         '--target', $fullTarget,
         '-t', $imageTag,

--- a/docker/build/build_guideants_ai.sh
+++ b/docker/build/build_guideants_ai.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REBUILD_BASE=false
 BUILD_ALL=false
 BACKEND=""
+AUDIOCPP_REF="release-0.2"
 
 usage() {
   cat <<'EOF'
@@ -13,6 +14,7 @@ Options:
   --rebuild-base         Rebuild dependency/base layers without cache
   --all                  Removed; use build_support_images.sh after backend builds
   --backend <value>      Backend: cpu | cuda13 | rocm | slim | vulkan
+  --audio-cpp-ref <ref>  audio.cpp git branch/tag for audiocpp_server build (default: release-0.2)
   -h, --help             Show help
 EOF
 }
@@ -29,6 +31,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --backend)
       BACKEND="${2:-}"
+      shift 2
+      ;;
+    --audio-cpp-ref)
+      AUDIOCPP_REF="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -209,6 +215,7 @@ echo "Image tag:     $IMAGE_TAG"
 echo "Latest alias:  $LATEST_IMAGE_TAG"
 echo "Deps target:   $DEPS_TARGET"
 echo "Rebuild base:  $REBUILD_BASE"
+echo "audio.cpp ref: $AUDIOCPP_REF"
 if [[ "$BUILD_ALL" == "true" ]]; then
   echo "All images:    Yes"
 fi
@@ -248,12 +255,18 @@ cp "$REQUIREMENTS_SRC" "$REQ_DEST"
 
 echo "Build context staged."
 
+BUILD_STATE_DIR="$DOCKER_ROOT/.build-state"
+mkdir -p "$BUILD_STATE_DIR"
+AUDIOCPP_REF_FILE="$BUILD_STATE_DIR/audio-cpp-ref.txt"
+printf '%s' "$AUDIOCPP_REF" > "$AUDIOCPP_REF_FILE"
+
 DEPS_HASH_INPUTS=(
   "$DOCKERFILE_PATH"
   "$BUILD_CONTEXT/asr-requirements.txt"
   "$BUILD_CONTEXT/tts-requirements.txt"
   "$BUILD_CONTEXT/emb-requirements.txt"
   "$REQ_DEST"
+  "$AUDIOCPP_REF_FILE"
 )
 DEPS_HASH="$(get_combined_hash "${DEPS_HASH_INPUTS[@]}")"
 DEPS_HASH="${DEPS_HASH:0:12}"
@@ -288,6 +301,7 @@ if [[ "$REBUILD_BASE" == "true" || "$DEPS_EXISTS" != "true" ]]; then
     fi
   fi
   DEPS_BUILD_ARGS+=(
+    --build-arg "AUDIOCPP_REF=$AUDIOCPP_REF"
     --target "$DEPS_TARGET"
     -t "$DEPS_TAG"
     -t "$DEPS_CACHE_TAG"
@@ -314,6 +328,7 @@ DOCKER_ARGS+=(
   --cache-from "type=local,src=$DEPS_CACHE_PATH"
   --cache-from "type=local,src=$FINAL_CACHE_PATH"
   --cache-from "$DEPS_CACHE_TAG"
+  --build-arg "AUDIOCPP_REF=$AUDIOCPP_REF"
   --build-arg "${DEPS_IMAGE_ARG}=$DEPS_TAG"
   --target "$FULL_TARGET"
   -t "$IMAGE_TAG"

--- a/docker/build/guideants-ai/Dockerfile.cpu
+++ b/docker/build/guideants-ai/Dockerfile.cpu
@@ -76,6 +76,7 @@ RUN git clone --recursive --depth 1 --shallow-submodules --branch ${AUDIOCPP_REF
     && mkdir -p /out \
     && if [ -f /src/audio.cpp/build/bin/audiocpp_server ]; then cp /src/audio.cpp/build/bin/audiocpp_server /out/audiocpp_server; \
        else echo "audiocpp_server binary was not produced by audio.cpp CPU build" && exit 1; fi \
+    && cp -r /src/audio.cpp/model_specs /out/model_specs \
     && (strip /out/audiocpp_server || true)
 
 
@@ -212,6 +213,7 @@ COPY --from=pydeps-cpu-builder /opt/venv /opt/venv
 COPY --from=sd-cli-cpu-builder /out/sd-cli /usr/local/bin/sd-cli
 COPY --from=sd-cli-cpu-builder /out/sd-server /usr/local/bin/sd-server
 COPY --from=audiocpp-cpu-builder /out/audiocpp_server /usr/local/bin/audiocpp_server
+COPY --from=audiocpp-cpu-builder /out/model_specs /app/model_specs
 RUN chmod +x /usr/local/bin/sd-cli /usr/local/bin/sd-server /usr/local/bin/audiocpp_server
 
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/docker/build/guideants-ai/Dockerfile.cuda
+++ b/docker/build/guideants-ai/Dockerfile.cuda
@@ -83,6 +83,7 @@ RUN git clone --recursive --depth 1 --shallow-submodules --branch ${AUDIOCPP_REF
     && mkdir -p /out \
     && if [ -f /src/audio.cpp/build/bin/audiocpp_server ]; then cp /src/audio.cpp/build/bin/audiocpp_server /out/audiocpp_server; \
        else echo "audiocpp_server binary was not produced by audio.cpp CUDA build" && exit 1; fi \
+    && cp -r /src/audio.cpp/model_specs /out/model_specs \
     && (strip /out/audiocpp_server || true)
 
 
@@ -219,6 +220,7 @@ COPY --from=pydeps-cuda13-builder /opt/venv /opt/venv
 COPY --from=sd-cli-cuda-builder /out/sd-cli /usr/local/bin/sd-cli
 COPY --from=sd-cli-cuda-builder /out/sd-server /usr/local/bin/sd-server
 COPY --from=audiocpp-cuda-builder /out/audiocpp_server /usr/local/bin/audiocpp_server
+COPY --from=audiocpp-cuda-builder /out/model_specs /app/model_specs
 RUN chmod +x /usr/local/bin/sd-cli /usr/local/bin/sd-server /usr/local/bin/audiocpp_server
 
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/docker/build/guideants-ai/Dockerfile.rocm
+++ b/docker/build/guideants-ai/Dockerfile.rocm
@@ -94,6 +94,7 @@ RUN git clone --recursive --depth 1 --shallow-submodules --branch ${AUDIOCPP_REF
     && mkdir -p /out \
     && if [ -f /src/audio.cpp/build/bin/audiocpp_server ]; then cp /src/audio.cpp/build/bin/audiocpp_server /out/audiocpp_server; \
        else echo "audiocpp_server binary was not produced by audio.cpp HIP build" && exit 1; fi \
+    && cp -r /src/audio.cpp/model_specs /out/model_specs \
     && (strip /out/audiocpp_server || true)
 
 FROM python:${PYTHON311_VERSION}-slim-bookworm AS python311-runtime
@@ -268,6 +269,7 @@ COPY --from=pydeps-rocm-builder /opt/venv /opt/venv
 COPY --from=sd-cli-rocm-builder /out/sd-cli /usr/local/bin/sd-cli
 COPY --from=sd-cli-rocm-builder /out/sd-server /usr/local/bin/sd-server
 COPY --from=audiocpp-rocm-builder /out/audiocpp_server /usr/local/bin/audiocpp_server
+COPY --from=audiocpp-rocm-builder /out/model_specs /app/model_specs
 RUN chmod +x /usr/local/bin/sd-cli /usr/local/bin/sd-server /usr/local/bin/audiocpp_server \
     && ldd /usr/local/bin/audiocpp_server | grep -q 'libomp.so =>' \
     && ldd /usr/local/bin/audiocpp_server | grep -vq 'not found'

--- a/docker/build/guideants-ai/Dockerfile.vulkan
+++ b/docker/build/guideants-ai/Dockerfile.vulkan
@@ -91,6 +91,7 @@ RUN git clone --recursive --depth 1 --shallow-submodules --branch ${AUDIOCPP_REF
     && mkdir -p /out \
     && if [ -f /src/audio.cpp/build/bin/audiocpp_server ]; then cp /src/audio.cpp/build/bin/audiocpp_server /out/audiocpp_server; \
        else echo "audiocpp_server binary was not produced by audio.cpp Vulkan build" && exit 1; fi \
+    && cp -r /src/audio.cpp/model_specs /out/model_specs \
     && (strip /out/audiocpp_server || true)
 
 # =============================================================================
@@ -287,6 +288,7 @@ COPY --from=pydeps-vulkan-builder /opt/venv /opt/venv
 COPY --from=sd-cli-vulkan-builder /out/sd-cli /usr/local/bin/sd-cli
 COPY --from=sd-cli-vulkan-builder /out/sd-server /usr/local/bin/sd-server
 COPY --from=audiocpp-vulkan-builder /out/audiocpp_server /usr/local/bin/audiocpp_server
+COPY --from=audiocpp-vulkan-builder /out/model_specs /app/model_specs
 RUN chmod +x /usr/local/bin/sd-cli /usr/local/bin/sd-server /usr/local/bin/audiocpp_server
 
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/docker/build/guideants-ai/admin-service/tests/test_catalog_completeness.py
+++ b/docker/build/guideants-ai/admin-service/tests/test_catalog_completeness.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_LIB_ROOT = Path(__file__).resolve().parents[2] / "lib"
+if str(_LIB_ROOT) not in sys.path:
+    sys.path.insert(0, str(_LIB_ROOT))
+
+from guideants_hf.catalog_completeness import (
+    catalog_entry_for_directory_name,
+    directory_model_entry_is_complete,
+    gguf_model_entry_is_complete,
+    has_partial_download_artifacts,
+)
+
+
+class CatalogCompletenessTests(unittest.TestCase):
+    def test_has_partial_download_artifacts_detects_tmp_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            open(os.path.join(tmp, "model.safetensors.tmp"), "w", encoding="utf-8").close()
+            self.assertTrue(has_partial_download_artifacts(tmp))
+
+    def test_directory_model_entry_is_complete_requires_catalog_files(self) -> None:
+        entry = {
+            "id": "demo",
+            "targetDirectory": "demo",
+            "requiredFiles": ["config.json", "weights.bin"],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "demo"), exist_ok=True)
+            model_path = os.path.join(tmp, "demo")
+            self.assertFalse(directory_model_entry_is_complete(model_path, entry))
+
+            open(os.path.join(model_path, "config.json"), "w", encoding="utf-8").close()
+            self.assertFalse(directory_model_entry_is_complete(model_path, entry))
+
+            open(os.path.join(model_path, "weights.bin"), "w", encoding="utf-8").close()
+            self.assertTrue(directory_model_entry_is_complete(model_path, entry))
+
+    def test_catalog_entry_for_directory_name_matches_target_directory(self) -> None:
+        entries = {
+            "omnivoice": {
+                "id": "omnivoice",
+                "targetDirectory": "OmniVoice",
+                "requiredFiles": ["config.json"],
+            }
+        }
+        matched = catalog_entry_for_directory_name("OmniVoice", entries)
+        self.assertIsNotNone(matched)
+        assert matched is not None
+        self.assertEqual("omnivoice", matched["id"])
+
+    def test_gguf_model_entry_is_complete_rejects_empty_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "model.gguf")
+            open(path, "w", encoding="utf-8").close()
+            self.assertFalse(gguf_model_entry_is_complete(path))
+
+            with open(path, "wb") as handle:
+                handle.write(b"gguf")
+            self.assertTrue(gguf_model_entry_is_complete(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/build/guideants-ai/admin-service/tests/test_warmup_desired_ini.py
+++ b/docker/build/guideants-ai/admin-service/tests/test_warmup_desired_ini.py
@@ -12,12 +12,15 @@ from warmup_desired_ini import (
     WarmupDesiredDocument,
     WarmupDesiredValidationError,
     WarmupServiceSection,
+    aux_section_load_request,
     parse_warmup_desired_ini,
     put_warmup_desired_text,
     read_warmup_desired,
+    section_execution_ref,
     serialize_warmup_desired_ini,
     write_warmup_desired,
 )
+from warmup_orchestrator import compute_transitions
 from warmup_state import (
     atomic_write_warmup_state,
     build_initial_state_from_desired,
@@ -32,29 +35,31 @@ def _sample_document(revision: int = 1) -> WarmupDesiredDocument:
         revision=revision,
         updated_at_utc="2026-07-12T19:00:00Z",
         sections={
-            "llama": WarmupServiceSection(
-                desired="warm",
-                router_alias="Qwen3.6-35B-A3B-MTP-GGUF",
-            ),
-            "SpeechTranscription": WarmupServiceSection(
-                desired="warm",
-                model_id="qwen3_asr_0_6b",
-            ),
-            "Embeddings": WarmupServiceSection(
-                desired="idle",
-            ),
-            "SpeechSynthesis": WarmupServiceSection(
-                desired="warm",
-                model_id="chatterbox",
-            ),
-            "ImageGeneration": WarmupServiceSection(
-                desired="idle",
-            ),
+            "llama": WarmupServiceSection(router_alias="Qwen3.6-35B-A3B-MTP-GGUF"),
+            "SpeechTranscription": WarmupServiceSection(model_id="qwen3_asr_0_6b"),
+            "Embeddings": WarmupServiceSection(enabled=False),
+            "SpeechSynthesis": WarmupServiceSection(model_path="OmniVoice"),
+            "ImageGeneration": WarmupServiceSection(enabled=False),
         },
     )
 
 
 SAMPLE_INI = """\
+version = 1
+revision = 1
+updated_at_utc = 2026-07-12T19:00:00Z
+
+[llama]
+router_alias = Qwen3.6-35B-A3B-MTP-GGUF
+
+[SpeechTranscription]
+model_id = qwen3_asr_0_6b
+
+[SpeechSynthesis]
+model_path = chatterbox
+"""
+
+LEGACY_INI = """\
 version = 1
 revision = 1
 updated_at_utc = 2026-07-12T19:00:00Z
@@ -69,7 +74,7 @@ model_id = qwen3_asr_0_6b
 
 [SpeechSynthesis]
 desired = warm
-model_id = chatterbox
+model_path = chatterbox
 """
 
 
@@ -77,15 +82,63 @@ class WarmupDesiredIniTests(unittest.TestCase):
     def test_round_trip_parses_plan_fixture(self) -> None:
         document = parse_warmup_desired_ini(SAMPLE_INI)
         self.assertEqual(document.version, 1)
-        self.assertEqual(document.revision, 1)
         self.assertEqual(document.sections["llama"].router_alias, "Qwen3.6-35B-A3B-MTP-GGUF")
-        self.assertEqual(document.sections["SpeechTranscription"].model_id, "qwen3_asr_0_6b")
         reserialized = serialize_warmup_desired_ini(document)
+        self.assertNotIn("desired = warm", reserialized)
+        self.assertIn("model_path = chatterbox", reserialized)
         reparsed = parse_warmup_desired_ini(reserialized)
-        self.assertEqual(reparsed.sections["llama"].desired, "warm")
-        self.assertEqual(reparsed.sections["SpeechTranscription"].model_id, "qwen3_asr_0_6b")
+        self.assertEqual(
+            section_execution_ref("SpeechSynthesis", reparsed.sections["SpeechSynthesis"]),
+            "chatterbox",
+        )
 
-    def test_warm_section_requires_model_ref(self) -> None:
+    def test_legacy_desired_warm_still_parses_on_read(self) -> None:
+        document = parse_warmup_desired_ini(LEGACY_INI)
+        self.assertEqual(
+            section_execution_ref("SpeechSynthesis", document.sections["SpeechSynthesis"]),
+            "chatterbox",
+        )
+
+    def test_model_path_section_round_trip(self) -> None:
+        ini = """\
+version = 1
+revision = 1
+updated_at_utc = 2026-07-12T19:00:00Z
+
+[SpeechSynthesis]
+model_path = OmniVoice
+"""
+        document = parse_warmup_desired_ini(ini)
+        self.assertEqual(document.sections["SpeechSynthesis"].model_path, "OmniVoice")
+        ref, field = aux_section_load_request(document.sections["SpeechSynthesis"])
+        self.assertEqual(ref, "OmniVoice")
+        self.assertEqual(field, "model_path")
+        self.assertNotIn("desired =", serialize_warmup_desired_ini(document))
+
+    def test_enabled_off_preserves_bundle_id_on_serialize(self) -> None:
+        document = parse_warmup_desired_ini(
+            """\
+version = 1
+revision = 1
+updated_at_utc = 2026-07-12T19:00:00Z
+
+[ImageGeneration]
+enabled = off
+bundle_id = flux2-klein-4b-q4ks
+"""
+        )
+        reserialized = serialize_warmup_desired_ini(document)
+        self.assertIn("enabled = off", reserialized)
+        self.assertIn("bundle_id = flux2-klein-4b-q4ks", reserialized)
+        self.assertIsNone(section_execution_ref("ImageGeneration", document.sections["ImageGeneration"]))
+
+    def test_legacy_model_id_still_validates_and_loads_via_model_id(self) -> None:
+        section = WarmupServiceSection(model_id="omnivoice")
+        ref, field = aux_section_load_request(section)
+        self.assertEqual(ref, "omnivoice")
+        self.assertEqual(field, "model_id")
+
+    def test_section_without_load_ref_is_invalid_on_write(self) -> None:
         bad = """\
 version = 1
 revision = 1
@@ -97,7 +150,7 @@ desired = warm
         with self.assertRaises(WarmupDesiredValidationError):
             parse_warmup_desired_ini(bad)
 
-    def test_image_generation_warm_without_bundle_id_is_valid(self) -> None:
+    def test_image_generation_without_bundle_id_is_invalid_on_write(self) -> None:
         ini = """\
 version = 1
 revision = 1
@@ -106,9 +159,27 @@ updated_at_utc = 2026-07-12T19:00:00Z
 [ImageGeneration]
 desired = warm
 """
-        document = parse_warmup_desired_ini(ini)
-        self.assertEqual(document.sections["ImageGeneration"].desired, "warm")
-        self.assertIsNone(document.sections["ImageGeneration"].bundle_id)
+        with self.assertRaises(WarmupDesiredValidationError):
+            parse_warmup_desired_ini(ini)
+
+    def test_read_warmup_desired_does_not_validate_legacy_disk_state(self) -> None:
+        ini = """\
+version = 1
+revision = 4
+updated_at_utc = 2026-07-12T19:00:00Z
+
+[ImageGeneration]
+desired = warm
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            ini_path = os.path.join(tmp, "warmup-desired.ini")
+            os.environ["GA_WARMUP_DESIRED_PATH"] = ini_path
+            with open(ini_path, "w", encoding="utf-8") as handle:
+                handle.write(ini)
+
+            loaded = read_warmup_desired()
+            assert loaded is not None
+            self.assertIsNone(section_execution_ref("ImageGeneration", loaded.sections["ImageGeneration"]))
 
     def test_atomic_write_bumps_revision(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -116,20 +187,15 @@ desired = warm
             os.environ["GA_WARMUP_DESIRED_PATH"] = ini_path
             first = write_warmup_desired(_sample_document(revision=0))
             self.assertEqual(first.revision, 1)
-            self.assertTrue(first.changed)
 
             second_doc = _sample_document(revision=0)
-            second_doc.sections["SpeechTranscription"] = WarmupServiceSection(
-                desired="idle",
-            )
+            second_doc.sections["SpeechTranscription"] = WarmupServiceSection(enabled=False)
             second = write_warmup_desired(second_doc)
             self.assertEqual(second.revision, 2)
-            self.assertTrue(second.changed)
 
             loaded = read_warmup_desired()
             assert loaded is not None
-            self.assertEqual(loaded.revision, 2)
-            self.assertEqual(loaded.sections["SpeechTranscription"].desired, "idle")
+            self.assertTrue(loaded.sections["SpeechTranscription"].enabled is False)
 
     def test_identical_content_does_not_bump_revision(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -154,18 +220,16 @@ desired = warm
             os.environ["GA_WARMUP_DESIRED_PATH"] = ini_path
             written, result = put_warmup_desired_text(SAMPLE_INI)
             self.assertEqual(result.revision, 1)
-            self.assertEqual(written.sections["SpeechSynthesis"].model_id, "chatterbox")
+            self.assertEqual(written.sections["SpeechSynthesis"].model_path, "chatterbox")
 
 
 class WarmupStateTests(unittest.TestCase):
-    def test_build_initial_state_tracks_revision(self) -> None:
+    def test_build_initial_state_tracks_plan_ref(self) -> None:
         document = _sample_document(revision=3)
         state = build_initial_state_from_desired(document, desired_sha256="abc123")
         self.assertEqual(state["desiredRevision"], 3)
-        self.assertEqual(state["appliedRevision"], 0)
-        self.assertEqual(state["applyStatus"], "pending")
-        self.assertEqual(state["services"]["llama"]["desired"], "warm")
-        self.assertEqual(state["services"]["llama"]["applied"], "idle")
+        self.assertEqual(state["services"]["llama"]["planRef"], "Qwen3.6-35B-A3B-MTP-GGUF")
+        self.assertNotIn("applied", state["services"]["llama"])
 
     def test_atomic_write_and_read_round_trip(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -177,31 +241,61 @@ class WarmupStateTests(unittest.TestCase):
             loaded = read_warmup_state()
             assert loaded is not None
             self.assertEqual(loaded["desiredRevision"], 2)
-            self.assertIn("SpeechTranscription", loaded["services"])
 
-    def test_sync_state_preserves_applied_on_desired_change(self) -> None:
+    def test_sync_state_preserves_loaded_ref_when_plan_turns_off(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             state_path = os.path.join(tmp, ".warmup-state.json")
-            ini_path = os.path.join(tmp, "warmup-desired.ini")
             os.environ["GA_WARMUP_STATE_PATH"] = state_path
-            os.environ["GA_WARMUP_DESIRED_PATH"] = ini_path
 
             document = _sample_document(revision=1)
             initial = build_initial_state_from_desired(document, desired_sha256="sha1")
-            initial["services"]["SpeechTranscription"]["applied"] = "warm"
+            initial["services"]["SpeechTranscription"]["modelId"] = "qwen3_asr_0_6b"
+            initial["services"]["SpeechTranscription"]["phase"] = "ready"
             atomic_write_warmup_state(initial)
 
             updated = _sample_document(revision=2)
-            updated.sections["SpeechTranscription"] = WarmupServiceSection(desired="idle")
+            updated.sections["SpeechTranscription"] = WarmupServiceSection(enabled=False)
             synced = sync_state_after_desired_write(
                 updated,
                 desired_sha256="sha2",
                 changed=True,
             )
-            self.assertEqual(synced["desiredRevision"], 2)
-            self.assertEqual(synced["services"]["SpeechTranscription"]["desired"], "idle")
-            self.assertEqual(synced["services"]["SpeechTranscription"]["applied"], "warm")
-            self.assertEqual(synced["applyStatus"], "pending")
+            entry = synced["services"]["SpeechTranscription"]
+            self.assertEqual(entry["modelId"], "qwen3_asr_0_6b")
+            self.assertNotIn("planRef", entry)
+
+            transitions = compute_transitions(updated, synced)
+            by_service = {item.service: item.action for item in transitions}
+            self.assertEqual(by_service["SpeechTranscription"], "unload")
+
+    def test_sync_state_model_path_change_preserves_loaded_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = os.path.join(tmp, ".warmup-state.json")
+            os.environ["GA_WARMUP_STATE_PATH"] = state_path
+
+            document = _sample_document(revision=1)
+            initial = build_initial_state_from_desired(document, desired_sha256="sha1")
+            tts = dict(initial["services"]["SpeechSynthesis"])
+            tts["modelId"] = "chatterbox"
+            tts["phase"] = "ready"
+            initial["services"]["SpeechSynthesis"] = tts
+            atomic_write_warmup_state(initial)
+
+            updated = _sample_document(revision=2)
+            updated.sections["SpeechSynthesis"] = WarmupServiceSection(model_path="OmniVoice")
+            synced = sync_state_after_desired_write(
+                updated,
+                desired_sha256="sha2",
+                changed=True,
+            )
+            entry = synced["services"]["SpeechSynthesis"]
+            self.assertEqual(entry["modelId"], "chatterbox")
+            self.assertEqual(entry["planRef"], "OmniVoice")
+            self.assertEqual(entry["phase"], "idle")
+
+            transitions = compute_transitions(updated, synced)
+            by_service = {item.service: item.action for item in transitions}
+            self.assertEqual(by_service["SpeechSynthesis"], "load")
 
 
 if __name__ == "__main__":

--- a/docker/build/guideants-ai/admin-service/tests/test_warmup_engine_client.py
+++ b/docker/build/guideants-ai/admin-service/tests/test_warmup_engine_client.py
@@ -1,0 +1,35 @@
+import sys
+import unittest
+from pathlib import Path
+
+_SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+from warmup_engine_client import _aux_load_body, post_aux_load
+
+
+class WarmupEngineClientTests(unittest.TestCase):
+    def test_aux_load_body_uses_model_path_by_default(self) -> None:
+        self.assertEqual(_aux_load_body("OmniVoice"), {"model_path": "OmniVoice"})
+
+    def test_aux_load_body_legacy_model_id_field(self) -> None:
+        self.assertEqual(
+            _aux_load_body("omnivoice", load_field="model_id"),
+            {"model_id": "omnivoice"},
+        )
+
+    def test_gguf_always_uses_model_path(self) -> None:
+        self.assertEqual(_aux_load_body("weights.gguf"), {"model_path": "weights.gguf"})
+
+    def test_image_generation_without_bundle_ref_returns_false(self) -> None:
+        from unittest.mock import patch
+
+        with patch("warmup_engine_client._post_json") as post_json:
+            self.assertFalse(post_aux_load("ImageGeneration", None))
+            self.assertFalse(post_aux_load("ImageGeneration", "  "))
+            post_json.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/build/guideants-ai/admin-service/tests/test_warmup_orchestrator.py
+++ b/docker/build/guideants-ai/admin-service/tests/test_warmup_orchestrator.py
@@ -18,6 +18,7 @@ from warmup_desired_ini import (
 import warmup_orchestrator
 from warmup_orchestrator import (
     _aux_services_to_drain_before_llama,
+    _reconcile_aux,
     _run_reconcile_loop,
     _run_startup_apply,
     apply_warmup_on_startup,
@@ -37,11 +38,11 @@ from warmup_state import (
 
 def _sample_document(revision: int = 1, sections: dict | None = None) -> WarmupDesiredDocument:
     default_sections = {
-        SERVICE_LLAMA: WarmupServiceSection(desired="warm", router_alias="Qwen-Test"),
-        "SpeechTranscription": WarmupServiceSection(desired="idle"),
-        "Embeddings": WarmupServiceSection(desired="idle"),
-        "SpeechSynthesis": WarmupServiceSection(desired="idle"),
-        "ImageGeneration": WarmupServiceSection(desired="idle"),
+        SERVICE_LLAMA: WarmupServiceSection(router_alias="Qwen-Test"),
+        "SpeechTranscription": WarmupServiceSection(enabled=False),
+        "Embeddings": WarmupServiceSection(enabled=False),
+        "SpeechSynthesis": WarmupServiceSection(enabled=False),
+        "ImageGeneration": WarmupServiceSection(enabled=False),
     }
     if sections is not None:
         default_sections.update(sections)
@@ -57,14 +58,20 @@ def _sample_document_with_sections(**overrides):
     return _sample_document(revision=1, sections=dict(overrides))
 
 
+def _mark_loaded(state: dict, service: str, *, ref_key: str, ref_value: str) -> None:
+    entry = state["services"][service]
+    entry["phase"] = "ready"
+    entry[ref_key] = ref_value
+
+
 class WarmupOrchestratorTests(unittest.TestCase):
     def test_compute_transitions_only_asr_to_idle(self) -> None:
         document = _sample_document_with_sections(
-            SpeechTranscription=WarmupServiceSection(desired="idle", model_id="asr-model"),
+            SpeechTranscription=WarmupServiceSection(enabled=False, model_id="asr-model"),
         )
         state = build_initial_state_from_desired(document, desired_sha256=document.content_fingerprint())
-        state["services"]["SpeechTranscription"]["applied"] = "warm"
-        state["services"][SERVICE_LLAMA]["applied"] = "warm"
+        _mark_loaded(state, "SpeechTranscription", ref_key="modelId", ref_value="asr-model")
+        _mark_loaded(state, SERVICE_LLAMA, ref_key="routerAlias", ref_value="Qwen-Test")
         transitions = compute_transitions(document, state)
         by_service = {item.service: item.action for item in transitions}
         self.assertEqual(by_service["SpeechTranscription"], "unload")
@@ -73,10 +80,9 @@ class WarmupOrchestratorTests(unittest.TestCase):
 
     def test_compute_transitions_model_change_is_load(self) -> None:
         document = _sample_document_with_sections(
-            Embeddings=WarmupServiceSection(desired="warm", model_id="new-emb"),
+            Embeddings=WarmupServiceSection(model_id="new-emb"),
         )
         state = build_initial_state_from_desired(document, desired_sha256=document.content_fingerprint())
-        state["services"]["Embeddings"]["applied"] = "warm"
         state["services"]["Embeddings"]["modelId"] = "old-emb"
         transitions = compute_transitions(document, state)
         by_service = {item.service: item.action for item in transitions}
@@ -122,8 +128,6 @@ class WarmupOrchestratorTests(unittest.TestCase):
                     desired_sha256=document.content_fingerprint(),
                     services={
                         SERVICE_LLAMA: {
-                            "desired": "warm",
-                            "applied": "warm",
                             "phase": "ready",
                             "routerAlias": "Qwen-Test",
                         }
@@ -138,7 +142,7 @@ class WarmupOrchestratorTests(unittest.TestCase):
             assert state is not None
             self.assertEqual(state["appliedRevision"], 0)
             self.assertEqual(state["applyStatus"], APPLY_STATUS_PENDING)
-            self.assertEqual(state["services"][SERVICE_LLAMA]["applied"], "idle")
+            self.assertEqual(state["services"][SERVICE_LLAMA]["phase"], "idle")
             mock_start.assert_called_once()
 
     @mock.patch("warmup_orchestrator._start_apply_worker_if_needed", return_value=True)
@@ -160,15 +164,17 @@ class WarmupOrchestratorTests(unittest.TestCase):
 
     def test_compute_transitions_llama_change_drains_applied_warm_aux(self) -> None:
         document = _sample_document_with_sections(
-            Embeddings=WarmupServiceSection(desired="warm", model_id="qwen3_embedding_0_6b"),
+            Embeddings=WarmupServiceSection(model_id="qwen3_embedding_0_6b"),
         )
         state = build_initial_state_from_desired(document, desired_sha256=document.content_fingerprint())
-        state["services"][SERVICE_LLAMA]["applied"] = "warm"
-        state["services"]["Embeddings"]["applied"] = "warm"
-        document.sections[SERVICE_LLAMA] = WarmupServiceSection(
-            desired="warm",
-            router_alias="New-Alias",
+        _mark_loaded(state, SERVICE_LLAMA, ref_key="routerAlias", ref_value="Old-Alias")
+        _mark_loaded(
+            state,
+            "Embeddings",
+            ref_key="modelId",
+            ref_value="qwen3_embedding_0_6b",
         )
+        document.sections[SERVICE_LLAMA] = WarmupServiceSection(router_alias="New-Alias")
         state["services"][SERVICE_LLAMA]["routerAlias"] = "Old-Alias"
         transitions = compute_transitions(document, state)
         by_service = {item.service: item.action for item in transitions}
@@ -191,15 +197,15 @@ class FakeEngine:
             for alias in self._loaded_llama
         ]
 
-    def post_aux_load(self, service, model_ref=None):
-        self.calls.append(("aux-load", service))
+    def post_aux_load(self, service, model_ref=None, load_field="model_path"):
+        self.calls.append(("aux-load", service, model_ref, load_field))
         return True
 
     def post_aux_unload(self, service):
         self.calls.append(("aux-unload", service))
         return True
 
-    def wait_aux_ready(self, service, timeout_seconds=None):
+    def wait_aux_ready(self, service, timeout_seconds=None, expected_model_ref=None):
         return True
 
     def wait_aux_unloaded(self, service, timeout_seconds=None):
@@ -245,13 +251,19 @@ class WarmupReconcileExecutionTests(unittest.TestCase):
             patcher.start()
             self.addCleanup(patcher.stop)
 
-    def _all_warm_aux(self):
+    def _all_loaded_aux(self):
         return {
-            "SpeechTranscription": WarmupServiceSection(desired="warm", model_id="asr-model"),
-            "Embeddings": WarmupServiceSection(desired="warm", model_id="emb-model"),
-            "SpeechSynthesis": WarmupServiceSection(desired="warm", model_id="tts-model"),
-            "ImageGeneration": WarmupServiceSection(desired="warm", bundle_id="sd-bundle"),
+            "SpeechTranscription": WarmupServiceSection(model_id="asr-model"),
+            "Embeddings": WarmupServiceSection(model_id="emb-model"),
+            "SpeechSynthesis": WarmupServiceSection(model_id="tts-model"),
+            "ImageGeneration": WarmupServiceSection(bundle_id="sd-bundle"),
         }
+
+    def _mark_all_aux_loaded(self, state: dict) -> None:
+        _mark_loaded(state, "SpeechTranscription", ref_key="modelId", ref_value="asr-model")
+        _mark_loaded(state, "Embeddings", ref_key="modelId", ref_value="emb-model")
+        _mark_loaded(state, "SpeechSynthesis", ref_key="modelId", ref_value="tts-model")
+        _mark_loaded(state, "ImageGeneration", ref_key="bundleId", ref_value="sd-bundle")
 
     def test_llama_change_drains_all_warm_aux_then_restores_in_d11_order(self) -> None:
         engine = FakeEngine(loaded_llama_aliases=["Old-Alias"])
@@ -262,39 +274,36 @@ class WarmupReconcileExecutionTests(unittest.TestCase):
             os.environ["GA_WARMUP_STATE_PATH"] = os.path.join(tmp, ".warmup-state.json")
 
             # Desired: llama warm on a NEW alias, every aux warm.
-            document = _sample_document(revision=2, sections=self._all_warm_aux())
-            document.sections[SERVICE_LLAMA] = WarmupServiceSection(desired="warm", router_alias="New-Alias")
+            document = _sample_document(revision=2, sections=self._all_loaded_aux())
+            document.sections[SERVICE_LLAMA] = WarmupServiceSection(router_alias="New-Alias")
             write_warmup_desired(document)
 
-            # Applied state: llama warm on Old-Alias, every aux already warm, revision behind.
             state = build_initial_state_from_desired(document, desired_sha256=document.content_fingerprint())
             state["appliedRevision"] = 1
-            state["services"][SERVICE_LLAMA]["applied"] = "warm"
-            state["services"][SERVICE_LLAMA]["routerAlias"] = "Old-Alias"
-            for aux in ("SpeechTranscription", "Embeddings", "SpeechSynthesis", "ImageGeneration"):
-                state["services"][aux]["applied"] = "warm"
+            _mark_loaded(state, SERVICE_LLAMA, ref_key="routerAlias", ref_value="Old-Alias")
+            self._mark_all_aux_loaded(state)
             atomic_write_warmup_state(state)
 
             _run_reconcile_loop()
 
         # GPU drain unloads every warm aux in D11 unload order.
-        unloads = [svc for kind, svc in engine.calls if kind == "aux-unload"]
+        unloads = [call[1] for call in engine.calls if call[0] == "aux-unload"]
         self.assertEqual(
             unloads,
             ["ImageGeneration", "SpeechSynthesis", "Embeddings", "SpeechTranscription"],
         )
 
         # Aux restored in D11 load order after the llama reconcile.
-        loads = [svc for kind, svc in engine.calls if kind == "aux-load"]
+        loads = [call[1] for call in engine.calls if call[0] == "aux-load"]
         self.assertEqual(
             loads,
             ["SpeechTranscription", "Embeddings", "SpeechSynthesis", "ImageGeneration"],
         )
 
         # All aux drained before the llama load; all aux reloaded after it.
-        llama_load_index = next(i for i, (kind, _) in enumerate(engine.calls) if kind == "llama-load")
-        last_unload_index = max(i for i, (kind, _) in enumerate(engine.calls) if kind == "aux-unload")
-        first_reload_index = min(i for i, (kind, _) in enumerate(engine.calls) if kind == "aux-load")
+        llama_load_index = next(i for i, call in enumerate(engine.calls) if call[0] == "llama-load")
+        last_unload_index = max(i for i, call in enumerate(engine.calls) if call[0] == "aux-unload")
+        first_reload_index = min(i for i, call in enumerate(engine.calls) if call[0] == "aux-load")
         self.assertLess(last_unload_index, llama_load_index, "aux must drain before llama load")
         self.assertLess(llama_load_index, first_reload_index, "aux must reload after llama load")
 
@@ -311,27 +320,25 @@ class WarmupReconcileExecutionTests(unittest.TestCase):
             os.environ["GA_WARMUP_STATE_PATH"] = os.path.join(tmp, ".warmup-state.json")
 
             # Only SpeechTranscription flips to idle; llama + other aux unchanged.
-            sections = self._all_warm_aux()
-            sections["SpeechTranscription"] = WarmupServiceSection(desired="idle", model_id="asr-model")
+            sections = self._all_loaded_aux()
+            sections["SpeechTranscription"] = WarmupServiceSection(enabled=False, model_id="asr-model")
             document = _sample_document(revision=2, sections=sections)
-            document.sections[SERVICE_LLAMA] = WarmupServiceSection(desired="warm", router_alias="Primary")
+            document.sections[SERVICE_LLAMA] = WarmupServiceSection(router_alias="Primary")
             write_warmup_desired(document)
 
             state = build_initial_state_from_desired(document, desired_sha256=document.content_fingerprint())
             state["appliedRevision"] = 1
-            state["services"][SERVICE_LLAMA]["applied"] = "warm"
-            state["services"][SERVICE_LLAMA]["routerAlias"] = "Primary"
-            for aux in ("SpeechTranscription", "Embeddings", "SpeechSynthesis", "ImageGeneration"):
-                state["services"][aux]["applied"] = "warm"
+            _mark_loaded(state, SERVICE_LLAMA, ref_key="routerAlias", ref_value="Primary")
+            self._mark_all_aux_loaded(state)
             atomic_write_warmup_state(state)
 
             _run_reconcile_loop()
             final_state = read_warmup_state()
 
         # No GPU drain: llama is unchanged, so only the single aux is unloaded.
-        unloads = [svc for kind, svc in engine.calls if kind == "aux-unload"]
+        unloads = [call[1] for call in engine.calls if call[0] == "aux-unload"]
         self.assertEqual(unloads, ["SpeechTranscription"])
-        self.assertEqual([svc for kind, svc in engine.calls if kind == "aux-load"], [])
+        self.assertEqual([call[1] for call in engine.calls if call[0] == "aux-load"], [])
         self.assertEqual([c for c in engine.calls if c[0].startswith("llama")], [])
         self.assertEqual(final_state["applyStatus"], APPLY_STATUS_APPLIED)
         self.assertEqual(final_state["appliedRevision"], 2)
@@ -344,8 +351,8 @@ class WarmupReconcileExecutionTests(unittest.TestCase):
             os.environ["GA_WARMUP_DESIRED_PATH"] = os.path.join(tmp, "warmup-desired.ini")
             os.environ["GA_WARMUP_STATE_PATH"] = os.path.join(tmp, ".warmup-state.json")
 
-            document = _sample_document(revision=1, sections=self._all_warm_aux())
-            document.sections[SERVICE_LLAMA] = WarmupServiceSection(desired="warm", router_alias="Primary")
+            document = _sample_document(revision=1, sections=self._all_loaded_aux())
+            document.sections[SERVICE_LLAMA] = WarmupServiceSection(router_alias="Primary")
             write_warmup_desired(document)
             atomic_write_warmup_state(
                 build_initial_state_from_desired(document, desired_sha256=document.content_fingerprint())
@@ -356,11 +363,30 @@ class WarmupReconcileExecutionTests(unittest.TestCase):
 
         self.assertEqual([c for c in engine.calls if c[0] == "llama-load"], [("llama-load", "Primary")])
         self.assertEqual(
-            [svc for kind, svc in engine.calls if kind == "aux-load"],
+            [call[1] for call in engine.calls if call[0] == "aux-load"],
             ["SpeechTranscription", "Embeddings", "SpeechSynthesis", "ImageGeneration"],
         )
         self.assertEqual(final_state["applyStatus"], APPLY_STATUS_APPLIED)
         self.assertEqual(final_state["appliedRevision"], 1)
+
+    def test_image_generation_load_without_bundle_id_fails_without_engine_calls(self) -> None:
+        engine = FakeEngine()
+        self._patch_engine(engine)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["GA_WARMUP_STATE_PATH"] = os.path.join(tmp, ".warmup-state.json")
+            document = _sample_document(revision=1)
+            atomic_write_warmup_state(
+                build_initial_state_from_desired(document, desired_sha256=document.content_fingerprint())
+            )
+            ok = _reconcile_aux("ImageGeneration", WarmupServiceSection(enabled=False), "load")
+            final_state = read_warmup_state()
+
+        self.assertFalse(ok)
+        self.assertEqual(engine.calls, [])
+        assert final_state is not None
+        self.assertEqual(final_state["services"]["ImageGeneration"]["phase"], "failed")
+        self.assertIn("bundle_id", final_state["services"]["ImageGeneration"]["error"])
 
 
 if __name__ == "__main__":

--- a/docker/build/guideants-ai/admin-service/warmup_desired_ini.py
+++ b/docker/build/guideants-ai/admin-service/warmup_desired_ini.py
@@ -1,4 +1,4 @@
-"""Warmup desired-state INI parsing and atomic writes (no FastAPI dependency)."""
+"""Warmup runtime INI — execution plan on disk (load ref = on, enabled = off = off)."""
 
 from __future__ import annotations
 
@@ -22,18 +22,26 @@ AUX_SERVICES = (
 )
 WARMUP_SERVICE_SECTIONS = (SERVICE_LLAMA,) + AUX_SERVICES
 
-VALID_DESIRED = frozenset({"warm", "idle"})
 HEADER_VERSION_KEY = "version"
 HEADER_REVISION_KEY = "revision"
 HEADER_UPDATED_AT_KEY = "updated_at_utc"
+ENABLED_OFF = "off"
+
+# Legacy INI only — never written on serialize.
+LEGACY_DESIRED_WARM = "warm"
+LEGACY_DESIRED_IDLE = "idle"
 
 
 @dataclass
 class WarmupServiceSection:
-    desired: str
+    """One service entry in the runtime execution plan."""
+
+    enabled: bool | None = None
     router_alias: str | None = None
+    model_path: str | None = None
     model_id: str | None = None
     bundle_id: str | None = None
+    desired: str | None = None  # legacy read only
     extras: dict[str, str] = field(default_factory=dict)
 
 
@@ -69,15 +77,66 @@ class WarmupDesiredValidationError(ValueError):
     pass
 
 
+def aux_section_model_ref(section: WarmupServiceSection) -> str | None:
+    """Disk-shaped ref for aux services (model_path preferred, model_id legacy)."""
+    if (section.model_path or "").strip():
+        return section.model_path.strip()
+    if (section.model_id or "").strip():
+        return section.model_id.strip()
+    return None
+
+
+def aux_section_load_request(
+    section: WarmupServiceSection,
+    *,
+    service: str | None = None,
+) -> tuple[str | None, str]:
+    """Return (ref, load_json_field) for aux engine /admin/load."""
+    if (section.model_path or "").strip():
+        trimmed = section.model_path.strip()
+        if trimmed.lower().endswith(".gguf"):
+            return trimmed, "model_path"
+        if service == "Embeddings":
+            return trimmed, "model_id"
+        return trimmed, "model_path"
+    if (section.model_id or "").strip():
+        trimmed = section.model_id.strip()
+        if trimmed.lower().endswith(".gguf"):
+            return trimmed, "model_path"
+        return trimmed, "model_id"
+    return None, "model_path"
+
+
+def section_execution_ref(section_name: str, section: WarmupServiceSection) -> str | None:
+    """Load instruction from the plan, or None when the service should be off."""
+    if section_is_off(section):
+        return None
+    if section_name == SERVICE_LLAMA:
+        return (section.router_alias or "").strip() or None
+    if section_name == "ImageGeneration":
+        return (section.bundle_id or "").strip() or None
+    return aux_section_model_ref(section)
+
+
+def section_is_off(section: WarmupServiceSection) -> bool:
+    if section.enabled is False:
+        return True
+    enabled_raw = (section.extras.get("enabled") or "").strip().lower()
+    if enabled_raw == ENABLED_OFF:
+        return True
+    if section.desired and section.desired.strip().lower() == LEGACY_DESIRED_IDLE:
+        return True
+    return False
+
+
+def section_should_load(section_name: str, section: WarmupServiceSection | None) -> bool:
+    if section is None:
+        return False
+    return section_execution_ref(section_name, section) is not None
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def _normalize_desired(value: str) -> str:
-    normalized = value.strip().lower()
-    if normalized not in VALID_DESIRED:
-        raise WarmupDesiredValidationError(f"desired must be one of {sorted(VALID_DESIRED)}; got '{value}'.")
-    return normalized
 
 
 def _validate_section_name(name: str) -> None:
@@ -89,6 +148,7 @@ def _validate_section_name(name: str) -> None:
 
 
 def validate_warmup_desired(document: WarmupDesiredDocument) -> None:
+    """Validate documents submitted for write (API PUT). Disk reads do not validate."""
     if document.version != 1:
         raise WarmupDesiredValidationError(f"version must be 1; got {document.version}.")
     if document.revision < 0:
@@ -96,25 +156,34 @@ def validate_warmup_desired(document: WarmupDesiredDocument) -> None:
 
     for section_name, section in document.sections.items():
         _validate_section_name(section_name)
-        desired = _normalize_desired(section.desired)
-        if desired == "warm":
-            if section_name == SERVICE_LLAMA:
-                if not (section.router_alias or "").strip():
-                    raise WarmupDesiredValidationError(
-                        f"[{section_name}] desired=warm requires router_alias."
-                    )
-            elif section_name == "ImageGeneration":
-                # bundle_id is optional: when omitted the orchestrator loads the
-                # active bundle already marked on disk (legacy local-SD behavior).
-                pass
-            else:
-                if not (section.model_id or "").strip():
-                    raise WarmupDesiredValidationError(
-                        f"[{section_name}] desired=warm requires model_id."
-                    )
+        if section_is_off(section):
+            continue
+        ref = section_execution_ref(section_name, section)
+        if not ref:
+            raise WarmupDesiredValidationError(
+                f"[{section_name}] must set enabled = off or include a load ref "
+                f"(router_alias, model_path, or bundle_id)."
+            )
+        legacy_desired = (section.desired or "").strip().lower()
+        if legacy_desired == LEGACY_DESIRED_WARM and not ref:
+            raise WarmupDesiredValidationError(
+                f"[{section_name}] legacy desired=warm without a load ref is invalid."
+            )
 
 
-def parse_warmup_desired_ini(text: str) -> WarmupDesiredDocument:
+def _coerce_enabled_field(fields: dict[str, str]) -> bool | None:
+    enabled_raw = fields.get("enabled")
+    if enabled_raw is None:
+        return None
+    normalized = enabled_raw.strip().lower()
+    if normalized == ENABLED_OFF:
+        return False
+    if normalized in {"on", "true", "1"}:
+        return True
+    return None
+
+
+def _parse_warmup_desired_ini_raw(text: str) -> WarmupDesiredDocument:
     version = 1
     revision = 0
     updated_at_utc = ""
@@ -126,16 +195,27 @@ def parse_warmup_desired_ini(text: str) -> WarmupDesiredDocument:
         nonlocal current_name, current_fields
         if not current_name:
             return
-        desired_raw = current_fields.get("desired", "idle")
+        enabled = _coerce_enabled_field(current_fields)
+        desired_raw = current_fields.get("desired")
         section = WarmupServiceSection(
+            enabled=enabled,
             desired=desired_raw,
             router_alias=current_fields.get("router_alias"),
+            model_path=current_fields.get("model_path"),
             model_id=current_fields.get("model_id"),
             bundle_id=current_fields.get("bundle_id"),
             extras={
                 key: value
                 for key, value in current_fields.items()
-                if key not in {"desired", "router_alias", "model_id", "bundle_id"}
+                if key
+                not in {
+                    "desired",
+                    "enabled",
+                    "router_alias",
+                    "model_path",
+                    "model_id",
+                    "bundle_id",
+                }
             },
         )
         sections[current_name] = section
@@ -153,8 +233,7 @@ def parse_warmup_desired_ini(text: str) -> WarmupDesiredDocument:
         if "=" not in line:
             continue
         key, value = line.split("=", 1)
-        key_raw = key.strip()
-        key_lower = key_raw.lower()
+        key_lower = key.strip().lower()
         value = value.strip()
         if current_name is None:
             if key_lower == HEADER_VERSION_KEY:
@@ -167,12 +246,16 @@ def parse_warmup_desired_ini(text: str) -> WarmupDesiredDocument:
         current_fields[key_lower] = value
 
     flush_current()
-    document = WarmupDesiredDocument(
+    return WarmupDesiredDocument(
         version=version,
         revision=revision,
         updated_at_utc=updated_at_utc,
         sections=sections,
     )
+
+
+def parse_warmup_desired_ini(text: str) -> WarmupDesiredDocument:
+    document = _parse_warmup_desired_ini_raw(text)
     validate_warmup_desired(document)
     return document
 
@@ -198,14 +281,19 @@ def serialize_warmup_desired_ini(
         if section is None:
             continue
         lines.append(f"[{section_name}]")
-        lines.append(f"desired = {section.desired}")
+        if section_is_off(section):
+            lines.append(f"enabled = {ENABLED_OFF}")
         if section.router_alias:
             lines.append(f"router_alias = {section.router_alias}")
+        if section.model_path:
+            lines.append(f"model_path = {section.model_path}")
         if section.model_id:
             lines.append(f"model_id = {section.model_id}")
         if section.bundle_id:
             lines.append(f"bundle_id = {section.bundle_id}")
         for extra_key in sorted(section.extras.keys()):
+            if extra_key == "enabled":
+                continue
             lines.append(f"{extra_key} = {section.extras[extra_key]}")
         lines.append("")
 
@@ -247,13 +335,13 @@ def resolve_warmup_desired_path() -> str:
 
 
 def read_warmup_desired() -> WarmupDesiredDocument | None:
+    """Read persisted INI without validation — stale volume state must not brick startup."""
     path = resolve_warmup_desired_path()
     with WARMUP_FILE_LOCK:
         if not os.path.exists(path):
             return None
         with open(path, "r", encoding="utf-8") as handle:
-            content = handle.read()
-        return parse_warmup_desired_ini(content)
+            return _parse_warmup_desired_ini_raw(handle.read())
 
 
 def write_warmup_desired(
@@ -270,7 +358,7 @@ def write_warmup_desired(
         prior: WarmupDesiredDocument | None = None
         if os.path.exists(path):
             with open(path, "r", encoding="utf-8") as handle:
-                prior = parse_warmup_desired_ini(handle.read())
+                prior = _parse_warmup_desired_ini_raw(handle.read())
 
         if expected_revision is not None:
             current_revision = prior.revision if prior is not None else 0

--- a/docker/build/guideants-ai/admin-service/warmup_engine_client.py
+++ b/docker/build/guideants-ai/admin-service/warmup_engine_client.py
@@ -96,30 +96,46 @@ def _get_json(url: str, timeout: float) -> tuple[int, Any]:
         return status, text
 
 
-def _aux_load_body(model_ref: str | None) -> dict[str, str] | None:
+def _aux_load_body(model_ref: str | None, *, load_field: str = "model_path") -> dict[str, str] | None:
     if not model_ref or not model_ref.strip():
         return None
     trimmed = model_ref.strip()
     if trimmed.lower().endswith(".gguf"):
         return {"model_path": trimmed}
-    return {"model_id": trimmed}
+    if load_field == "model_id":
+        return {"model_id": trimmed}
+    return {"model_path": trimmed}
 
 
-def post_aux_load(service_id: str, model_ref: str | None) -> bool:
+def post_aux_load(service_id: str, model_ref: str | None, *, load_field: str = "model_path") -> bool:
     base = SERVICE_ENGINE_BASE_URLS.get(service_id)
     if not base:
         return False
     timeout = float(READY_TIMEOUT_SECONDS.get(service_id, 900))
     if service_id == "ImageGeneration":
-        if model_ref and model_ref.strip():
-            bundle_id = model_ref.strip()
-            select_url = f"{base.rstrip('/')}/admin/bundles/{urllib.parse.quote(bundle_id, safe='')}/select-active"
-            _post_json(select_url, None, timeout=min(timeout, 120.0))
+        if not model_ref or not model_ref.strip():
+            return False
+        bundle_id = model_ref.strip()
+        select_url = f"{base.rstrip('/')}/admin/bundles/{urllib.parse.quote(bundle_id, safe='')}/select-active"
+        _post_json(select_url, None, timeout=min(timeout, 120.0))
         status, _ = _post_json(f"{base.rstrip('/')}/admin/load", None, timeout=timeout)
         return status in (200, 201, 202, 204, 409)
-    body = _aux_load_body(model_ref)
+    body = _aux_load_body(model_ref, load_field=load_field)
     status, _ = _post_json(f"{base.rstrip('/')}/admin/load", body, timeout=timeout)
     return status in (200, 201, 202, 204, 409)
+
+
+def _aux_ready_matches_expected(payload: dict[str, Any], expected_model_ref: str) -> bool:
+    expected = expected_model_ref.strip()
+    if not expected:
+        return True
+    candidates = {
+        str(payload.get("modelRef") or payload.get("model_ref") or "").strip(),
+        str(payload.get("catalogEntryId") or payload.get("catalog_entry_id") or "").strip(),
+        str(payload.get("bundleId") or payload.get("bundle_id") or "").strip(),
+    }
+    candidates.discard("")
+    return bool(candidates) and expected in candidates
 
 
 def post_aux_unload(service_id: str) -> bool:
@@ -131,7 +147,7 @@ def post_aux_unload(service_id: str) -> bool:
     return status in (200, 201, 202, 204, 409)
 
 
-def wait_aux_ready(service_id: str) -> bool:
+def wait_aux_ready(service_id: str, *, expected_model_ref: str | None = None) -> bool:
     base = SERVICE_ENGINE_BASE_URLS.get(service_id)
     if not base:
         return False
@@ -146,6 +162,11 @@ def wait_aux_ready(service_id: str) -> bool:
                     process_alive = engine.get("processAlive")
                     healthy = engine.get("healthy")
                     if process_alive is True and healthy is True:
+                        if expected_model_ref:
+                            active_bundle = str(payload.get("activeBundleId") or engine.get("loadedBundleId") or "")
+                            if active_bundle and active_bundle != expected_model_ref.strip():
+                                time.sleep(POLL_INTERVAL_SECONDS)
+                                continue
                         return True
                     if process_alive is True and healthy is None:
                         return True
@@ -156,8 +177,12 @@ def wait_aux_ready(service_id: str) -> bool:
             time.sleep(POLL_INTERVAL_SECONDS)
         return False
     while time.monotonic() < deadline:
-        status, _ = _get_json(f"{base.rstrip('/')}/ready", timeout=5.0)
+        status, payload = _get_json(f"{base.rstrip('/')}/ready", timeout=5.0)
         if status == 200:
+            if expected_model_ref and isinstance(payload, dict):
+                if not _aux_ready_matches_expected(payload, expected_model_ref):
+                    time.sleep(POLL_INTERVAL_SECONDS)
+                    continue
             return True
         time.sleep(POLL_INTERVAL_SECONDS)
     return False

--- a/docker/build/guideants-ai/admin-service/warmup_engine_client.py
+++ b/docker/build/guideants-ai/admin-service/warmup_engine_client.py
@@ -116,9 +116,8 @@ def post_aux_load(service_id: str, model_ref: str | None, *, load_field: str = "
         if not model_ref or not model_ref.strip():
             return False
         bundle_id = model_ref.strip()
-        select_url = f"{base.rstrip('/')}/admin/bundles/{urllib.parse.quote(bundle_id, safe='')}/select-active"
-        _post_json(select_url, None, timeout=min(timeout, 120.0))
-        status, _ = _post_json(f"{base.rstrip('/')}/admin/load", None, timeout=timeout)
+        body = {"bundle_id": bundle_id}
+        status, _ = _post_json(f"{base.rstrip('/')}/admin/load", body, timeout=timeout)
         return status in (200, 201, 202, 204, 409)
     body = _aux_load_body(model_ref, load_field=load_field)
     status, _ = _post_json(f"{base.rstrip('/')}/admin/load", body, timeout=timeout)
@@ -163,8 +162,13 @@ def wait_aux_ready(service_id: str, *, expected_model_ref: str | None = None) ->
                     healthy = engine.get("healthy")
                     if process_alive is True and healthy is True:
                         if expected_model_ref:
-                            active_bundle = str(payload.get("activeBundleId") or engine.get("loadedBundleId") or "")
-                            if active_bundle and active_bundle != expected_model_ref.strip():
+                            engine = payload.get("engine") or {}
+                            loaded_bundle = str(
+                                engine.get("loadedBundleId")
+                                or payload.get("loadedBundleId")
+                                or ""
+                            ).strip()
+                            if loaded_bundle and loaded_bundle != expected_model_ref.strip():
                                 time.sleep(POLL_INTERVAL_SECONDS)
                                 continue
                         return True

--- a/docker/build/guideants-ai/admin-service/warmup_orchestrator.py
+++ b/docker/build/guideants-ai/admin-service/warmup_orchestrator.py
@@ -184,6 +184,8 @@ def _set_service_phase(
         entry["phase"] = phase
         if error is not None:
             entry["error"] = error
+        else:
+            entry.pop("error", None)
         if clear_loaded_refs:
             entry.pop("modelId", None)
             entry.pop("bundleId", None)

--- a/docker/build/guideants-ai/admin-service/warmup_orchestrator.py
+++ b/docker/build/guideants-ai/admin-service/warmup_orchestrator.py
@@ -9,9 +9,14 @@ from typing import Any, Callable
 from warmup_desired_ini import (
     SERVICE_LLAMA,
     AUX_SERVICES,
+    WARMUP_SERVICE_SECTIONS,
     WarmupDesiredDocument,
     WarmupServiceSection,
+    aux_section_load_request,
     read_warmup_desired,
+    section_execution_ref,
+    section_is_off,
+    section_should_load,
 )
 from warmup_engine_client import (
     list_llama_models,
@@ -76,15 +81,7 @@ class ServiceTransition:
     action: str  # load | unload | noop
 
 
-def _service_model_ref(section_name: str, section: WarmupServiceSection) -> str | None:
-    if section_name == SERVICE_LLAMA:
-        return section.router_alias
-    if section_name == "ImageGeneration":
-        return section.bundle_id
-    return section.model_id
-
-
-def _applied_model_ref(service_state: dict[str, Any]) -> str | None:
+def _loaded_model_ref(service_state: dict[str, Any]) -> str | None:
     if service_state.get("routerAlias"):
         return str(service_state["routerAlias"])
     if service_state.get("bundleId"):
@@ -96,26 +93,23 @@ def _applied_model_ref(service_state: dict[str, Any]) -> str | None:
 
 def _needs_transition(
     section_name: str,
-    desired_section: WarmupServiceSection,
+    plan_section: WarmupServiceSection | None,
     service_state: dict[str, Any] | None,
 ) -> ServiceTransition:
     prior = service_state or {}
-    applied = str(prior.get("applied", "idle")).lower()
-    desired = desired_section.desired
-    desired_ref = _service_model_ref(section_name, desired_section)
-    applied_ref = _applied_model_ref(prior)
+    loaded_ref = _loaded_model_ref(prior)
+    plan_ref = (
+        section_execution_ref(section_name, plan_section)
+        if plan_section is not None
+        else None
+    )
 
-    if desired == "idle":
-        if applied == "warm":
+    if plan_ref is None:
+        if loaded_ref:
             return ServiceTransition(section_name, "unload")
         return ServiceTransition(section_name, "noop")
 
-    # desired warm
-    if applied != "warm":
-        return ServiceTransition(section_name, "load")
-    if desired_ref and applied_ref and desired_ref != applied_ref:
-        return ServiceTransition(section_name, "load")
-    if desired_ref and not applied_ref:
+    if loaded_ref != plan_ref:
         return ServiceTransition(section_name, "load")
     return ServiceTransition(section_name, "noop")
 
@@ -127,17 +121,11 @@ def compute_transitions(
     services = state.get("services") or {}
     transitions: list[ServiceTransition] = []
 
-    llama_section = document.sections.get(SERVICE_LLAMA)
-    if llama_section is not None:
+    for section_name in WARMUP_SERVICE_SECTIONS:
+        section = document.sections.get(section_name)
         transitions.append(
-            _needs_transition(SERVICE_LLAMA, llama_section, services.get(SERVICE_LLAMA))
+            _needs_transition(section_name, section, services.get(section_name))
         )
-
-    for service in AUX_SERVICES:
-        section = document.sections.get(service)
-        if section is None:
-            continue
-        transitions.append(_needs_transition(service, section, services.get(service)))
 
     return transitions
 
@@ -151,7 +139,7 @@ def _llama_needs_gpu_drain(transitions: dict[str, str], document: WarmupDesiredD
     if llama_action in {"load", "unload"}:
         return True
     llama_section = document.sections.get(SERVICE_LLAMA)
-    if llama_section is None or llama_section.desired != "warm":
+    if not section_should_load(SERVICE_LLAMA, llama_section):
         return False
     # Loading aux while llama is not warm may still be fine; only drain when llama itself changes.
     return False
@@ -161,16 +149,15 @@ def _aux_services_to_drain_before_llama(
     document: WarmupDesiredDocument,
     state: dict[str, Any],
 ) -> set[str]:
-    """D11 GPU drain: unload every aux that should stay warm but is currently applied warm."""
+    """D11 GPU drain: unload every aux that stays in the plan but is currently loaded."""
     services = state.get("services") or {}
     to_drain: set[str] = set()
     for service in AUX_UNLOAD_ORDER:
         section = document.sections.get(service)
-        if section is None or section.desired != "warm":
+        if not section_should_load(service, section):
             continue
         entry = services.get(service) or {}
-        applied = str(entry.get("applied", "idle")).lower()
-        if applied == "warm":
+        if _loaded_model_ref(entry):
             to_drain.add(service)
     return to_drain
 
@@ -185,17 +172,34 @@ def _set_service_phase(
     service: str,
     *,
     phase: str,
-    applied: str | None = None,
     error: str | None = None,
+    model_id: str | None = None,
+    bundle_id: str | None = None,
+    router_alias: str | None = None,
+    clear_loaded_refs: bool = False,
 ) -> None:
     def mutate(state: dict[str, Any]) -> None:
         services = dict(state.get("services") or {})
         entry = dict(services.get(service) or {})
         entry["phase"] = phase
-        if applied is not None:
-            entry["applied"] = applied
         if error is not None:
             entry["error"] = error
+        if clear_loaded_refs:
+            entry.pop("modelId", None)
+            entry.pop("bundleId", None)
+            entry.pop("routerAlias", None)
+        if model_id is not None:
+            entry["modelId"] = model_id
+            entry.pop("bundleId", None)
+            entry.pop("routerAlias", None)
+        if bundle_id is not None:
+            entry["bundleId"] = bundle_id
+            entry.pop("modelId", None)
+            entry.pop("routerAlias", None)
+        if router_alias is not None:
+            entry["routerAlias"] = router_alias
+            entry.pop("modelId", None)
+            entry.pop("bundleId", None)
         services[service] = entry
         state["services"] = services
 
@@ -234,7 +238,7 @@ def _unload_llama_to_idle() -> bool:
         elif not wait_llama_unloaded(alias):
             ok = False
     if ok:
-        _set_service_phase(SERVICE_LLAMA, phase=SERVICE_PHASE_IDLE, applied="idle", error=None)
+        _set_service_phase(SERVICE_LLAMA, phase=SERVICE_PHASE_IDLE, error=None, clear_loaded_refs=True)
     else:
         _set_service_phase(SERVICE_LLAMA, phase=SERVICE_PHASE_FAILED, error="llama unload timed out")
     return ok
@@ -251,6 +255,17 @@ def _is_llama_loaded_entry(entry: dict[str, Any]) -> bool:
 
 
 def _load_llama_alias(alias: str) -> bool:
+    for entry in list_llama_models():
+        entry_id = entry.get("id")
+        if isinstance(entry_id, str) and entry_id == alias and _is_llama_loaded_entry(entry):
+            _set_service_phase(
+                SERVICE_LLAMA,
+                phase=SERVICE_PHASE_READY,
+                error=None,
+                router_alias=alias,
+            )
+            return True
+
     loaded_aliases = [
         str(entry.get("id"))
         for entry in list_llama_models()
@@ -271,7 +286,12 @@ def _load_llama_alias(alias: str) -> bool:
     if not wait_llama_loaded(alias):
         _set_service_phase(SERVICE_LLAMA, phase=SERVICE_PHASE_FAILED, error="llama load timed out")
         return False
-    _set_service_phase(SERVICE_LLAMA, phase=SERVICE_PHASE_READY, applied="warm", error=None)
+    _set_service_phase(
+        SERVICE_LLAMA,
+        phase=SERVICE_PHASE_READY,
+        error=None,
+        router_alias=alias,
+    )
     return ok
 
 
@@ -279,22 +299,16 @@ def _reconcile_llama(section: WarmupServiceSection, action: str) -> bool:
     if action == "unload":
         return _unload_llama_to_idle()
     if action == "load":
-        alias = (section.router_alias or "").strip()
+        alias = section_execution_ref(SERVICE_LLAMA, section)
         if not alias:
             _set_service_phase(
                 SERVICE_LLAMA,
                 phase=SERVICE_PHASE_FAILED,
-                error="llama desired warm but router_alias is missing",
+                error="llama plan missing router_alias",
             )
             return False
         return _load_llama_alias(alias)
     return True
-
-
-def _model_ref_for_aux(service: str, section: WarmupServiceSection) -> str | None:
-    if service == "ImageGeneration":
-        return section.bundle_id
-    return section.model_id
 
 
 def _reconcile_aux(service: str, section: WarmupServiceSection, action: str) -> bool:
@@ -306,37 +320,61 @@ def _reconcile_aux(service: str, section: WarmupServiceSection, action: str) -> 
         if not wait_aux_unloaded(service):
             _set_service_phase(service, phase=SERVICE_PHASE_FAILED, error="unload timed out")
             return False
-        _set_service_phase(service, phase=SERVICE_PHASE_IDLE, applied="idle", error=None)
+        _set_service_phase(service, phase=SERVICE_PHASE_IDLE, error=None, clear_loaded_refs=True)
         return True
 
     if action == "load":
-        model_ref = _model_ref_for_aux(service, section)
+        if service == "ImageGeneration":
+            model_ref = section_execution_ref(service, section)
+            load_field = "model_path"
+            if not model_ref:
+                _set_service_phase(
+                    service,
+                    phase=SERVICE_PHASE_FAILED,
+                    error="plan missing bundle_id",
+                )
+                return False
+        else:
+            model_ref, load_field = aux_section_load_request(section, service=service)
         if service != "ImageGeneration" and not model_ref:
             _set_service_phase(
                 service,
                 phase=SERVICE_PHASE_FAILED,
-                error="desired warm but model_id is missing",
+                error="plan missing model_path",
             )
             return False
         _set_service_phase(service, phase=SERVICE_PHASE_LOADING)
-        if not post_aux_load(service, model_ref):
+        if not post_aux_load(service, model_ref, load_field=load_field):
             _set_service_phase(service, phase=SERVICE_PHASE_FAILED, error="load request failed")
             return False
-        if not wait_aux_ready(service):
-            _set_service_phase(service, phase=SERVICE_PHASE_FAILED, error="ready timed out")
+        if not wait_aux_ready(service, expected_model_ref=model_ref):
+            _set_service_phase(service, phase=SERVICE_PHASE_FAILED, error="ready timed out or model mismatch")
             return False
-        _set_service_phase(service, phase=SERVICE_PHASE_READY, applied="warm", error=None)
+        if service == "ImageGeneration":
+            _set_service_phase(
+                service,
+                phase=SERVICE_PHASE_READY,
+                error=None,
+                bundle_id=model_ref,
+            )
+        else:
+            _set_service_phase(
+                service,
+                phase=SERVICE_PHASE_READY,
+                error=None,
+                model_id=model_ref,
+            )
         return True
 
     return True
 
 
 def _cold_start_load_map(document: WarmupDesiredDocument) -> dict[str, str]:
-    """Warm services to load on container cold start. Engines are empty — no unloads."""
+    """Services with a load ref in the plan — cold start only loads, never unloads."""
     actions: dict[str, str] = {}
-    for service in (SERVICE_LLAMA, *AUX_SERVICES):
+    for service in WARMUP_SERVICE_SECTIONS:
         section = document.sections.get(service)
-        if section is not None and section.desired == "warm":
+        if section_should_load(service, section):
             actions[service] = "load"
     return actions
 

--- a/docker/build/guideants-ai/admin-service/warmup_state.py
+++ b/docker/build/guideants-ai/admin-service/warmup_state.py
@@ -9,12 +9,12 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from warmup_desired_ini import (
-    SERVICE_LLAMA,
     WARMUP_SERVICE_SECTIONS,
     WarmupDesiredDocument,
     WarmupServiceSection,
     read_warmup_desired,
     resolve_warmup_desired_path,
+    section_execution_ref,
 )
 
 WARMUP_STATE_PATH = "/models-local/.warmup-state.json"
@@ -41,20 +41,25 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _loaded_ref_from_service_state(service_state: dict[str, Any]) -> str | None:
+    if service_state.get("routerAlias"):
+        return str(service_state["routerAlias"])
+    if service_state.get("bundleId"):
+        return str(service_state["bundleId"])
+    if service_state.get("modelId"):
+        return str(service_state["modelId"])
+    return None
+
+
 def _service_state_from_section(section_name: str, section: WarmupServiceSection) -> dict[str, Any]:
-    applied = "idle"
+    """Fresh service state — plan ref from INI, nothing loaded yet."""
+    plan_ref = section_execution_ref(section_name, section)
     state: dict[str, Any] = {
-        "desired": section.desired,
-        "applied": applied,
         "phase": SERVICE_PHASE_IDLE,
         "error": None,
     }
-    if section_name == SERVICE_LLAMA and section.router_alias:
-        state["routerAlias"] = section.router_alias
-    if section.model_id:
-        state["modelId"] = section.model_id
-    if section.bundle_id:
-        state["bundleId"] = section.bundle_id
+    if plan_ref:
+        state["planRef"] = plan_ref
     return state
 
 
@@ -80,7 +85,7 @@ def build_warmup_state_document(
     written_at: str | None = None,
 ) -> dict[str, Any]:
     return {
-        "schemaVersion": 1,
+        "schemaVersion": 2,
         "desiredRevision": desired_revision,
         "appliedRevision": applied_revision,
         "inProgressRevision": in_progress_revision,
@@ -142,7 +147,7 @@ def sync_state_after_desired_write(
     desired_sha256: str,
     changed: bool,
 ) -> dict[str, Any]:
-    """Update warmup state after a desired INI write."""
+    """Update warmup state after a runtime plan write."""
     with WARMUP_STATE_LOCK:
         current = _read_warmup_state_unlocked()
         if current is None:
@@ -151,6 +156,7 @@ def sync_state_after_desired_write(
             return state
 
         next_state = dict(current)
+        next_state["schemaVersion"] = 2
         next_state["desiredRevision"] = document.revision
         next_state["desiredSha256"] = desired_sha256
         next_state["writtenAt"] = _utc_now_iso()
@@ -159,13 +165,37 @@ def sync_state_after_desired_write(
         for section_name in WARMUP_SERVICE_SECTIONS:
             section = document.sections.get(section_name)
             if section is None:
-                services.pop(section_name, None)
+                prior = services.get(section_name)
+                if prior and _loaded_ref_from_service_state(prior):
+                    services[section_name] = {
+                        "phase": prior.get("phase", SERVICE_PHASE_IDLE),
+                        "error": prior.get("error"),
+                        **_loaded_ref_fields(prior),
+                    }
+                else:
+                    services.pop(section_name, None)
                 continue
-            prior = services.get(section_name) or {}
-            updated = _service_state_from_section(section_name, section)
-            updated["applied"] = prior.get("applied", "idle")
-            updated["phase"] = prior.get("phase", SERVICE_PHASE_IDLE)
-            updated["error"] = prior.get("error")
+
+            prior = dict(services.get(section_name) or {})
+            plan_ref = section_execution_ref(section_name, section)
+            updated: dict[str, Any] = {
+                "phase": prior.get("phase", SERVICE_PHASE_IDLE),
+                "error": prior.get("error"),
+            }
+            if plan_ref:
+                updated["planRef"] = plan_ref
+            else:
+                updated.pop("planRef", None)
+
+            for key in ("modelId", "bundleId", "routerAlias"):
+                if key in prior:
+                    updated[key] = prior[key]
+
+            loaded_ref = _loaded_ref_from_service_state(prior)
+            if plan_ref and loaded_ref and plan_ref != loaded_ref:
+                updated["phase"] = SERVICE_PHASE_IDLE
+                updated["error"] = None
+
             services[section_name] = updated
         next_state["services"] = services
 
@@ -175,6 +205,14 @@ def sync_state_after_desired_write(
 
         atomic_write_warmup_state(next_state)
         return next_state
+
+
+def _loaded_ref_fields(prior: dict[str, Any]) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for key in ("modelId", "bundleId", "routerAlias"):
+        if key in prior:
+            fields[key] = prior[key]
+    return fields
 
 
 def mutate_warmup_state(mutator: Callable[[dict[str, Any]], None]) -> dict[str, Any]:

--- a/docker/build/guideants-ai/asr-service/asr_service.py
+++ b/docker/build/guideants-ai/asr-service/asr_service.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from guideants_hf.catalog_completeness import catalog_entry_for_directory_name, directory_model_entry_is_complete
 from guideants_hf.catalog_download import download_catalog_entry_files, verify_required_files
 from guideants_hf.engine_process import format_engine_exit_error
 from guideants_hf.operations import find_in_flight_operation
@@ -791,12 +792,14 @@ def list_model_entries() -> list[dict[str, Any]]:
             size_bytes = os.path.getsize(full_path) if os.path.isfile(full_path) else 0
         except OSError:
             size_bytes = 0
+        catalog_entry = catalog_entry_for_directory_name(name, CATALOG["entries"])
         items.append(
             {
                 "modelRef": name,
                 "path": full_path,
                 "isDirectory": os.path.isdir(full_path),
                 "sizeBytes": size_bytes,
+                "complete": directory_model_entry_is_complete(full_path, catalog_entry),
                 "active": bool(active_ref and (active_ref == name or active_ref == full_path)),
             }
         )

--- a/docker/build/guideants-ai/emb-service/emb_service.py
+++ b/docker/build/guideants-ai/emb-service/emb_service.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from guideants_hf.catalog_completeness import gguf_model_entry_is_complete
 from guideants_hf.catalog_download import download_catalog_entry_files
 from guideants_hf.operations import find_in_flight_operation
 
@@ -655,12 +656,14 @@ def list_model_entries() -> list[dict[str, Any]]:
             size_bytes = os.path.getsize(full_path) if os.path.isfile(full_path) else 0
         except OSError:
             size_bytes = 0
+        catalog_match = catalog_entry_for_gguf_filename(name)
         items.append(
             {
                 "modelRef": name,
                 "path": full_path,
                 "isDirectory": os.path.isdir(full_path),
                 "sizeBytes": size_bytes,
+                "complete": catalog_match is not None and gguf_model_entry_is_complete(full_path),
                 "active": bool(active_ref and (active_ref == name or active_ref == full_path)),
             }
         )

--- a/docker/build/guideants-ai/lib/guideants_hf/catalog_completeness.py
+++ b/docker/build/guideants-ai/lib/guideants_hf/catalog_completeness.py
@@ -1,0 +1,48 @@
+import os
+from typing import Any
+
+from guideants_hf.catalog_download import verify_required_files
+
+
+def has_partial_download_artifacts(path: str) -> bool:
+    for root, _, files in os.walk(path):
+        for filename in files:
+            if filename.endswith(".tmp") or filename.endswith(".partial"):
+                return True
+    return False
+
+
+def catalog_entry_for_directory_name(name: str, catalog_entries: dict[str, Any]) -> dict[str, Any] | None:
+    for entry in catalog_entries.values():
+        target = str(entry.get("targetDirectory") or entry.get("id") or "").strip()
+        entry_id = str(entry.get("id") or "").strip()
+        if name == target or name == entry_id:
+            return entry
+    return None
+
+
+def directory_model_entry_is_complete(full_path: str, entry: dict[str, Any] | None) -> bool:
+    if entry is None or not os.path.isdir(full_path):
+        return False
+    if has_partial_download_artifacts(full_path):
+        return False
+    required = entry.get("requiredFiles")
+    if not isinstance(required, list) or not required:
+        return True
+    try:
+        verify_required_files(full_path, entry)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def gguf_model_entry_is_complete(full_path: str) -> bool:
+    if not os.path.isfile(full_path):
+        return False
+    basename = os.path.basename(full_path)
+    if basename.endswith(".tmp") or basename.endswith(".partial"):
+        return False
+    try:
+        return os.path.getsize(full_path) > 0
+    except OSError:
+        return False

--- a/docker/build/guideants-ai/sd-service/sd_service.py
+++ b/docker/build/guideants-ai/sd-service/sd_service.py
@@ -345,7 +345,7 @@ def resolve_bundle_dir(model_dir: str, bundle_id: str) -> str:
     return bundle_path
 
 
-def resolve_runtime_config() -> SdRuntimeConfig:
+def resolve_runtime_config(*, bundle_id: str | None = None) -> SdRuntimeConfig:
     model_dir = os.getenv("GA_SD_MODEL_DIR", "/models-local/sd")
 
     server_path = (os.getenv("GA_SD_SERVER_PATH") or "").strip()
@@ -354,18 +354,11 @@ def resolve_runtime_config() -> SdRuntimeConfig:
     elif not os.path.isabs(server_path):
         server_path = shutil.which(server_path) or server_path
 
-    # The active bundle is the single authority for diffusion / VAE / text
-    # encoder paths. Operators no longer configure these via environment
-    # variables at all — if no bundle is active, the service refuses to
-    # start. There is no hardcoded filename fallback on purpose: silent
-    # defaults have repeatedly caused the service to launch against files the
-    # operator did not pick.
-    selected_bundle = read_active_bundle(model_dir)
+    selected_bundle = (bundle_id or "").strip()
     if not selected_bundle:
         raise RuntimeError(
-            "No active Stable Diffusion bundle is selected. Download a "
-            "bundle and mark it active via the /admin/bundles endpoints "
-            "before starting the SD service."
+            "bundle_id is required. Selection is owned by ServiceModes; "
+            "warmup orchestration must call POST /admin/load with bundle_id."
         )
 
     bundle_paths = expected_bundle_paths(model_dir, selected_bundle)
@@ -475,10 +468,16 @@ def read_active_bundle(model_dir: str) -> str | None:
     try:
         with open(marker, "r", encoding="utf-8") as handle:
             payload = json.load(handle)
-            bundle_id = payload.get("bundleId")
-            return validate_bundle_id(str(bundle_id)) if bundle_id else None
+        bundle_id = str(payload.get("bundleId") or "").strip()
+        return bundle_id or None
     except Exception:
         return None
+
+
+def write_active_bundle_marker(model_dir: str, bundle_id: str) -> None:
+    marker = active_bundle_file(model_dir)
+    with open(marker, "w", encoding="utf-8") as handle:
+        json.dump({"bundleId": bundle_id, "updatedAtUtc": utc_now_iso()}, handle)
 
 
 def expected_bundle_paths(model_dir: str, bundle_id: str) -> dict[str, str]:
@@ -672,7 +671,6 @@ def role_directory_ready(path: str) -> bool:
 
 def list_bundles(model_dir: str) -> list[dict[str, Any]]:
     root = bundle_root_dir(model_dir)
-    active_bundle = read_active_bundle(model_dir)
     bundles: list[dict[str, Any]] = []
     try:
         bundle_ids = sorted(os.listdir(root))
@@ -696,7 +694,6 @@ def list_bundles(model_dir: str) -> list[dict[str, Any]]:
             }
             bundle: dict[str, Any] = {
                 "bundleId": bundle_id,
-                "active": bundle_id == active_bundle,
                 "roles": role_state,
                 "complete": all(role["ready"] for role in role_state.values()),
             }
@@ -724,7 +721,6 @@ def list_bundles(model_dir: str) -> list[dict[str, Any]]:
             bundles.append(
                 {
                     "bundleId": bundle_id,
-                    "active": bundle_id == active_bundle,
                     "roles": {
                         role: {"path": path, "ready": False}
                         for role, path in roles.items()
@@ -1180,20 +1176,20 @@ def stop_engine() -> None:
     STATE.engine_started_at_utc = None
 
 
-def start_engine() -> tuple[bool, str | None]:
+def start_engine(*, bundle_id: str) -> tuple[bool, str | None]:
     """
-    Resolve the currently-active bundle, spawn sd-server, and wait until it
-    answers /v1/models. Caller must hold ENGINE_LOCK.
+    Load ``bundle_id`` into sd-server. Caller must hold ENGINE_LOCK.
 
-    Returns ``(ok, error)``. On failure the subprocess (if any) is terminated,
-    STATE is cleared back to "unloaded", and ``STATE.config_error`` is
-    populated so the next /health / /admin/bundles read surfaces the reason.
+    Returns ``(ok, error)``. On success writes active_bundle.json as a derived
+    record of the last bundle that was loaded successfully.
     """
     if is_engine_process_alive():
-        return True, None
+        if STATE.loaded_bundle_id == bundle_id:
+            return True, None
+        stop_engine()
 
     try:
-        config = resolve_runtime_config()
+        config = resolve_runtime_config(bundle_id=bundle_id)
     except RuntimeError as exc:
         config_error = truncate_text(str(exc), 2048)
         STATE.config = None
@@ -1205,7 +1201,7 @@ def start_engine() -> tuple[bool, str | None]:
         return False, STATE.config_error
 
     STATE.config = config
-    STATE.loaded_bundle_id = read_active_bundle(config.model_dir)
+    STATE.loaded_bundle_id = bundle_id
     command = build_sd_server_command(config)
     log_event(
         "sd_engine_start",
@@ -1227,6 +1223,7 @@ def start_engine() -> tuple[bool, str | None]:
         wait_for_engine_ready(config)
         STATE.loaded_at_utc = utc_now_iso()
         STATE.config_error = None
+        write_active_bundle_marker(config.model_dir, bundle_id)
         log_event(
             "sd_engine_ready",
             bundleId=STATE.loaded_bundle_id,
@@ -1893,7 +1890,7 @@ async def admin_list_bundles() -> JSONResponse:
         status_code=200,
         content={
             "modelDir": model_dir,
-            "activeBundleId": read_active_bundle(model_dir),
+            "legacyMarkerBundleId": read_active_bundle(model_dir),
             "loadedBundleId": loaded_id,
             "engine": engine_state_dict(),
             "items": items,
@@ -1951,113 +1948,67 @@ async def admin_cancel_bundle_operation(operation_id: str) -> JSONResponse:
 
 @APP.post("/admin/bundles/{bundle_id}/select-active")
 async def admin_select_active_bundle(bundle_id: str) -> JSONResponse:
-    model_dir = _require_model_dir()
-    bundle_id = require_valid_bundle_id(bundle_id)
-    bundle = next((item for item in list_bundles(model_dir) if item["bundleId"] == bundle_id), None)
-    if bundle is None:
-        raise HTTPException(status_code=404, detail="bundle not found")
-    if not bundle.get("complete"):
-        missing = [name for name, role in bundle.get("roles", {}).items() if not role.get("ready")]
-        raise HTTPException(status_code=409, detail=f"bundle is incomplete; missing roles: {', '.join(missing)}")
+    raise HTTPException(
+        status_code=410,
+        detail=(
+            "Bundle selection is owned by ServiceModes. Use the GuideAnts "
+            "select-active API, which writes warmup-desired.ini and calls "
+            "POST /admin/load with bundle_id."
+        ),
+    )
 
-    if not ENGINE_LOCK.acquire(blocking=False):
-        raise HTTPException(
-            status_code=409,
-            detail="engine lifecycle operation already in progress; retry in a moment",
-        )
-    try:
-        marker = active_bundle_file(model_dir)
-        with open(marker, "w", encoding="utf-8") as handle:
-            json.dump({"bundleId": bundle_id, "updatedAtUtc": utc_now_iso()}, handle)
 
-        # Marker-only path: when no engine is running, simply record the new
-        # active bundle and let the next /admin/load pick it up.
-        if not is_engine_process_alive():
-            return JSONResponse(
-                status_code=200,
-                content={
-                    "ok": True,
-                    "action": "marker-updated",
-                    "activeBundleId": bundle_id,
-                    "engine": engine_state_dict(),
-                },
-            )
-
-        # Hot-swap path: tear down the current engine, then start a fresh one
-        # which will read the new active marker and load the new bundle's
-        # files into memory. Failure leaves the engine unloaded so the UI
-        # surfaces the error instead of silently running against stale
-        # weights.
-        log_event(
-            "sd_engine_hot_swap_start",
-            fromBundleId=STATE.loaded_bundle_id,
-            toBundleId=bundle_id,
-        )
-        stop_engine()
-        ok, err = start_engine()
-        if ok:
-            log_event(
-                "sd_engine_hot_swap_complete",
-                bundleId=STATE.loaded_bundle_id,
-            )
-            return JSONResponse(
-                status_code=200,
-                content={
-                    "ok": True,
-                    "action": "hot-swapped",
-                    "activeBundleId": bundle_id,
-                    "engine": engine_state_dict(),
-                },
-            )
-        log_event(
-            "sd_engine_hot_swap_failed",
-            toBundleId=bundle_id,
-            error=truncate_text(err or "", 2048),
-        )
-        return JSONResponse(
-            status_code=503,
-            content={
-                "ok": False,
-                "action": "hot-swap-failed",
-                "activeBundleId": bundle_id,
-                "error": "engine_start_failed",
-                "engine": engine_state_dict(),
-            },
-        )
-    finally:
-        ENGINE_LOCK.release()
+class AdminLoadRequest(BaseModel):
+    bundle_id: str | None = None
 
 
 @APP.post("/admin/load")
-async def admin_load() -> JSONResponse:
+async def admin_load(payload: AdminLoadRequest | None = None) -> JSONResponse:
     """
-    Start the sd-server subprocess using whichever bundle is marked active on
-    disk. If the engine is already running, this is a no-op that returns the
-    current state. Serialized with /admin/unload and /admin/bundles/.../select-
-    active via ENGINE_LOCK.
+    Load ``bundle_id`` into sd-server. Selection authority is upstream
+    (ServiceModes → warmup INI → orchestrator); this endpoint only executes
+    the load request it is given.
     """
+    bundle_id = require_valid_bundle_id((payload.bundle_id if payload else "") or "")
+    model_dir = _require_model_dir()
+    bundle = next((item for item in list_bundles(model_dir) if item["bundleId"] == bundle_id), None)
+    if bundle is None:
+        return JSONResponse(status_code=404, content={"ok": False, "error": "bundle not found"})
+    if not bundle.get("complete"):
+        missing = [name for name, role in bundle.get("roles", {}).items() if not role.get("ready")]
+        return JSONResponse(
+            status_code=409,
+            content={
+                "ok": False,
+                "error": "bundle_incomplete",
+                "missingRoles": missing,
+            },
+        )
+
     if not ENGINE_LOCK.acquire(blocking=False):
         return JSONResponse(
             status_code=409,
             content={"ok": False, "error": "engine lifecycle operation already in progress"},
         )
     try:
-        if is_engine_process_alive():
+        if is_engine_process_alive() and STATE.loaded_bundle_id == bundle_id:
             return JSONResponse(
                 status_code=200,
                 content={
                     "ok": True,
                     "action": "noop-already-loaded",
+                    "bundleId": bundle_id,
                     "engine": engine_state_dict(),
                 },
             )
-        ok, err = start_engine()
+        ok, err = start_engine(bundle_id=bundle_id)
         if ok:
             return JSONResponse(
                 status_code=200,
                 content={
                     "ok": True,
                     "action": "loaded",
+                    "bundleId": bundle_id,
                     "engine": engine_state_dict(),
                 },
             )
@@ -2066,7 +2017,8 @@ async def admin_load() -> JSONResponse:
             content={
                 "ok": False,
                 "action": "load-failed",
-                "error": "engine_start_failed",
+                "error": err or "engine_start_failed",
+                "bundleId": bundle_id,
                 "engine": engine_state_dict(),
             },
         )
@@ -2125,8 +2077,8 @@ async def admin_unload() -> JSONResponse:
 async def admin_delete_bundle(bundle_id: str) -> JSONResponse:
     model_dir = _require_model_dir()
     bundle_id = require_valid_bundle_id(bundle_id)
-    if read_active_bundle(model_dir) == bundle_id:
-        raise HTTPException(status_code=409, detail="cannot remove active bundle")
+    if STATE.loaded_bundle_id == bundle_id:
+        raise HTTPException(status_code=409, detail="cannot remove loaded bundle")
 
     try:
         target = resolve_bundle_dir(model_dir, bundle_id)

--- a/docker/build/guideants-ai/tts-service/catalog/manifest.json
+++ b/docker/build/guideants-ai/tts-service/catalog/manifest.json
@@ -153,8 +153,10 @@
         "config.json",
         "model.safetensors",
         "tokenizer.json",
+        "tokenizer_config.json",
         "audio_tokenizer/config.json",
-        "audio_tokenizer/model.safetensors"
+        "audio_tokenizer/model.safetensors",
+        "audio_tokenizer/preprocessor_config.json"
       ],
       "layout": "hf_snapshot",
       "format": "safetensors",

--- a/docker/build/guideants-ai/tts-service/tts_service.py
+++ b/docker/build/guideants-ai/tts-service/tts_service.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from guideants_hf.catalog_completeness import catalog_entry_for_directory_name, directory_model_entry_is_complete
 from guideants_hf.catalog_download import download_catalog_entry_files
 from guideants_hf.engine_process import format_engine_exit_error
 from guideants_hf.operations import find_in_flight_operation
@@ -1155,11 +1156,13 @@ def list_model_entries() -> list[dict[str, Any]]:
         if name.startswith("."):
             continue
         full_path = os.path.join(model_dir, name)
+        catalog_entry = catalog_entry_for_directory_name(name, CATALOG["entries"])
         items.append(
             {
                 "modelRef": name,
                 "path": full_path,
                 "isDirectory": os.path.isdir(full_path),
+                "complete": directory_model_entry_is_complete(full_path, catalog_entry),
                 "activeModel": bool(active_model and (active_model == name or active_model == full_path)),
                 "activeTokenizer": False,
             }

--- a/docker/guideants-ai-build.md
+++ b/docker/guideants-ai-build.md
@@ -180,8 +180,18 @@ Supported switches:
 
 - none: prompt for backend, build final GuideAnts AI image
 - `-RebuildBase`: prompt for backend, force rebuild without cache
+- `-AudioCppRef <branch|tag>`: audio.cpp git ref cloned during `audiocpp_server` compile (default `release-0.2`; use `main` for Release 0.3 WIP)
 - `-All`: build GuideAnts AI, PlantUML, MSSQL, and the compose-used WebAPI+UI image
 - `-RebuildBase -All`: full no-cache GuideAnts AI build plus additional images
+
+Example (CUDA 13, fresh compile from `audio.cpp` `main`):
+
+```powershell
+cd docker\build
+.\build_guideants_ai.ps1 -Backend cuda13 -RebuildBase -AudioCppRef main
+cd ..\docker
+docker compose -f docker-compose.cuda.yml up -d --force-recreate guideants-ai
+```
 
 ### Troubleshooting: `/usr/bin/env: 'bash\r': No such file or directory`
 

--- a/docs/ini-driven-warmup-orchestration/fixtures/warmup-desired.fixture.ini
+++ b/docs/ini-driven-warmup-orchestration/fixtures/warmup-desired.fixture.ini
@@ -1,23 +1,18 @@
 version = 1
-revision = 42
+revision = 1
 updated_at_utc = 2026-07-12T19:00:00Z
 
 [llama]
-desired = warm
 router_alias = Qwen3.6-35B-A3B-MTP-GGUF
 
 [SpeechTranscription]
-desired = warm
 model_id = qwen3_asr_0_6b
 
 [Embeddings]
-desired = warm
-model_id = qwen3_embedding_0_6b
+enabled = off
 
 [SpeechSynthesis]
-desired = warm
-model_id = chatterbox
+model_path = chatterbox
 
 [ImageGeneration]
-desired = warm
-bundle_id = flux2-klein-4b-q4ks
+enabled = off

--- a/src/client/src/components/notebook/header-toolbar/AsrToolbarPanel.tsx
+++ b/src/client/src/components/notebook/header-toolbar/AsrToolbarPanel.tsx
@@ -4,6 +4,8 @@ import { textButtonClassName } from '../../../pages/settings/components/shared/A
 import type { ServicePanelCommonProps } from './types';
 import { WORKSPACE_CONTROLS_COPY, serviceStatusHeadline, statusToneClass, toolbarProviderOptionLabel } from './toolbarFormatters';
 import { ServiceLocalRuntimePowerSection } from './ServiceLocalRuntimePowerSection';
+import { ToolbarActionError } from './ToolbarActionError';
+import { useToolbarAsyncAction } from './useToolbarAsyncAction';
 
 export function AsrToolbarPanel({
   service,
@@ -12,6 +14,7 @@ export function AsrToolbarPanel({
   onOpenSettings,
   showWorkspaceCopy = true,
 }: ServicePanelCommonProps) {
+  const { error, run } = useToolbarAsyncAction(setInFlight);
   const activeProviderIsLocal = service.supportsLocalRuntimePower;
   const localProvider = service.providerOptions.find((provider) =>
     provider.providerKind.toLowerCase().includes('local')
@@ -20,37 +23,31 @@ export function AsrToolbarPanel({
     (provider) => provider.providerId !== localProvider?.providerId
   );
 
-  const setProvider = async (providerId: string) => {
-    setInFlight(true);
-    try {
+  const setProvider = (providerId: string) => {
+    void run(async () => {
       const updated = await api.settings.services.updateActiveProvider(service.serviceId, providerId);
       if (updated.activeProviderId !== providerId) {
-        console.error(
-          `[toolbar][asr] provider switch mismatch: requested='${providerId}' actual='${updated.activeProviderId}'`
+        throw new Error(
+          `Provider switch failed: requested '${providerId}' but active is '${updated.activeProviderId}'.`
         );
       }
       await onRefresh();
-    } finally {
-      setInFlight(false);
-    }
+    });
   };
 
-  const setModel = async (modelRef: string) => {
-    setInFlight(true);
-    try {
+  const setModel = (modelRef: string) => {
+    void run(async () => {
       if (localProvider && service.activeProviderId !== localProvider.providerId) {
         const updated = await api.settings.services.updateActiveProvider(service.serviceId, localProvider.providerId);
         if (updated.activeProviderId !== localProvider.providerId) {
-          console.error(
-            `[toolbar][asr] provider switch mismatch: requested='${localProvider.providerId}' actual='${updated.activeProviderId}'`
+          throw new Error(
+            `Provider switch failed: requested '${localProvider.providerId}' but active is '${updated.activeProviderId}'.`
           );
         }
       }
       await api.settings.localModels.selectActive(service.serviceId, modelRef);
       await onRefresh();
-    } finally {
-      setInFlight(false);
-    }
+    });
   };
 
   return (
@@ -60,6 +57,7 @@ export function AsrToolbarPanel({
       {service.blockers.length > 0 && (
         <div className="text-xs text-red-700">{service.blockers[0]}</div>
       )}
+      <ToolbarActionError message={error} />
 
       <div className="space-y-1">
         {cloudModelOptions.map((provider) => {
@@ -72,7 +70,7 @@ export function AsrToolbarPanel({
                 provider.canActivate ? '' : 'opacity-60'
               } ${isCurrentProvider ? 'ring-2 ring-emerald-400/60 bg-emerald-50 font-medium' : ''}`}
               disabled={!provider.canActivate}
-              onClick={() => void setProvider(provider.providerId)}
+              onClick={() => setProvider(provider.providerId)}
               title={provider.canActivate ? undefined : provider.blockers[0] ?? 'Provider is blocked.'}
               role="option"
               aria-selected={isCurrentProvider}
@@ -96,12 +94,14 @@ export function AsrToolbarPanel({
                 model.isComplete ? '' : 'opacity-50'
               } ${isCurrent ? 'ring-2 ring-emerald-400/60 bg-emerald-50 font-medium' : ''}`}
               disabled={!model.isComplete}
-              onClick={() => void setModel(model.modelRef)}
+              onClick={() => setModel(model.modelRef)}
+              title={model.isComplete ? undefined : 'Download is incomplete. Finish the download in Settings.'}
               role="option"
               aria-selected={isCurrent}
             >
               {model.displayLabel}
               {isCurrent && !model.displayLabel.includes('(active)') ? ' ✓' : ''}
+              {!model.isComplete ? ' (incomplete)' : ''}
             </button>
           );
         })}

--- a/src/client/src/components/notebook/header-toolbar/ImageToolbarPanel.tsx
+++ b/src/client/src/components/notebook/header-toolbar/ImageToolbarPanel.tsx
@@ -4,6 +4,8 @@ import { textButtonClassName } from '../../../pages/settings/components/shared/A
 import type { ServicePanelCommonProps } from './types';
 import { WORKSPACE_CONTROLS_COPY, serviceStatusHeadline, statusToneClass, toolbarProviderOptionLabel } from './toolbarFormatters';
 import { ServiceLocalRuntimePowerSection } from './ServiceLocalRuntimePowerSection';
+import { ToolbarActionError } from './ToolbarActionError';
+import { useToolbarAsyncAction } from './useToolbarAsyncAction';
 
 export function ImageToolbarPanel({
   service,
@@ -12,6 +14,7 @@ export function ImageToolbarPanel({
   onOpenSettings,
   showWorkspaceCopy = true,
 }: ServicePanelCommonProps) {
+  const { error, run } = useToolbarAsyncAction(setInFlight);
   const activeProviderIsLocal = service.supportsLocalRuntimePower;
   const localProvider = service.providerOptions.find((provider) =>
     provider.providerKind.toLowerCase().includes('local')
@@ -20,37 +23,31 @@ export function ImageToolbarPanel({
     (provider) => provider.providerId !== localProvider?.providerId
   );
 
-  const setProvider = async (providerId: string) => {
-    setInFlight(true);
-    try {
+  const setProvider = (providerId: string) => {
+    void run(async () => {
       const updated = await api.settings.services.updateActiveProvider(service.serviceId, providerId);
       if (updated.activeProviderId !== providerId) {
-        console.error(
-          `[toolbar][image] provider switch mismatch: requested='${providerId}' actual='${updated.activeProviderId}'`
+        throw new Error(
+          `Provider switch failed: requested '${providerId}' but active is '${updated.activeProviderId}'.`
         );
       }
       await onRefresh();
-    } finally {
-      setInFlight(false);
-    }
+    });
   };
 
-  const setModel = async (modelRef: string) => {
-    setInFlight(true);
-    try {
+  const setModel = (modelRef: string) => {
+    void run(async () => {
       if (localProvider && service.activeProviderId !== localProvider.providerId) {
         const updated = await api.settings.services.updateActiveProvider(service.serviceId, localProvider.providerId);
         if (updated.activeProviderId !== localProvider.providerId) {
-          console.error(
-            `[toolbar][image] provider switch mismatch: requested='${localProvider.providerId}' actual='${updated.activeProviderId}'`
+          throw new Error(
+            `Provider switch failed: requested '${localProvider.providerId}' but active is '${updated.activeProviderId}'.`
           );
         }
       }
       await api.settings.localModels.selectActive(service.serviceId, modelRef);
       await onRefresh();
-    } finally {
-      setInFlight(false);
-    }
+    });
   };
 
   return (
@@ -60,6 +57,7 @@ export function ImageToolbarPanel({
       {service.blockers.length > 0 && (
         <div className="text-xs text-red-700">{service.blockers[0]}</div>
       )}
+      <ToolbarActionError message={error} />
 
       <div className="space-y-1">
         {cloudModelOptions.map((provider) => {
@@ -72,7 +70,7 @@ export function ImageToolbarPanel({
                 provider.canActivate ? '' : 'opacity-60'
               } ${isCurrentProvider ? 'ring-2 ring-emerald-400/60 bg-emerald-50 font-medium' : ''}`}
               disabled={!provider.canActivate}
-              onClick={() => void setProvider(provider.providerId)}
+              onClick={() => setProvider(provider.providerId)}
               title={provider.canActivate ? undefined : provider.blockers[0] ?? 'Provider is blocked.'}
               role="option"
               aria-selected={isCurrentProvider}
@@ -96,12 +94,14 @@ export function ImageToolbarPanel({
                 model.isComplete ? '' : 'opacity-50'
               } ${isCurrent ? 'ring-2 ring-emerald-400/60 bg-emerald-50 font-medium' : ''}`}
               disabled={!model.isComplete}
-              onClick={() => void setModel(model.modelRef)}
+              onClick={() => setModel(model.modelRef)}
+              title={model.isComplete ? undefined : 'Download is incomplete. Finish the download in Settings.'}
               role="option"
               aria-selected={isCurrent}
             >
               {model.displayLabel}
               {isCurrent && !model.displayLabel.includes('(active)') ? ' ✓' : ''}
+              {!model.isComplete ? ' (incomplete)' : ''}
             </button>
           );
         })}

--- a/src/client/src/components/notebook/header-toolbar/ServiceLocalRuntimePowerSection.tsx
+++ b/src/client/src/components/notebook/header-toolbar/ServiceLocalRuntimePowerSection.tsx
@@ -1,6 +1,8 @@
 import { FaCheck, FaPlay, FaSpinner, FaStop } from 'react-icons/fa';
 import { api } from '../../../services/api';
 import type { NotebookToolbarServiceDto } from '../../../types/notebookToolbar';
+import { ToolbarActionError } from './ToolbarActionError';
+import { useToolbarAsyncAction } from './useToolbarAsyncAction';
 
 interface ServiceLocalRuntimePowerSectionProps {
   service: NotebookToolbarServiceDto;
@@ -15,6 +17,7 @@ export function ServiceLocalRuntimePowerSection({
   onRefresh,
   resourceLabel = 'Local model',
 }: ServiceLocalRuntimePowerSectionProps) {
+  const { error, run } = useToolbarAsyncAction(setInFlight);
   const hasPendingOp =
     Boolean(service.inProgressState)
     && service.inProgressState !== 'ready'
@@ -31,25 +34,19 @@ export function ServiceLocalRuntimePowerSection({
       ? 'Loaded'
       : 'Load model';
 
-  const powerOn = async () => {
-    setInFlight(true);
-    try {
+  const powerOn = () => {
+    void run(async () => {
       const request = activeModelRef ? { model_path: activeModelRef } : {};
       await api.settings.localModels.load(service.serviceId, request);
       await onRefresh();
-    } finally {
-      setInFlight(false);
-    }
+    });
   };
 
-  const powerOff = async () => {
-    setInFlight(true);
-    try {
+  const powerOff = () => {
+    void run(async () => {
       await api.settings.localModels.unload(service.serviceId);
       await onRefresh();
-    } finally {
-      setInFlight(false);
-    }
+    });
   };
 
   if (!service.supportsLocalRuntimePower) {
@@ -57,50 +54,53 @@ export function ServiceLocalRuntimePowerSection({
   }
 
   return (
-    <div className="mt-2 flex items-center gap-2 border-t pt-2">
-      <span className="text-xs text-slate-700">{resourceLabel}</span>
-      <button
-        type="button"
-        className={`inline-flex items-center gap-1 rounded border px-2 py-1 text-xs font-medium ${
-          service.localRuntimeOn
-            ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-            : 'border-emerald-300 bg-white text-emerald-700 hover:bg-emerald-50'
-        } disabled:cursor-not-allowed disabled:opacity-70`}
-        aria-label={
-          service.localRuntimeOn
-            ? `Selected local ${resourceLabel.toLowerCase()} is loaded`
-            : `Load selected local ${resourceLabel.toLowerCase()}`
-        }
-        title={
-          service.localRuntimeOn
-            ? `Selected local ${resourceLabel.toLowerCase()} is loaded`
-            : `Load selected local ${resourceLabel.toLowerCase()}`
-        }
-        disabled={hasPendingOp || service.localRuntimeOn}
-        onClick={() => void powerOn()}
-      >
-        {hasPendingOp ? (
-          <FaSpinner className="h-3.5 w-3.5 animate-spin" />
-        ) : service.localRuntimeOn ? (
-          <FaCheck className="h-3.5 w-3.5" />
-        ) : (
-          <FaPlay className="h-3.5 w-3.5" />
-        )}
-        {loadButtonLabel}
-      </button>
-      {service.localRuntimeOn ? (
+    <div className="mt-2 space-y-1 border-t pt-2">
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-slate-700">{resourceLabel}</span>
         <button
           type="button"
-          className="inline-flex items-center gap-1 rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-70"
-          aria-label={`Unload selected local ${resourceLabel.toLowerCase()}`}
-          title={`Unload selected local ${resourceLabel.toLowerCase()}`}
-          disabled={hasPendingOp}
-          onClick={() => void powerOff()}
+          className={`inline-flex items-center gap-1 rounded border px-2 py-1 text-xs font-medium ${
+            service.localRuntimeOn
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+              : 'border-emerald-300 bg-white text-emerald-700 hover:bg-emerald-50'
+          } disabled:cursor-not-allowed disabled:opacity-70`}
+          aria-label={
+            service.localRuntimeOn
+              ? `Selected local ${resourceLabel.toLowerCase()} is loaded`
+              : `Load selected local ${resourceLabel.toLowerCase()}`
+          }
+          title={
+            service.localRuntimeOn
+              ? `Selected local ${resourceLabel.toLowerCase()} is loaded`
+              : `Load selected local ${resourceLabel.toLowerCase()}`
+          }
+          disabled={hasPendingOp || service.localRuntimeOn}
+          onClick={powerOn}
         >
-          <FaStop className="h-3.5 w-3.5" />
-          Unload
+          {hasPendingOp ? (
+            <FaSpinner className="h-3.5 w-3.5 animate-spin" />
+          ) : service.localRuntimeOn ? (
+            <FaCheck className="h-3.5 w-3.5" />
+          ) : (
+            <FaPlay className="h-3.5 w-3.5" />
+          )}
+          {loadButtonLabel}
         </button>
-      ) : null}
+        {service.localRuntimeOn ? (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-70"
+            aria-label={`Unload selected local ${resourceLabel.toLowerCase()}`}
+            title={`Unload selected local ${resourceLabel.toLowerCase()}`}
+            disabled={hasPendingOp}
+            onClick={powerOff}
+          >
+            <FaStop className="h-3.5 w-3.5" />
+            Unload
+          </button>
+        ) : null}
+      </div>
+      <ToolbarActionError message={error} />
     </div>
   );
 }

--- a/src/client/src/components/notebook/header-toolbar/ToolbarActionError.tsx
+++ b/src/client/src/components/notebook/header-toolbar/ToolbarActionError.tsx
@@ -1,0 +1,15 @@
+interface ToolbarActionErrorProps {
+  message: string | null;
+}
+
+export function ToolbarActionError({ message }: ToolbarActionErrorProps) {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <div className="text-xs text-red-700" role="alert">
+      {message}
+    </div>
+  );
+}

--- a/src/client/src/components/notebook/header-toolbar/TtsToolbarPanel.tsx
+++ b/src/client/src/components/notebook/header-toolbar/TtsToolbarPanel.tsx
@@ -4,6 +4,8 @@ import { textButtonClassName } from '../../../pages/settings/components/shared/A
 import type { ServicePanelCommonProps } from './types';
 import { WORKSPACE_CONTROLS_COPY, serviceStatusHeadline, statusToneClass, toolbarProviderOptionLabel } from './toolbarFormatters';
 import { ServiceLocalRuntimePowerSection } from './ServiceLocalRuntimePowerSection';
+import { ToolbarActionError } from './ToolbarActionError';
+import { useToolbarAsyncAction } from './useToolbarAsyncAction';
 
 export function TtsToolbarPanel({
   service,
@@ -12,6 +14,7 @@ export function TtsToolbarPanel({
   onOpenSettings,
   showWorkspaceCopy = true,
 }: ServicePanelCommonProps) {
+  const { error, run } = useToolbarAsyncAction(setInFlight);
   const activeProviderIsLocal = service.supportsLocalRuntimePower;
   const localProvider = service.providerOptions.find((provider) =>
     provider.providerKind.toLowerCase().includes('local')
@@ -20,37 +23,31 @@ export function TtsToolbarPanel({
     (provider) => provider.providerId !== localProvider?.providerId
   );
 
-  const setProvider = async (providerId: string) => {
-    setInFlight(true);
-    try {
+  const setProvider = (providerId: string) => {
+    void run(async () => {
       const updated = await api.settings.services.updateActiveProvider(service.serviceId, providerId);
       if (updated.activeProviderId !== providerId) {
-        console.error(
-          `[toolbar][tts] provider switch mismatch: requested='${providerId}' actual='${updated.activeProviderId}'`
+        throw new Error(
+          `Provider switch failed: requested '${providerId}' but active is '${updated.activeProviderId}'.`
         );
       }
       await onRefresh();
-    } finally {
-      setInFlight(false);
-    }
+    });
   };
 
-  const setModel = async (modelRef: string) => {
-    setInFlight(true);
-    try {
+  const setModel = (modelRef: string) => {
+    void run(async () => {
       if (localProvider && service.activeProviderId !== localProvider.providerId) {
         const updated = await api.settings.services.updateActiveProvider(service.serviceId, localProvider.providerId);
         if (updated.activeProviderId !== localProvider.providerId) {
-          console.error(
-            `[toolbar][tts] provider switch mismatch: requested='${localProvider.providerId}' actual='${updated.activeProviderId}'`
+          throw new Error(
+            `Provider switch failed: requested '${localProvider.providerId}' but active is '${updated.activeProviderId}'.`
           );
         }
       }
       await api.settings.localModels.selectActive(service.serviceId, modelRef);
       await onRefresh();
-    } finally {
-      setInFlight(false);
-    }
+    });
   };
 
   return (
@@ -60,6 +57,7 @@ export function TtsToolbarPanel({
       {service.blockers.length > 0 && (
         <div className="text-xs text-red-700">{service.blockers[0]}</div>
       )}
+      <ToolbarActionError message={error} />
 
       <div className="space-y-1">
         {cloudModelOptions.map((provider) => {
@@ -72,7 +70,7 @@ export function TtsToolbarPanel({
                 provider.canActivate ? '' : 'opacity-60'
               } ${isCurrentProvider ? 'ring-2 ring-emerald-400/60 bg-emerald-50 font-medium' : ''}`}
               disabled={!provider.canActivate}
-              onClick={() => void setProvider(provider.providerId)}
+              onClick={() => setProvider(provider.providerId)}
               title={provider.canActivate ? undefined : provider.blockers[0] ?? 'Provider is blocked.'}
               role="option"
               aria-selected={isCurrentProvider}
@@ -96,12 +94,14 @@ export function TtsToolbarPanel({
                 model.isComplete ? '' : 'opacity-50'
               } ${isCurrent ? 'ring-2 ring-emerald-400/60 bg-emerald-50 font-medium' : ''}`}
               disabled={!model.isComplete}
-              onClick={() => void setModel(model.modelRef)}
+              onClick={() => setModel(model.modelRef)}
+              title={model.isComplete ? undefined : 'Download is incomplete. Finish the download in Settings.'}
               role="option"
               aria-selected={isCurrent}
             >
               {model.displayLabel}
               {isCurrent && !model.displayLabel.includes('(active)') ? ' ✓' : ''}
+              {!model.isComplete ? ' (incomplete)' : ''}
             </button>
           );
         })}

--- a/src/client/src/components/notebook/header-toolbar/__tests__/TtsToolbarPanel.test.tsx
+++ b/src/client/src/components/notebook/header-toolbar/__tests__/TtsToolbarPanel.test.tsx
@@ -262,4 +262,56 @@ describe('TtsToolbarPanel', () => {
     expect(screen.getByRole('button', { name: /load selected local local model/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /load selected local local model/i })).toHaveTextContent('Loading...');
   });
+
+  it('shows API errors when selecting a local model fails', async () => {
+    vi.clearAllMocks();
+    const user = userEvent.setup();
+    vi.mocked(api.settings.localModels.selectActive).mockRejectedValueOnce(
+      Object.assign(new Error('model_id OmniVoice is not in the curated TTS catalog'), { status: 400 })
+    );
+
+    render(
+      <TtsToolbarPanel
+        service={{
+          serviceId: 'SpeechSynthesis',
+          displayName: 'Speech Synthesis',
+          kind: 'tts',
+          status: 'ready',
+          summary: 'ready',
+          activeProviderId: 'SpeechSynthesis.LocalTts.Http',
+          activeProviderLabel: 'Local',
+          supportsLocalRuntimePower: true,
+          localRuntimeOn: false,
+          providerOptions: [
+            {
+              providerId: 'SpeechSynthesis.LocalTts.Http',
+              displayName: 'LocalServiceHosts:SpeechSynthesisBaseUrl',
+              providerKind: 'LocalHttp',
+              canActivate: true,
+              blockers: [],
+              providerSection: 'LocalServiceHosts:SpeechSynthesisBaseUrl',
+              modelId: null,
+            },
+          ],
+          selection: null,
+          blockers: [],
+          localModelOptions: [
+            { modelRef: 'OmniVoice', displayLabel: 'OmniVoice', isComplete: true, isActive: false },
+          ],
+          inProgressOperationId: null,
+          inProgressState: null,
+        }}
+        projectId="p1"
+        notebookId="n1"
+        conversationId="c1"
+        inFlight={false}
+        setInFlight={vi.fn()}
+        onRefresh={vi.fn(async () => {})}
+        onOpenSettings={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('option', { name: /OmniVoice/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('model_id OmniVoice is not in the curated TTS catalog');
+  });
 });

--- a/src/client/src/components/notebook/header-toolbar/useToolbarAsyncAction.ts
+++ b/src/client/src/components/notebook/header-toolbar/useToolbarAsyncAction.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from 'react';
+
+export function formatToolbarActionError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+  if (typeof error === 'string' && error.trim()) {
+    return error.trim();
+  }
+  return 'Action failed. Check the browser console for details.';
+}
+
+export function useToolbarAsyncAction(setInFlight: (value: boolean) => void) {
+  const [error, setError] = useState<string | null>(null);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  const run = useCallback(
+    async (action: () => Promise<void>) => {
+      setError(null);
+      setInFlight(true);
+      try {
+        await action();
+      } catch (err) {
+        const message = formatToolbarActionError(err);
+        console.error('[toolbar]', err);
+        setError(message);
+      } finally {
+        setInFlight(false);
+      }
+    },
+    [setInFlight]
+  );
+
+  return { error, clearError, run };
+}

--- a/src/client/src/pages/settings/editors/image-generation/ImageBundleManager.tsx
+++ b/src/client/src/pages/settings/editors/image-generation/ImageBundleManager.tsx
@@ -70,7 +70,9 @@ type EngineState = {
 
 type BundleListPayload = {
   modelDir?: string;
+  selectedBundleId?: string | null;
   activeBundleId?: string | null;
+  legacyMarkerBundleId?: string | null;
   loadedBundleId?: string | null;
   engine?: EngineState;
   items?: BundleListItem[];
@@ -327,6 +329,10 @@ export function ImageBundleManager({ enabled, onDownloadOperationChange, onRunti
   const engine = payload?.engine;
   const engineAlive = Boolean(engine?.processAlive);
   const loadedBundleId = payload?.loadedBundleId ?? engine?.loadedBundleId ?? null;
+  const selectedBundleId =
+    payload?.selectedBundleId
+    ?? payload?.activeBundleId
+    ?? null;
 
   useEffect(() => {
     if (!onRuntimeReadinessChange) {
@@ -376,7 +382,7 @@ export function ImageBundleManager({ enabled, onDownloadOperationChange, onRunti
       });
       return;
     }
-    if (!payload?.activeBundleId) {
+    if (!selectedBundleId) {
       onRuntimeReadinessChange({
         serviceId: SERVICE_ID,
         ready: false,
@@ -410,7 +416,7 @@ export function ImageBundleManager({ enabled, onDownloadOperationChange, onRunti
     hasInFlightOperation,
     loadedBundleId,
     onRuntimeReadinessChange,
-    payload?.activeBundleId,
+    selectedBundleId,
     phase,
   ]);
 
@@ -556,12 +562,8 @@ export function ImageBundleManager({ enabled, onDownloadOperationChange, onRunti
   };
 
   const handleActivate = async (bundleId: string) => {
-    // Activation triggers a hot-swap on the SD service when an engine is
-    // already loaded (stop current sd-server subprocess, start a new one
-    // against the newly-active bundle). When unloaded, it just updates the
-    // active_bundle.json marker on disk so the next /admin/load picks it up.
-    // Either way, we refresh the list so the Loaded badge and engine state
-    // reflect reality.
+    // Selection is persisted on ServiceModes and written into warmup-desired.ini
+    // by the web API reconcile path; the SD engine loads via orchestrator apply.
     setActionError(null);
     setBusyBundleId(bundleId);
     try {

--- a/src/client/src/pages/settings/editors/speech-synthesis/TtsModelManager.tsx
+++ b/src/client/src/pages/settings/editors/speech-synthesis/TtsModelManager.tsx
@@ -26,6 +26,7 @@ type TtsModelEntry = {
   isDirectory?: boolean;
   activeModel?: boolean;
   activeTokenizer?: boolean;
+  complete?: boolean;
 };
 
 type TtsListPayload = {
@@ -346,9 +347,10 @@ export function TtsModelManager({ enabled, onDownloadOperationChange, onRuntimeR
               ) : null}
               {items.map((m) => {
                 const isLoaded = !!m.activeModel;
+                const isIncomplete = m.complete === false;
                 const isBusyRow =
                   engineBusy !== null && engineBusy.op === 'load' && engineBusy.modelRef === m.modelRef;
-                const disableLoad = engineBusy !== null || hasInFlightDownload || isLoaded;
+                const disableLoad = engineBusy !== null || hasInFlightDownload || isLoaded || isIncomplete;
                 const disableRemove = engineBusy !== null || hasInFlightDownload || isLoaded || !!m.activeTokenizer;
                 return (
                   <tr key={m.modelRef} className="border-t border-gray-100">
@@ -366,7 +368,15 @@ export function TtsModelManager({ enabled, onDownloadOperationChange, onRuntimeR
                             Loaded (tokenizer)
                           </span>
                         ) : null}
-                        {!m.activeModel && !m.activeTokenizer ? <span className="text-gray-500">—</span> : null}
+                        {!m.activeModel && !m.activeTokenizer ? (
+                          isIncomplete ? (
+                            <span className="inline-flex items-center rounded bg-amber-100 px-2 py-0.5 font-semibold text-amber-900">
+                              Incomplete download
+                            </span>
+                          ) : (
+                            <span className="text-gray-500">—</span>
+                          )
+                        ) : null}
                       </div>
                     </td>
                     <td className="px-3 py-2 text-right">
@@ -384,6 +394,8 @@ export function TtsModelManager({ enabled, onDownloadOperationChange, onRuntimeR
                           title={
                             isLoaded
                               ? 'This model is already loaded.'
+                              : isIncomplete
+                              ? 'Download is incomplete. Wait for the download to finish or remove and re-download.'
                               : 'Load this model into the TTS engine.'
                           }
                         />

--- a/src/client/src/pages/settings/editors/speech-transcription/AsrModelManager.tsx
+++ b/src/client/src/pages/settings/editors/speech-transcription/AsrModelManager.tsx
@@ -26,6 +26,7 @@ type AsrModelEntry = {
   isDirectory?: boolean;
   sizeBytes?: number;
   active?: boolean;
+  complete?: boolean;
 };
 
 type AsrListPayload = {
@@ -350,9 +351,10 @@ export function AsrModelManager({ enabled, onDownloadOperationChange, onRuntimeR
                 </tr>
               ) : null}
               {items.map((m) => {
+                const isIncomplete = m.complete === false;
                 const isBusyRow =
                   engineBusy !== null && engineBusy.op === 'load' && engineBusy.modelRef === m.modelRef;
-                const disableLoad = engineBusy !== null || hasInFlightDownload || !!m.active;
+                const disableLoad = engineBusy !== null || hasInFlightDownload || !!m.active || isIncomplete;
                 const disableRemove = engineBusy !== null || hasInFlightDownload || !!m.active;
                 return (
                   <tr key={m.modelRef} className="border-t border-gray-100">
@@ -364,6 +366,10 @@ export function AsrModelManager({ enabled, onDownloadOperationChange, onRuntimeR
                       {m.active ? (
                         <span className="inline-flex items-center rounded bg-blue-100 px-2 py-0.5 font-semibold text-blue-800">
                           Loaded
+                        </span>
+                      ) : isIncomplete ? (
+                        <span className="inline-flex items-center rounded bg-amber-100 px-2 py-0.5 font-semibold text-amber-900">
+                          Incomplete download
                         </span>
                       ) : (
                         <span className="text-gray-500">—</span>
@@ -384,6 +390,8 @@ export function AsrModelManager({ enabled, onDownloadOperationChange, onRuntimeR
                           title={
                             m.active
                               ? 'This model is already loaded.'
+                              : isIncomplete
+                              ? 'Download is incomplete. Wait for the download to finish or remove and re-download.'
                               : 'Load this model into the ASR engine.'
                           }
                         />

--- a/src/server/GuideAntsApi.IntegrationTests/Infrastructure/SettingsRoutingIntegrationTestBase.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Infrastructure/SettingsRoutingIntegrationTestBase.cs
@@ -23,21 +23,57 @@ namespace GuideAntsApi.IntegrationTests.Infrastructure;
 [TestClass]
 public abstract class SettingsRoutingIntegrationTestBase : IAsyncDisposable
 {
+    private static int _sharedFactoryRefCount;
+    private static readonly SemaphoreSlim SharedFactoryGate = new(1, 1);
+
     protected static SettingsRoutingTestWebApplicationFactory? SharedFactory;
     protected HttpClient Client { get; private set; } = null!;
 
     public static async Task InitializeSharedFactoryAsync(TestContext context)
     {
-        SharedFactory = new SettingsRoutingTestWebApplicationFactory();
-        await SharedFactory.InitializeAsync();
+        await SharedFactoryGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (SharedFactory is null)
+            {
+                SharedFactory = new SettingsRoutingTestWebApplicationFactory();
+                await SharedFactory.InitializeAsync().ConfigureAwait(false);
+            }
+
+            Interlocked.Increment(ref _sharedFactoryRefCount);
+        }
+        finally
+        {
+            SharedFactoryGate.Release();
+        }
     }
 
     public static async Task DisposeSharedFactoryAsync()
     {
-        if (SharedFactory != null)
+        await SharedFactoryGate.WaitAsync().ConfigureAwait(false);
+        try
         {
-            await SharedFactory.DisposeAsync();
-            SharedFactory = null;
+            var remaining = Interlocked.Decrement(ref _sharedFactoryRefCount);
+            if (remaining > 0)
+            {
+                return;
+            }
+
+            if (remaining < 0)
+            {
+                Interlocked.Increment(ref _sharedFactoryRefCount);
+                return;
+            }
+
+            if (SharedFactory is not null)
+            {
+                await SharedFactory.DisposeAsync().ConfigureAwait(false);
+                SharedFactory = null;
+            }
+        }
+        finally
+        {
+            SharedFactoryGate.Release();
         }
     }
 

--- a/src/server/GuideAntsApi.IntegrationTests/Services/LlamaCpp/RuntimeConcurrencyTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Services/LlamaCpp/RuntimeConcurrencyTests.cs
@@ -36,13 +36,6 @@ namespace GuideAntsApi.IntegrationTests.Services.LlamaCpp;
 [TestCategory("RuntimeLoadOps")]
 public sealed class RuntimeConcurrencyTests : SettingsRoutingIntegrationTestBase
 {
-    [TestInitialize]
-    public override async Task BaseTestInitialize()
-    {
-        await base.BaseTestInitialize();
-        EnsureRuntimeLoadTestsEnabled();
-    }
-
     [ClassInitialize]
     public static async Task ClassInit(TestContext ctx)
     {
@@ -53,22 +46,6 @@ public sealed class RuntimeConcurrencyTests : SettingsRoutingIntegrationTestBase
     public static async Task ClassCleanup()
     {
         await DisposeSharedFactoryAsync();
-    }
-
-    private static void EnsureRuntimeLoadTestsEnabled()
-    {
-        var flag = Environment.GetEnvironmentVariable("GA_ENABLE_RUNTIME_LOAD_TESTS");
-        var enabled = string.Equals(flag, "1", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(flag, "true", StringComparison.OrdinalIgnoreCase);
-
-        if (enabled)
-        {
-            return;
-        }
-
-        Assert.Inconclusive(
-            "Runtime load/unload integration tests are disabled by default. " +
-            "Set GA_ENABLE_RUNTIME_LOAD_TESTS=1 to enable.");
     }
 
     /// <summary>

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiDesiredStateBuilderTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiDesiredStateBuilderTests.cs
@@ -14,7 +14,7 @@ namespace GuideAntsApi.Tests.Services.Bootstrap;
 public sealed class LocalAiDesiredStateBuilderTests
 {
     [TestMethod]
-    public async Task BuildIniAsync_EmbeddingsLocalWithModel_WritesWarmAndModelId()
+    public async Task BuildIniAsync_EmbeddingsLocalWithModel_WritesWarmAndModelPath()
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -63,10 +63,10 @@ public sealed class LocalAiDesiredStateBuilderTests
         var ini = await builder.BuildIniAsync();
 
         ini.Should().Contain("[Embeddings]");
-        ini.Should().Contain("desired = warm");
-        ini.Should().Contain("model_id = qwen3_embedding_0_6b");
+        ini.Should().Contain("model_path = qwen3_embedding_0_6b");
+        ini.Should().NotContain("desired = warm");
         ini.Should().Contain("[SpeechTranscription]");
-        ini.Should().Contain("desired = idle");
+        ini.Should().Contain("enabled = off");
     }
 
     [TestMethod]
@@ -98,18 +98,90 @@ public sealed class LocalAiDesiredStateBuilderTests
         var ini = await builder.BuildIniAsync(new WarmupDesiredBuildOptions { ForceAuxiliaryIdle = true });
 
         ini.Should().Contain("[Embeddings]");
-        ini.Should().Contain("desired = idle");
-        ini.Should().NotContain("model_id = qwen3_embedding_0_6b");
+        ini.Should().Contain("enabled = off");
+        ini.Should().Contain("model_path = qwen3_embedding_0_6b");
     }
 
     [TestMethod]
-    public async Task BuildIniAsync_ImageGenerationLocal_UsesActiveBundleFromSdAdmin()
+    public async Task BuildIniAsync_ImageGenerationRemoteActive_PreservesLocalBundleIdAsOff()
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["LlamaCpp:BaseUrl"] = "http://localhost:8080/llama-cpp",
-                ["LocalServiceHosts:ImageGenerationBaseUrl"] = "http://guideants-ai:80",
+            })
+            .Build();
+
+        var modeResolver = new FakeServiceModeResolver(
+            (RoutedServiceNames.ImageGeneration, new ServiceMode(
+                ModeId: "ImageGeneration.OpenRouter.Image",
+                ProviderSection: "OpenRouter",
+                ModelId: "recraft/recraft-v4",
+                RequestPresetJson: null,
+                Enabled: true,
+                IsDefault: true)),
+            (RoutedServiceNames.ImageGeneration, new ServiceMode(
+                ModeId: "ImageGeneration.LocalSd.Http",
+                ProviderSection: "LocalServiceHosts:ImageGenerationBaseUrl",
+                ModelId: "flux2-klein-4b-q4ks",
+                RequestPresetJson: null,
+                Enabled: true,
+                IsDefault: false)));
+
+        var builder = new LocalAiDesiredStateBuilder(
+            configuration,
+            new ServiceScopeFactoryStub(),
+            modeResolver,
+            new StubHttpClientFactory(),
+            NullLogger<LocalAiDesiredStateBuilder>.Instance);
+
+        var ini = await builder.BuildIniAsync();
+
+        ini.Should().Contain("[ImageGeneration]");
+        ini.Should().Contain("enabled = off");
+        ini.Should().Contain("bundle_id = flux2-klein-4b-q4ks");
+    }
+
+    [TestMethod]
+    public async Task BuildIniAsync_ImageGenerationLocal_UsesPersistedServiceModeBundleId()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["LlamaCpp:BaseUrl"] = "http://localhost:8080/llama-cpp",
+            })
+            .Build();
+
+        var modeResolver = new FakeServiceModeResolver(
+            (RoutedServiceNames.ImageGeneration, new ServiceMode(
+                ModeId: "default",
+                ProviderSection: "LocalServiceHosts:ImageGenerationBaseUrl",
+                ModelId: "flux2-klein-4b-q4ks",
+                RequestPresetJson: null,
+                Enabled: true,
+                IsDefault: true)));
+
+        var builder = new LocalAiDesiredStateBuilder(
+            configuration,
+            new ServiceScopeFactoryStub(),
+            modeResolver,
+            new StubHttpClientFactory(),
+            NullLogger<LocalAiDesiredStateBuilder>.Instance);
+
+        var ini = await builder.BuildIniAsync();
+
+        ini.Should().Contain("[ImageGeneration]");
+        ini.Should().Contain("bundle_id = flux2-klein-4b-q4ks");
+        ini.Should().NotContain("desired = warm");
+    }
+
+    [TestMethod]
+    public async Task BuildIniAsync_ImageGenerationLocalWithoutModelId_WritesIdle()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["LlamaCpp:BaseUrl"] = "http://localhost:8080/llama-cpp",
             })
             .Build();
 
@@ -122,30 +194,18 @@ public sealed class LocalAiDesiredStateBuilderTests
                 Enabled: true,
                 IsDefault: true)));
 
-        var httpFactory = new StubHttpClientFactory(
-            new Dictionary<string, HttpResponseMessage>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["http://guideants-ai:80/sd/admin/bundles"] = new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(
-                        """{"activeBundleId":"flux2-klein-4b-q4ks","items":[]}""",
-                        Encoding.UTF8,
-                        "application/json"),
-                },
-            });
-
         var builder = new LocalAiDesiredStateBuilder(
             configuration,
             new ServiceScopeFactoryStub(),
             modeResolver,
-            httpFactory,
+            new StubHttpClientFactory(),
             NullLogger<LocalAiDesiredStateBuilder>.Instance);
 
         var ini = await builder.BuildIniAsync();
 
         ini.Should().Contain("[ImageGeneration]");
-        ini.Should().Contain("desired = warm");
-        ini.Should().Contain("bundle_id = flux2-klein-4b-q4ks");
+        ini.Should().Contain("enabled = off");
+        ini.Should().NotContain("bundle_id =");
     }
 
     private sealed class StubHttpClientFactory : IHttpClientFactory

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
@@ -388,8 +388,20 @@ public sealed class LocalAiStartupWarmupServiceTests
             return Task.FromResult(_localMode);
         }
 
-        public Task<IReadOnlyList<ServiceMode>> GetModesAsync(string serviceName, CancellationToken cancellationToken = default) =>
-            throw new NotSupportedException();
+        public Task<IReadOnlyList<ServiceMode>> GetModesAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (!string.Equals(serviceName, _serviceName, StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult<IReadOnlyList<ServiceMode>>(Array.Empty<ServiceMode>());
+            }
+
+            if (!_gate.Activated)
+            {
+                return Task.FromResult<IReadOnlyList<ServiceMode>>(Array.Empty<ServiceMode>());
+            }
+
+            return Task.FromResult<IReadOnlyList<ServiceMode>>(new[] { _localMode });
+        }
     }
 
     private static IHttpClientFactory CreateHttpClientFactory() =>

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
@@ -64,12 +64,13 @@ public sealed class LocalAiStartupWarmupServiceTests
             builder,
             orchestration.Object,
             modeResolver,
+            CreateHttpClientFactory(),
             NullLogger<LocalAiStartupWarmupService>.Instance);
 
         await service.SyncDesiredAndApplyAsync(waitForCompletion: false);
 
         capturedIni.Should().NotBeNullOrWhiteSpace();
-        capturedIni.Should().Contain("model_id = qwen3_embedding_0_6b");
+        capturedIni.Should().Contain("model_path = qwen3_embedding_0_6b");
         orchestration.VerifyAll();
     }
 
@@ -100,6 +101,7 @@ public sealed class LocalAiStartupWarmupServiceTests
             builder.Object,
             orchestration.Object,
             modeResolver,
+            CreateHttpClientFactory(),
             NullLogger<LocalAiStartupWarmupService>.Instance);
 
         var result = await service.ReconcileLocalServiceAsync(
@@ -107,6 +109,103 @@ public sealed class LocalAiStartupWarmupServiceTests
             requestedModelRef: "qwen3_asr_0_6b");
 
         result.Outcome.Should().Be(LocalServiceReconcileOutcome.NotActiveProvider);
+    }
+
+    [TestMethod]
+    public async Task ReconcileLocalServiceAsync_PersistsFolderRefVerbatim()
+    {
+        string? capturedIni = null;
+        var orchestration = new Mock<ILocalAiWarmupOrchestrationClient>(MockBehavior.Strict);
+        orchestration
+            .Setup(c => c.PutDesiredAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .Callback<string, int?, CancellationToken>((ini, _, _) => capturedIni = ini)
+            .ReturnsAsync(new WarmupDesiredWriteResult(Revision: 2, Sha256: "abc", Changed: true));
+        orchestration
+            .Setup(c => c.ApplyAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WarmupApplyResult(
+                Ok: true,
+                Noop: false,
+                Continue: false,
+                Started: true,
+                DesiredRevision: 2,
+                AppliedRevision: 0,
+                ApplyStatus: "applying"));
+        orchestration
+            .Setup(c => c.GetStatusAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WarmupStatusDocument(
+                SchemaVersion: 1,
+                DesiredRevision: 2,
+                AppliedRevision: 2,
+                InProgressRevision: null,
+                ApplyStatus: "applied",
+                ApplyError: null,
+                DesiredSha256: "abc",
+                WrittenAt: "2026-07-12T19:00:00Z",
+                Services: new Dictionary<string, WarmupServiceStatus>(StringComparer.Ordinal)
+                {
+                    [RoutedServiceNames.SpeechSynthesis] = new WarmupServiceStatus(
+                        Desired: "on",
+                        Applied: "on",
+                        Phase: "ready",
+                        Error: null,
+                        PlanRef: "OmniVoice",
+                        RouterAlias: null,
+                        ModelId: "OmniVoice",
+                        BundleId: null),
+                }));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["LlamaCpp:BaseUrl"] = "http://localhost:8080/llama-cpp",
+            })
+            .Build();
+
+        var routingGate = new RoutingActivationGate();
+        routingGate.Activate();
+        var modeResolver = new GatedServiceModeResolver(
+            routingGate,
+            RoutedServiceNames.SpeechSynthesis,
+            new ServiceMode(
+                ModeId: "local",
+                ProviderSection: "LocalServiceHosts:SpeechSynthesisBaseUrl",
+                ModelId: "chatterbox",
+                RequestPresetJson: null,
+                Enabled: true,
+                IsDefault: true));
+
+        var settingsMock = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        settingsMock
+            .Setup(s => s.SetServiceModeModelIdAsync(
+                RoutedServiceNames.SpeechSynthesis,
+                "OmniVoice",
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback(() => modeResolver.SetModelId("OmniVoice"));
+
+        var builder = new LocalAiDesiredStateBuilder(
+            configuration,
+            new ServiceScopeFactoryStub(settingsMock.Object),
+            modeResolver,
+            CreateHttpClientFactory(),
+            NullLogger<LocalAiDesiredStateBuilder>.Instance);
+
+        var service = new LocalAiStartupWarmupService(
+            configuration,
+            new ServiceScopeFactoryStub(settingsMock.Object),
+            builder,
+            orchestration.Object,
+            modeResolver,
+            CreateHttpClientFactory(),
+            NullLogger<LocalAiStartupWarmupService>.Instance);
+
+        var result = await service.ReconcileLocalServiceAsync(
+            RoutedServiceNames.SpeechSynthesis,
+            requestedModelRef: "OmniVoice");
+
+        result.Outcome.Should().Be(LocalServiceReconcileOutcome.Warm);
+        capturedIni.Should().Contain("model_path = OmniVoice");
+        settingsMock.VerifyAll();
     }
 
     [TestMethod]
@@ -140,10 +239,11 @@ public sealed class LocalAiStartupWarmupServiceTests
                 Services: new Dictionary<string, WarmupServiceStatus>(StringComparer.Ordinal)
                 {
                     [ImageGenerationOptions.SectionName] = new WarmupServiceStatus(
-                        Desired: "warm",
-                        Applied: "warm",
+                        Desired: "on",
+                        Applied: "on",
                         Phase: "ready",
                         Error: null,
+                        PlanRef: "flux2-klein-4b-q4ks",
                         RouterAlias: null,
                         ModelId: null,
                         BundleId: "flux2-klein-4b-q4ks"),
@@ -187,6 +287,13 @@ public sealed class LocalAiStartupWarmupServiceTests
                 Providers: [],
                 Readiness: new ServiceEditorReadinessDto("ready", [], [])))
             .Callback(() => routingGate.Activate());
+        settingsMock
+            .Setup(s => s.SetServiceModeModelIdAsync(
+                ImageGenerationOptions.SectionName,
+                "flux2-klein-4b-q4ks",
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback(() => modeResolver.SetModelId("flux2-klein-4b-q4ks"));
 
         var builder = new LocalAiDesiredStateBuilder(
             configuration,
@@ -201,6 +308,7 @@ public sealed class LocalAiStartupWarmupServiceTests
             builder,
             orchestration.Object,
             modeResolver,
+            CreateHttpClientFactory(),
             NullLogger<LocalAiStartupWarmupService>.Instance);
 
         var result = await service.ReconcileLocalServiceAsync(
@@ -253,7 +361,7 @@ public sealed class LocalAiStartupWarmupServiceTests
     {
         private readonly RoutingActivationGate _gate;
         private readonly string _serviceName;
-        private readonly ServiceMode _localMode;
+        private ServiceMode _localMode;
 
         public GatedServiceModeResolver(RoutingActivationGate gate, string serviceName, ServiceMode localMode)
         {
@@ -261,6 +369,9 @@ public sealed class LocalAiStartupWarmupServiceTests
             _serviceName = serviceName;
             _localMode = localMode;
         }
+
+        public void SetModelId(string modelId) =>
+            _localMode = _localMode with { ModelId = modelId };
 
         public Task<ServiceMode> ResolveAsync(string serviceName, string? modeId, CancellationToken cancellationToken = default)
         {

--- a/src/server/GuideAntsApi.Tests/Services/NotebookHeaderToolbarServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/NotebookHeaderToolbarServiceTests.cs
@@ -561,7 +561,7 @@ public sealed class NotebookHeaderToolbarServiceTests
                 {
                     return JsonResponse(
                         HttpStatusCode.OK,
-                        """[{"model_id":"chatterbox","activeModel":true,"model_path":"/models/chatterbox"}]""");
+                        """[{"model_id":"chatterbox","activeModel":true,"model_path":"/models/chatterbox","complete":true}]""");
                 }
 
                 return new HttpResponseMessage(HttpStatusCode.NotFound);
@@ -613,7 +613,7 @@ public sealed class NotebookHeaderToolbarServiceTests
                 {
                     return JsonResponse(
                         HttpStatusCode.OK,
-                        """[{"model_id":"chatterbox","activeModel":true,"model_path":"/models/chatterbox"}]""");
+                        """[{"model_id":"chatterbox","activeModel":true,"model_path":"/models/chatterbox","complete":true}]""");
                 }
 
                 return new HttpResponseMessage(HttpStatusCode.NotFound);
@@ -625,6 +625,63 @@ public sealed class NotebookHeaderToolbarServiceTests
         tts.Status.Should().Be("requiresLoad");
         tts.InProgressState.Should().BeNull();
         tts.Summary.Should().Contain("Load the local model");
+    }
+
+    [TestMethod]
+    public async Task GetToolbarAsync_MarksIncompleteLocalTtsModels_WhenInventoryReportsIncomplete()
+    {
+        await using var db = CreateDb();
+        var notebook = await SeedNotebookAsync(db);
+
+        var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        settings
+            .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SettingsModelDto>());
+        settings
+            .Setup(x => x.GetServiceEditorStateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string serviceId, CancellationToken _) =>
+                string.Equals(serviceId, RoutedServiceNames.SpeechSynthesis, StringComparison.Ordinal)
+                    ? CreateLocalServiceState(
+                        RoutedServiceNames.SpeechSynthesis,
+                        ServiceProviderIds.SpeechSynthesisLocalTtsHttp,
+                        "LocalServiceHosts:SpeechSynthesisBaseUrl")
+                    : CreateReadyServiceState(serviceId));
+
+        var sut = CreateSut(
+            db,
+            notebook.Id,
+            settings.Object,
+            httpClientFactory: CreateHttpClientFactory(request =>
+            {
+                if (request.RequestUri?.AbsolutePath.Contains("/ready", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    return JsonResponse(
+                        HttpStatusCode.ServiceUnavailable,
+                        """{"ready":false,"loaded":false,"loading":false,"warmupEnabled":true,"warmupSucceeded":false}""");
+                }
+
+                if (request.RequestUri?.AbsolutePath.Contains("/admin/models", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                        """
+                        [
+                          {"modelRef":"chatterbox","activeModel":true,"complete":true},
+                          {"modelRef":"OmniVoice","activeModel":false,"complete":false}
+                        ]
+                        """);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }));
+
+        var toolbar = await sut.GetToolbarAsync(notebook.Id, conversationId: null);
+        var tts = toolbar.Services.Single(service => service.Kind == "tts");
+
+        tts.LocalModelOptions.Should().Contain(option =>
+            option.ModelRef == "chatterbox" && option.IsComplete);
+        tts.LocalModelOptions.Should().Contain(option =>
+            option.ModelRef == "OmniVoice" && !option.IsComplete);
     }
 
     private static async Task<Notebook> SeedNotebookAsync(ApplicationDbContext db)

--- a/src/server/GuideAntsApi.Tests/TestUtils/FakeServiceModeResolver.cs
+++ b/src/server/GuideAntsApi.Tests/TestUtils/FakeServiceModeResolver.cs
@@ -3,20 +3,22 @@ using GuideAntsApi.Services.Routing;
 namespace GuideAntsApi.Tests.TestUtils;
 
 /// <summary>
-/// Test fake for <see cref="IServiceModeResolver"/> that returns a preconfigured
-/// <see cref="ServiceMode"/> per service name. Use to drive provider-routed
+/// Test fake for <see cref="IServiceModeResolver"/> that returns preconfigured
+/// <see cref="ServiceMode"/> rows per service name. Use to drive provider-routed
 /// services from unit tests without the full database-backed resolver.
 /// </summary>
 internal sealed class FakeServiceModeResolver : IServiceModeResolver
 {
-    private readonly Dictionary<string, ServiceMode> _modesByService;
+    private readonly Dictionary<string, IReadOnlyList<ServiceMode>> _modesByService;
 
     public FakeServiceModeResolver(params (string ServiceName, ServiceMode Mode)[] modes)
     {
-        _modesByService = modes.ToDictionary(
-            m => m.ServiceName,
-            m => m.Mode,
-            StringComparer.OrdinalIgnoreCase);
+        _modesByService = modes
+            .GroupBy(m => m.ServiceName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<ServiceMode>)g.Select(x => x.Mode).ToList(),
+                StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -35,21 +37,31 @@ internal sealed class FakeServiceModeResolver : IServiceModeResolver
 
     public Task<ServiceMode> ResolveAsync(string serviceName, string? modeId, CancellationToken cancellationToken = default)
     {
-        if (!_modesByService.TryGetValue(serviceName, out var mode))
+        if (!_modesByService.TryGetValue(serviceName, out var modes) || modes.Count == 0)
         {
             throw RoutingException.ModeNotFound(serviceName, modeId ?? "default");
         }
 
-        return Task.FromResult(mode);
+        if (string.IsNullOrWhiteSpace(modeId))
+        {
+            var selected = modes.FirstOrDefault(m => m.IsDefault && m.Enabled)
+                ?? modes.FirstOrDefault(m => m.IsDefault)
+                ?? modes[0];
+            return Task.FromResult(selected);
+        }
+
+        var explicitMode = modes.FirstOrDefault(m => string.Equals(m.ModeId, modeId, StringComparison.Ordinal))
+            ?? throw RoutingException.ModeNotFound(serviceName, modeId);
+        return Task.FromResult(explicitMode);
     }
 
     public Task<IReadOnlyList<ServiceMode>> GetModesAsync(string serviceName, CancellationToken cancellationToken = default)
     {
-        if (!_modesByService.TryGetValue(serviceName, out var mode))
+        if (!_modesByService.TryGetValue(serviceName, out var modes))
         {
             return Task.FromResult<IReadOnlyList<ServiceMode>>(Array.Empty<ServiceMode>());
         }
 
-        return Task.FromResult<IReadOnlyList<ServiceMode>>(new[] { mode });
+        return Task.FromResult(modes);
     }
 }

--- a/src/server/GuideAntsApi/Endpoints/Settings/ServiceLocalModelListEnricher.cs
+++ b/src/server/GuideAntsApi/Endpoints/Settings/ServiceLocalModelListEnricher.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using GuideAntsApi.Endpoints;
+using GuideAntsApi.Options;
+using GuideAntsApi.Services.Routing;
+using GuideAntsApi.Settings;
+using Microsoft.AspNetCore.Http;
+
+namespace GuideAntsApi.Endpoints.Settings;
+
+/// <summary>
+/// Injects ServiceModes selection into proxied local inventory responses so UI
+/// and operators never treat engine disk markers as the selected model/bundle.
+/// </summary>
+internal static class ServiceLocalModelListEnricher
+{
+    public static async Task<IResult> ProxyAndEnrichImageBundlesAsync(
+        HttpClient httpClient,
+        HttpRequestMessage request,
+        IApplicationSettingsService settings,
+        CancellationToken cancellationToken)
+    {
+        var upstreamTarget = request.RequestUri?.ToString() ?? string.Empty;
+        HttpResponseMessage response;
+        try
+        {
+            response = await httpClient.SendAsync(request, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            return Results.Json(
+                new LocalServiceAdminRouting.UpstreamProxyEnvelope(
+                    Error: $"Upstream request to {upstreamTarget} failed: {ex.Message}",
+                    UpstreamTarget: upstreamTarget,
+                    UpstreamStatus: 0,
+                    UpstreamStatusText: "NetworkError",
+                    UpstreamContentType: string.Empty,
+                    UpstreamBody: string.Empty),
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        using (response)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return Results.Json(
+                    new LocalServiceAdminRouting.UpstreamProxyEnvelope(
+                        Error: "Upstream local service returned a non-success status.",
+                        UpstreamTarget: upstreamTarget,
+                        UpstreamStatus: (int)response.StatusCode,
+                        UpstreamStatusText: response.StatusCode.ToString(),
+                        UpstreamContentType: response.Content.Headers.ContentType?.MediaType ?? string.Empty,
+                        UpstreamBody: body),
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+
+            var selectedBundleId = await ResolveSelectedImageBundleIdAsync(
+                    settings,
+                    body,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            var enriched = ApplyImageBundleSelection(body, selectedBundleId);
+            return Results.Content(enriched, "application/json");
+        }
+    }
+
+    private static async Task<string?> ResolveSelectedImageBundleIdAsync(
+        IApplicationSettingsService settings,
+        string upstreamBody,
+        CancellationToken cancellationToken)
+    {
+        var modes = await settings
+            .GetServiceModesAsync(RoutedServiceNames.ImageGeneration, cancellationToken)
+            .ConfigureAwait(false);
+        var localSection = $"{LocalServiceHostsOptions.SectionName}:ImageGenerationBaseUrl";
+        var localMode = modes.FirstOrDefault(mode =>
+            string.Equals(mode.ProviderSection, localSection, StringComparison.OrdinalIgnoreCase));
+        var selected = localMode?.ModelId?.Trim();
+        if (!string.IsNullOrWhiteSpace(selected))
+        {
+            return selected;
+        }
+
+        var legacyMarker = TryReadLegacyActiveBundleMarker(upstreamBody);
+        if (string.IsNullOrWhiteSpace(legacyMarker))
+        {
+            return null;
+        }
+
+        await settings
+            .SetServiceModeModelIdAsync(RoutedServiceNames.ImageGeneration, legacyMarker, cancellationToken)
+            .ConfigureAwait(false);
+        return legacyMarker;
+    }
+
+    private static string? TryReadLegacyActiveBundleMarker(string upstreamBody)
+    {
+        try
+        {
+            var root = JsonNode.Parse(upstreamBody) as JsonObject;
+            var marker = root?["legacyMarkerBundleId"]?.GetValue<string>()?.Trim()
+                ?? root?["activeBundleId"]?.GetValue<string>()?.Trim();
+            return string.IsNullOrWhiteSpace(marker) ? null : marker;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string ApplyImageBundleSelection(string upstreamBody, string? selectedBundleId)
+    {
+        var root = JsonNode.Parse(upstreamBody) as JsonObject ?? new JsonObject();
+        root["selectedBundleId"] = selectedBundleId;
+        root["activeBundleId"] = selectedBundleId;
+
+        if (root["items"] is JsonArray items)
+        {
+            foreach (var itemNode in items)
+            {
+                if (itemNode is not JsonObject item)
+                {
+                    continue;
+                }
+
+                var bundleId = item["bundleId"]?.GetValue<string>();
+                var isSelected = !string.IsNullOrWhiteSpace(selectedBundleId)
+                    && !string.IsNullOrWhiteSpace(bundleId)
+                    && string.Equals(bundleId, selectedBundleId, StringComparison.Ordinal);
+                item["active"] = isSelected;
+            }
+        }
+
+        return root.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+    }
+}

--- a/src/server/GuideAntsApi/Endpoints/Settings/SettingsServiceLocalModelsEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/Settings/SettingsServiceLocalModelsEndpoints.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using GuideAntsApi.Services.Bootstrap;
 using GuideAntsApi.Services.HuggingFace;
+using GuideAntsApi.Settings;
 
 namespace GuideAntsApi.Endpoints.Settings;
 
@@ -15,6 +16,7 @@ public static class SettingsServiceLocalModelsEndpoints
             string serviceId,
             IHttpClientFactory httpClientFactory,
             IConfiguration configuration,
+            IApplicationSettingsService settings,
             CancellationToken cancellationToken) =>
         {
             var adminBase = LocalServiceAdminRouting.ResolveAdminBase(serviceId, configuration);
@@ -27,6 +29,15 @@ public static class SettingsServiceLocalModelsEndpoints
                 ? "/admin/bundles"
                 : "/admin/models";
             using var request = new HttpRequestMessage(HttpMethod.Get, $"{adminBase}{path}");
+            if (string.Equals(serviceId, "ImageGeneration", StringComparison.Ordinal))
+            {
+                return await ServiceLocalModelListEnricher.ProxyAndEnrichImageBundlesAsync(
+                    httpClientFactory.CreateClient(),
+                    request,
+                    settings,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
             return await LocalServiceAdminRouting.ProxyAsync(
                 httpClientFactory.CreateClient(), request, cancellationToken);
         })

--- a/src/server/GuideAntsApi/Endpoints/Settings/SettingsServiceLocalModelsEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/Settings/SettingsServiceLocalModelsEndpoints.cs
@@ -252,10 +252,11 @@ public static class SettingsServiceLocalModelsEndpoints
         // requested while the service is not the active provider is refused (409), per
         // the rule that a non-active local service must load nothing.
         //
-        //  - ASR / TTS / Embeddings: optional model_path selects a specific downloaded
-        //    model; omit it to (re)load the resolved active/default model.
-        //  - Image Generation: the request body is ignored; the active bundle on disk is
-        //    authoritative (set via /local-models/{bundleId}/select-active).
+        //  - ASR / TTS / Embeddings: optional model_path or model_id selects a specific
+        //    downloaded model folder; the ref is persisted verbatim on ServiceModes
+        //    and written into warmup-desired.ini as model_path before apply.
+        //  - Image Generation: bundle id is persisted on ServiceModes and required in
+        //    warmup-desired.ini when desired=warm (set via select-active).
         serviceEditorsGroup.MapPost("/{serviceId}/local-models/load", async (
             string serviceId,
             [FromBody] JsonElement payload,

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiDesiredStateBuilder.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiDesiredStateBuilder.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using GuideAntsApi.Configuration;
 using GuideAntsApi.DataModel;
 using GuideAntsApi.Endpoints;
@@ -14,11 +13,9 @@ public sealed class WarmupDesiredBuildOptions
 {
     public IReadOnlyDictionary<string, string>? ServiceDesiredOverrides { get; init; }
 
-    public IReadOnlyDictionary<string, string>? ModelIdOverrides { get; init; }
-
     public string? LlamaRouterAliasOverride { get; init; }
 
-    /// <summary>When true, all auxiliary services are written as idle regardless of routing.</summary>
+    /// <summary>When true, all auxiliary services are written as off regardless of routing.</summary>
     public bool ForceAuxiliaryIdle { get; init; }
 }
 
@@ -95,12 +92,11 @@ public sealed class LocalAiDesiredStateBuilder : ILocalAiDesiredStateBuilder
 
         if (string.IsNullOrWhiteSpace(alias))
         {
-            builder.AppendLine("desired = idle");
+            builder.AppendLine("enabled = off");
             builder.AppendLine();
             return;
         }
 
-        builder.AppendLine("desired = warm");
         builder.AppendLine($"router_alias = {alias}");
         builder.AppendLine();
     }
@@ -113,48 +109,66 @@ public sealed class LocalAiDesiredStateBuilder : ILocalAiDesiredStateBuilder
     {
         builder.AppendLine($"[{serviceId}]");
 
-        if (options.ForceAuxiliaryIdle)
-        {
-            builder.AppendLine("desired = idle");
-            builder.AppendLine();
-            return;
-        }
+        var persistedLocalRef = await ResolvePersistedLocalModeModelRefAsync(serviceId, cancellationToken)
+            .ConfigureAwait(false);
 
         if (options.ServiceDesiredOverrides is not null
             && options.ServiceDesiredOverrides.TryGetValue(serviceId, out var desiredOverride)
             && !string.IsNullOrWhiteSpace(desiredOverride))
         {
             var normalized = desiredOverride.Trim().ToLowerInvariant();
-            builder.AppendLine($"desired = {normalized}");
-            if (normalized == "warm")
+            if (normalized is "warm" or "on")
             {
-                var modelRef = await ResolveAuxiliaryModelRefAsync(serviceId, options, cancellationToken)
-                    .ConfigureAwait(false);
-                AppendAuxiliaryWarmModelRef(builder, serviceId, modelRef);
+                AppendAuxiliaryExecutionPlan(
+                    builder,
+                    serviceId,
+                    loadRef: persistedLocalRef,
+                    routingWarm: true);
+            }
+            else
+            {
+                AppendAuxiliaryExecutionPlan(
+                    builder,
+                    serviceId,
+                    loadRef: persistedLocalRef,
+                    routingWarm: false);
             }
 
             builder.AppendLine();
             return;
         }
 
-        var routing = await ResolveLocalRoutingDesiredStateAsync(serviceId, cancellationToken)
-            .ConfigureAwait(false);
-        if (routing == LocalRoutingDesiredState.Warm)
-        {
-            var modelRef = await ResolveAuxiliaryModelRefAsync(serviceId, options, cancellationToken)
-                .ConfigureAwait(false);
-            builder.AppendLine("desired = warm");
-            AppendAuxiliaryWarmModelRef(builder, serviceId, modelRef);
-        }
-        else
-        {
-            builder.AppendLine("desired = idle");
-        }
+        var routingWarm = !options.ForceAuxiliaryIdle
+            && await IsLocalRoutingWarmAsync(serviceId, cancellationToken).ConfigureAwait(false);
 
+        AppendAuxiliaryExecutionPlan(
+            builder,
+            serviceId,
+            loadRef: persistedLocalRef,
+            routingWarm: routingWarm);
         builder.AppendLine();
     }
 
-    private static void AppendAuxiliaryWarmModelRef(StringBuilder builder, string serviceId, string? modelRef)
+    private static void AppendAuxiliaryExecutionPlan(
+        StringBuilder builder,
+        string serviceId,
+        string? loadRef,
+        bool routingWarm)
+    {
+        if (routingWarm && !string.IsNullOrWhiteSpace(loadRef))
+        {
+            AppendAuxiliaryLoadRef(builder, serviceId, loadRef);
+            return;
+        }
+
+        builder.AppendLine("enabled = off");
+        if (!string.IsNullOrWhiteSpace(loadRef))
+        {
+            AppendAuxiliaryLoadRef(builder, serviceId, loadRef);
+        }
+    }
+
+    private static void AppendAuxiliaryLoadRef(StringBuilder builder, string serviceId, string? modelRef)
     {
         if (string.IsNullOrWhiteSpace(modelRef))
         {
@@ -167,104 +181,55 @@ public sealed class LocalAiDesiredStateBuilder : ILocalAiDesiredStateBuilder
         }
         else
         {
-            builder.AppendLine($"model_id = {modelRef}");
+            builder.AppendLine($"model_path = {modelRef}");
         }
     }
 
-    private async Task<string?> ResolveAuxiliaryModelRefAsync(
+    private async Task<string?> ResolvePersistedLocalModeModelRefAsync(
         string serviceId,
-        WarmupDesiredBuildOptions options,
         CancellationToken cancellationToken)
     {
-        if (options.ModelIdOverrides is not null
-            && options.ModelIdOverrides.TryGetValue(serviceId, out var overrideRef)
-            && !string.IsNullOrWhiteSpace(overrideRef))
-        {
-            return overrideRef.Trim();
-        }
-
-        if (string.Equals(serviceId, RoutedServiceNames.ImageGeneration, StringComparison.Ordinal))
-        {
-            return await ResolveImageGenerationBundleRefAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return await ResolveConfiguredServiceModeModelRefAsync(serviceId, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    private async Task<string?> ResolveImageGenerationBundleRefAsync(CancellationToken cancellationToken)
-    {
-        var fromMode = await ResolveConfiguredServiceModeModelRefAsync(
-                RoutedServiceNames.ImageGeneration,
-                cancellationToken)
-            .ConfigureAwait(false);
-        if (!string.IsNullOrWhiteSpace(fromMode))
-        {
-            return fromMode;
-        }
-
-        // Local SD marks the active bundle on disk; ServiceModes often has no ModelId.
-        var adminBase = LocalServiceAdminRouting.ResolveAdminBase(
-            RoutedServiceNames.ImageGeneration,
-            _configuration);
-        if (adminBase is null)
+        var localProviderSection = ResolveLocalProviderSection(serviceId);
+        if (localProviderSection is null)
         {
             return null;
         }
 
         try
         {
-            using var client = _httpClientFactory.CreateClient();
-            client.Timeout = TimeSpan.FromSeconds(30);
-            using var response = await client
-                .GetAsync($"{adminBase.TrimEnd('/')}/admin/bundles", cancellationToken)
+            var modes = await _serviceModeResolver
+                .GetModesAsync(serviceId, cancellationToken)
                 .ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogDebug(
-                    "ImageGeneration bundle inventory returned {StatusCode}.",
-                    (int)response.StatusCode);
-                return null;
-            }
-
-            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            using var document = JsonDocument.Parse(json);
-            if (document.RootElement.TryGetProperty("activeBundleId", out var active)
-                && active.ValueKind == JsonValueKind.String)
-            {
-                var bundleId = active.GetString()?.Trim();
-                return string.IsNullOrWhiteSpace(bundleId) ? null : bundleId;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed resolving active ImageGeneration bundle from local SD admin.");
-        }
-
-        return null;
-    }
-
-    private async Task<string?> ResolveConfiguredServiceModeModelRefAsync(
-        string serviceId,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            var mode = await _serviceModeResolver
-                .ResolveAsync(serviceId, modeId: null, cancellationToken)
-                .ConfigureAwait(false);
-            var modelId = mode.ModelId?.Trim();
+            var localMode = modes.FirstOrDefault(mode =>
+                string.Equals(mode.ProviderSection, localProviderSection, StringComparison.OrdinalIgnoreCase));
+            var modelId = localMode?.ModelId?.Trim();
             return string.IsNullOrWhiteSpace(modelId) ? null : modelId;
         }
         catch (Exception ex)
         {
             _logger.LogDebug(
                 ex,
-                "Failed resolving configured ServiceModes ModelId for service '{ServiceId}'.",
+                "Failed resolving persisted local ServiceModes ModelId for service '{ServiceId}'.",
                 serviceId);
             return null;
         }
     }
+
+    private async Task<bool> IsLocalRoutingWarmAsync(
+        string serviceId,
+        CancellationToken cancellationToken) =>
+        await ResolveLocalRoutingDesiredStateAsync(serviceId, cancellationToken).ConfigureAwait(false)
+        == LocalRoutingDesiredState.Warm;
+
+    private static string? ResolveLocalProviderSection(string serviceId) =>
+        serviceId switch
+        {
+            RoutedServiceNames.SpeechTranscription => $"{LocalServiceHostsOptions.SectionName}:SpeechTranscriptionBaseUrl",
+            RoutedServiceNames.Embeddings => $"{LocalServiceHostsOptions.SectionName}:EmbeddingsBaseUrl",
+            RoutedServiceNames.SpeechSynthesis => $"{LocalServiceHostsOptions.SectionName}:SpeechSynthesisBaseUrl",
+            RoutedServiceNames.ImageGeneration => $"{LocalServiceHostsOptions.SectionName}:ImageGenerationBaseUrl",
+            _ => null,
+        };
 
     private async Task<string?> ResolveConfiguredDefaultRouterAliasAsync(CancellationToken cancellationToken)
     {
@@ -319,14 +284,7 @@ public sealed class LocalAiDesiredStateBuilder : ILocalAiDesiredStateBuilder
         string serviceId,
         CancellationToken cancellationToken)
     {
-        var expectedLocalProviderSection = serviceId switch
-        {
-            RoutedServiceNames.SpeechTranscription => $"{LocalServiceHostsOptions.SectionName}:SpeechTranscriptionBaseUrl",
-            RoutedServiceNames.Embeddings => $"{LocalServiceHostsOptions.SectionName}:EmbeddingsBaseUrl",
-            RoutedServiceNames.SpeechSynthesis => $"{LocalServiceHostsOptions.SectionName}:SpeechSynthesisBaseUrl",
-            RoutedServiceNames.ImageGeneration => $"{LocalServiceHostsOptions.SectionName}:ImageGenerationBaseUrl",
-            _ => null,
-        };
+        var expectedLocalProviderSection = ResolveLocalProviderSection(serviceId);
 
         if (expectedLocalProviderSection is null)
         {

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiDesiredStateBuilder.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiDesiredStateBuilder.cs
@@ -202,8 +202,9 @@ public sealed class LocalAiDesiredStateBuilder : ILocalAiDesiredStateBuilder
                 .ConfigureAwait(false);
             var localMode = modes.FirstOrDefault(mode =>
                 string.Equals(mode.ProviderSection, localProviderSection, StringComparison.OrdinalIgnoreCase));
-            var modelId = localMode?.ModelId?.Trim();
-            return string.IsNullOrWhiteSpace(modelId) ? null : modelId;
+            return localMode?.ModelId?.Trim() is { Length: > 0 } modelId
+                ? modelId
+                : null;
         }
         catch (Exception ex)
         {

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStartupWarmupService.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStartupWarmupService.cs
@@ -69,6 +69,7 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
     private readonly ILocalAiDesiredStateBuilder _desiredStateBuilder;
     private readonly ILocalAiWarmupOrchestrationClient _orchestrationClient;
     private readonly IServiceModeResolver _serviceModeResolver;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<LocalAiStartupWarmupService> _logger;
 
     public LocalAiStartupWarmupService(
@@ -77,6 +78,7 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
         ILocalAiDesiredStateBuilder desiredStateBuilder,
         ILocalAiWarmupOrchestrationClient orchestrationClient,
         IServiceModeResolver serviceModeResolver,
+        IHttpClientFactory httpClientFactory,
         ILogger<LocalAiStartupWarmupService> logger)
     {
         _configuration = configuration;
@@ -84,6 +86,7 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
         _desiredStateBuilder = desiredStateBuilder;
         _orchestrationClient = orchestrationClient;
         _serviceModeResolver = serviceModeResolver;
+        _httpClientFactory = httpClientFactory;
         _logger = logger;
     }
 
@@ -102,10 +105,17 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
             waitForCompletion: true,
             cancellationToken: cancellationToken);
 
-    public async Task SyncDesiredAndApplyAsync(
+    public Task SyncDesiredAndApplyAsync(
         WarmupDesiredBuildOptions? options = null,
         bool waitForCompletion = false,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        SyncDesiredAndApplyCoreAsync(options, waitForCompletion, allowRetry: true, cancellationToken);
+
+    private async Task SyncDesiredAndApplyCoreAsync(
+        WarmupDesiredBuildOptions? options,
+        bool waitForCompletion,
+        bool allowRetry,
+        CancellationToken cancellationToken)
     {
         if (!IsOrchestrationConfigured())
         {
@@ -119,6 +129,12 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
             if (waitForCompletion)
             {
                 await WaitForApplyCompleteAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (allowRetry && options is not null)
+            {
+                await SyncDesiredAndApplyCoreAsync(options, waitForCompletion, allowRetry: false, cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             return;
@@ -250,16 +266,40 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
         }
         else
         {
-            var overrides = new Dictionary<string, string>(StringComparer.Ordinal);
             if (!string.IsNullOrWhiteSpace(requestedModelRef))
             {
-                overrides[serviceId] = requestedModelRef.Trim();
+                var trimmedRef = requestedModelRef.Trim();
+                if (!LocalServiceModelRefRules.IsLoadableLocalModelRef(trimmedRef))
+                {
+                    var refKind = string.Equals(serviceId, RoutedServiceNames.ImageGeneration, StringComparison.Ordinal)
+                        ? "bundle id"
+                        : "local model path";
+                    return new LocalServiceReconcileResult(
+                        LocalServiceReconcileOutcome.Failed,
+                        $"Model reference '{trimmedRef}' is not a valid {refKind}.");
+                }
+
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var settings = scope.ServiceProvider.GetRequiredService<IApplicationSettingsService>();
+                    await settings
+                        .SetServiceModeModelIdAsync(serviceId, trimmedRef, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Could not persist configured model ref for '{ServiceId}'.",
+                        LogValueSanitizer.Sanitize(serviceId));
+                    return new LocalServiceReconcileResult(
+                        LocalServiceReconcileOutcome.Failed,
+                        ex.Message);
+                }
             }
 
-            options = new WarmupDesiredBuildOptions
-            {
-                ModelIdOverrides = overrides.Count > 0 ? overrides : null,
-            };
+            options = new WarmupDesiredBuildOptions();
         }
 
         try
@@ -300,10 +340,10 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
                 serviceStatus.Error ?? "Orchestrator reported failure.");
         }
 
-        var applied = serviceStatus.Applied.Trim().ToLowerInvariant();
         if (expectWarm)
         {
-            if (applied == "warm")
+            if (string.Equals(serviceStatus.Phase, "ready", StringComparison.OrdinalIgnoreCase)
+                && HasLoadedRef(serviceStatus))
             {
                 return new LocalServiceReconcileResult(LocalServiceReconcileOutcome.Warm);
             }
@@ -321,7 +361,8 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
                 $"Service '{serviceId}' did not reach warm state.");
         }
 
-        if (applied == "idle")
+        if (string.Equals(serviceStatus.Phase, "idle", StringComparison.OrdinalIgnoreCase)
+            && !HasLoadedRef(serviceStatus))
         {
             return new LocalServiceReconcileResult(LocalServiceReconcileOutcome.Idle);
         }
@@ -330,6 +371,11 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
             LocalServiceReconcileOutcome.Timeout,
             $"Service '{serviceId}' did not reach idle state.");
     }
+
+    private static bool HasLoadedRef(WarmupServiceStatus serviceStatus) =>
+        !string.IsNullOrWhiteSpace(serviceStatus.RouterAlias)
+        || !string.IsNullOrWhiteSpace(serviceStatus.ModelId)
+        || !string.IsNullOrWhiteSpace(serviceStatus.BundleId);
 
     private async Task WaitForApplyCompleteAsync(CancellationToken cancellationToken)
     {

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStartupWarmupService.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStartupWarmupService.cs
@@ -332,12 +332,19 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
                 $"Warmup status did not include '{serviceId}'.");
         }
 
-        if (string.Equals(serviceStatus.Phase, "failed", StringComparison.OrdinalIgnoreCase)
-            || !string.IsNullOrWhiteSpace(serviceStatus.Error))
+        if (string.Equals(serviceStatus.Phase, "failed", StringComparison.OrdinalIgnoreCase))
         {
             return new LocalServiceReconcileResult(
                 LocalServiceReconcileOutcome.Failed,
                 serviceStatus.Error ?? "Orchestrator reported failure.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(serviceStatus.Error)
+            && !string.Equals(serviceStatus.Phase, "ready", StringComparison.OrdinalIgnoreCase))
+        {
+            return new LocalServiceReconcileResult(
+                LocalServiceReconcileOutcome.Failed,
+                serviceStatus.Error);
         }
 
         if (expectWarm)

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiWarmupOrchestrationClient.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiWarmupOrchestrationClient.cs
@@ -123,11 +123,21 @@ public sealed class LocalAiWarmupOrchestrationClient : ILocalAiWarmupOrchestrati
         {
             foreach (var (serviceId, entry) in parsed.Services)
             {
+                var planRef = entry.PlanRef?.Trim();
+                var loadedRef = entry.RouterAlias?.Trim()
+                    ?? entry.ModelId?.Trim()
+                    ?? entry.BundleId?.Trim();
+                var phase = entry.Phase ?? "idle";
+                var hasPlan = !string.IsNullOrWhiteSpace(planRef);
+                var isReady = string.Equals(phase, "ready", StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrWhiteSpace(loadedRef);
+
                 services[serviceId] = new WarmupServiceStatus(
-                    Desired: entry.Desired ?? "idle",
-                    Applied: entry.Applied ?? "idle",
-                    Phase: entry.Phase ?? "idle",
+                    Desired: hasPlan ? "on" : "off",
+                    Applied: isReady ? "on" : "off",
+                    Phase: phase,
                     Error: entry.Error,
+                    PlanRef: planRef,
                     RouterAlias: entry.RouterAlias,
                     ModelId: entry.ModelId,
                     BundleId: entry.BundleId);
@@ -192,6 +202,9 @@ public sealed class LocalAiWarmupOrchestrationClient : ILocalAiWarmupOrchestrati
 
         [JsonPropertyName("error")]
         public string? Error { get; set; }
+
+        [JsonPropertyName("planRef")]
+        public string? PlanRef { get; set; }
 
         [JsonPropertyName("routerAlias")]
         public string? RouterAlias { get; set; }

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAuxiliaryCatalogDefaults.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAuxiliaryCatalogDefaults.cs
@@ -36,6 +36,12 @@ internal static class LocalAuxiliaryCatalogDefaults
             return "ResembleAI/chatterbox";
         }
 
+        if (string.Equals(serviceId, RoutedServiceNames.ImageGeneration, StringComparison.Ordinal)
+            && string.Equals(providerId, ServiceProviderIds.ImageGenerationLocalSdHttp, StringComparison.Ordinal))
+        {
+            return "flux2-klein-4b-q4ks";
+        }
+
         return null;
     }
 }

--- a/src/server/GuideAntsApi/Services/Bootstrap/WarmupOrchestrationModels.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/WarmupOrchestrationModels.cs
@@ -19,6 +19,7 @@ public sealed record WarmupServiceStatus(
     string Applied,
     string Phase,
     string? Error,
+    string? PlanRef,
     string? RouterAlias,
     string? ModelId,
     string? BundleId);

--- a/src/server/GuideAntsApi/Services/NotebookHeaderToolbar/NotebookHeaderToolbarService.cs
+++ b/src/server/GuideAntsApi/Services/NotebookHeaderToolbar/NotebookHeaderToolbarService.cs
@@ -805,7 +805,8 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
             var active = it?["active"]?.GetValue<bool>() is true
                 || it?["activeModel"]?.GetValue<bool>() is true
                 || string.Equals(id, it?["active_model_id"]?.GetValue<string>(), StringComparison.Ordinal);
-            list.Add(new NotebookToolbarLocalModelOptionDto(id, label, true, active));
+            var complete = it?["complete"]?.GetValue<bool>() ?? false;
+            list.Add(new NotebookToolbarLocalModelOptionDto(id, label, complete, active));
         }
         return list;
     }

--- a/src/server/GuideAntsApi/Services/NotebookHeaderToolbar/NotebookHeaderToolbarService.cs
+++ b/src/server/GuideAntsApi/Services/NotebookHeaderToolbar/NotebookHeaderToolbarService.cs
@@ -508,7 +508,17 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
             isImage,
             cancellationToken).ConfigureAwait(false);
 
-        var selection = BuildSelectionForService(state, isImage, localModels);
+        var selectedLocalRef = ResolveSelectedLocalModelRef(state, localProviderId);
+        if (isImage)
+        {
+            localModels = MarkImageBundleSelection(localModels, selectedLocalRef);
+        }
+        else
+        {
+            localModels = MarkVoiceModelSelection(localModels, selectedLocalRef);
+        }
+
+        var selection = BuildSelectionForService(state, isImage, localModels, selectedLocalRef);
         var runtimeProbe = supportsPower
             ? await ProbeLocalRuntimeAsync(serviceId, isImage, cancellationToken).ConfigureAwait(false)
             : new LocalRuntimeProbe(false, false, false, false);
@@ -637,24 +647,74 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
     private static NotebookToolbarSelectionDto? BuildSelectionForService(
         ServiceEditorStateDto state,
         bool isImage,
-        IReadOnlyList<NotebookToolbarLocalModelOptionDto> localModels)
+        IReadOnlyList<NotebookToolbarLocalModelOptionDto> localModels,
+        string? selectedLocalRef)
     {
-        if (isImage)
+        if (!string.IsNullOrWhiteSpace(selectedLocalRef))
         {
-            var act = localModels.FirstOrDefault(m => m.IsActive);
             return new NotebookToolbarSelectionDto(
-                act?.ModelRef,
-                act != null ? $"active: {act.ModelRef}" : "no active bundle");
+                selectedLocalRef,
+                $"active: {selectedLocalRef}");
         }
 
-        var active = localModels.FirstOrDefault(m => m.IsActive);
-        var pick = active ?? localModels.FirstOrDefault(m => m.ModelRef.Length > 0);
+        if (isImage)
+        {
+            return new NotebookToolbarSelectionDto(null, "no active bundle");
+        }
+
+        var pick = localModels.FirstOrDefault(m => m.ModelRef.Length > 0);
         if (pick == null)
         {
             return new NotebookToolbarSelectionDto(null, "no installed local models");
         }
 
         return new NotebookToolbarSelectionDto(pick.ModelRef, pick.ModelRef);
+    }
+
+    private static string? ResolveSelectedLocalModelRef(
+        ServiceEditorStateDto state,
+        string localProviderId)
+    {
+        var localProvider = state.Providers.FirstOrDefault(p =>
+            string.Equals(p.ProviderId, localProviderId, StringComparison.Ordinal));
+        return localProvider is null ? null : ExtractModelId(localProvider);
+    }
+
+    private static IReadOnlyList<NotebookToolbarLocalModelOptionDto> MarkImageBundleSelection(
+        IReadOnlyList<NotebookToolbarLocalModelOptionDto> localModels,
+        string? selectedLocalRef)
+    {
+        if (string.IsNullOrWhiteSpace(selectedLocalRef))
+        {
+            return localModels;
+        }
+
+        return localModels
+            .Select(model => model with
+            {
+                IsActive = string.Equals(model.ModelRef, selectedLocalRef, StringComparison.Ordinal),
+                DisplayLabel = string.Equals(model.ModelRef, selectedLocalRef, StringComparison.Ordinal)
+                    ? $"{model.ModelRef} (active)"
+                    : model.DisplayLabel,
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<NotebookToolbarLocalModelOptionDto> MarkVoiceModelSelection(
+        IReadOnlyList<NotebookToolbarLocalModelOptionDto> localModels,
+        string? selectedLocalRef)
+    {
+        if (string.IsNullOrWhiteSpace(selectedLocalRef))
+        {
+            return localModels;
+        }
+
+        return localModels
+            .Select(model => model with
+            {
+                IsActive = string.Equals(model.ModelRef, selectedLocalRef, StringComparison.Ordinal),
+            })
+            .ToList();
     }
 
     private async Task<LocalRuntimeProbe> ProbeLocalRuntimeAsync(
@@ -753,7 +813,6 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
         if (items is null) return Array.Empty<NotebookToolbarLocalModelOptionDto>();
 
         var list = new List<NotebookToolbarLocalModelOptionDto>();
-        var activeId = root?["activeBundleId"]?.GetValue<string>();
         foreach (var it in items)
         {
             if (it?["bundleId"]?.GetValue<string>() is not { } id)
@@ -761,9 +820,9 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
                 continue;
             }
             var complete = it["complete"]?.GetValue<bool>() ?? false;
-            var active = string.Equals(id, activeId, StringComparison.Ordinal);
-            var label = active ? $"{id} (active)" : id;
-            list.Add(new NotebookToolbarLocalModelOptionDto(id, label, complete, active));
+            var loaded = it["loaded"]?.GetValue<bool>() ?? false;
+            var label = loaded ? $"{id} (loaded)" : id;
+            list.Add(new NotebookToolbarLocalModelOptionDto(id, label, complete, IsActive: false));
         }
         return list;
     }

--- a/src/server/GuideAntsApi/Services/Routing/RoutingReadinessService.cs
+++ b/src/server/GuideAntsApi/Services/Routing/RoutingReadinessService.cs
@@ -373,15 +373,24 @@ public sealed class RoutingReadinessService : IRoutingReadinessService
                 return Array.Empty<string>();
             }
 
-            if (string.Equals(serviceStatus.Desired, "warm", StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(serviceStatus.Applied, "warm", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(serviceStatus.PlanRef)
+                && !string.Equals(serviceStatus.Phase, "ready", StringComparison.OrdinalIgnoreCase))
             {
                 var detail = string.IsNullOrWhiteSpace(serviceStatus.Error)
                     ? $"phase={serviceStatus.Phase}"
                     : serviceStatus.Error;
                 return
                 [
-                    $"{BlockerKeys.RuntimeState}: warmup orchestrator has not applied warm state for '{service}' ({detail})."
+                    $"{BlockerKeys.RuntimeState}: runtime plan not loaded for '{service}' ({detail})."
+                ];
+            }
+
+            if (!string.IsNullOrWhiteSpace(serviceStatus.PlanRef)
+                && !LoadedRefMatchesPlan(serviceStatus))
+            {
+                return
+                [
+                    $"{BlockerKeys.RuntimeState}: loaded model does not match runtime plan for '{service}'."
                 ];
             }
         }
@@ -391,6 +400,20 @@ public sealed class RoutingReadinessService : IRoutingReadinessService
         }
 
         return Array.Empty<string>();
+    }
+
+    private static bool LoadedRefMatchesPlan(WarmupServiceStatus serviceStatus)
+    {
+        var planRef = serviceStatus.PlanRef?.Trim();
+        if (string.IsNullOrWhiteSpace(planRef))
+        {
+            return true;
+        }
+
+        var loadedRef = serviceStatus.RouterAlias?.Trim()
+            ?? serviceStatus.ModelId?.Trim()
+            ?? serviceStatus.BundleId?.Trim();
+        return string.Equals(planRef, loadedRef, StringComparison.Ordinal);
     }
 
     private static bool IsLocalServiceProviderSection(string providerSection) =>

--- a/src/server/GuideAntsApi/Settings/ApplicationSettingsService.ServiceEditors.cs
+++ b/src/server/GuideAntsApi/Settings/ApplicationSettingsService.ServiceEditors.cs
@@ -597,19 +597,36 @@ public sealed partial class ApplicationSettingsService
                 $"Service '{serviceId}' has no default service mode; cannot persist configured model id.");
         }
 
-        if (string.Equals(activeMode.ModelId, trimmed, StringComparison.Ordinal))
+        var localProviderSection = ResolveLocalProviderSectionKey(canonicalService);
+        var targetMode = !string.IsNullOrWhiteSpace(localProviderSection)
+            ? modes.FirstOrDefault(mode =>
+                string.Equals(mode.ProviderSection, localProviderSection, StringComparison.OrdinalIgnoreCase))
+            : null;
+        targetMode ??= activeMode;
+
+        if (string.Equals(targetMode.ModelId, trimmed, StringComparison.Ordinal))
         {
             return;
         }
 
         var updatedModes = modes
-            .Select(mode => string.Equals(mode.ModeId, activeMode.ModeId, StringComparison.Ordinal)
+            .Select(mode => string.Equals(mode.ModeId, targetMode.ModeId, StringComparison.Ordinal)
                 ? mode with { ModelId = trimmed }
                 : mode)
             .ToList();
         ServiceModesPayload.WriteModesFor(payload, canonicalService, updatedModes, activeMode.ModeId);
         await PersistServiceModesAsync(row, payload, cancellationToken).ConfigureAwait(false);
     }
+
+    private static string? ResolveLocalProviderSectionKey(string serviceId) =>
+        serviceId switch
+        {
+            RoutedServiceNames.SpeechTranscription => $"{LocalServiceHostsOptions.SectionName}:SpeechTranscriptionBaseUrl",
+            RoutedServiceNames.Embeddings => $"{LocalServiceHostsOptions.SectionName}:EmbeddingsBaseUrl",
+            RoutedServiceNames.SpeechSynthesis => $"{LocalServiceHostsOptions.SectionName}:SpeechSynthesisBaseUrl",
+            RoutedServiceNames.ImageGeneration => $"{LocalServiceHostsOptions.SectionName}:ImageGenerationBaseUrl",
+            _ => null,
+        };
 
     private static string? ResolveInitialServiceModeModelId(string serviceId, string providerId) =>
         LocalAuxiliaryCatalogDefaults.TryGetDefaultCatalogModelId(serviceId, providerId);


### PR DESCRIPTION
Fix warmup INI execution-plan contract and post-merge orchestration gaps.
Replace desired=warm/idle sections with explicit load refs and enabled=off,
then align ga-admin reconciliation, desired-state building, and routing
readiness on plan phase and loaded-ref matching. Add catalog completeness
checks for partial model downloads, surface toolbar async failures in the
notebook header, and derive local model selection from persisted settings
instead of engine disk markers.