### PR TITLE
Fix/imagegen warmup bundle propagation

### DIFF
--- a/src/client/src/components/guides/editor/BaseEntityEditor.tsx
+++ b/src/client/src/components/guides/editor/BaseEntityEditor.tsx
@@ -1071,6 +1071,26 @@ export default function BaseEntityEditor({ entityType, entityId, projectId }: Ba
     setIsDirty(true);
   }, [formData]);
 
+  const handleCrewMemberInvocationLimitChange = useCallback(
+    (assistantId: string, maxToolCallsPerInvocation: number | undefined) => {
+      setFormData((prev) => {
+        const crewMemberInvocationLimits = {
+          ...prev.crewMemberInvocationLimits,
+          [assistantId]: maxToolCallsPerInvocation,
+        };
+        if (areFormValuesEqual(prev.crewMemberInvocationLimits, crewMemberInvocationLimits)) {
+          return prev;
+        }
+        return {
+          ...prev,
+          crewMemberInvocationLimits,
+        };
+      });
+      setIsDirty(true);
+    },
+    [],
+  );
+
   const handlePreviewMarkdown = useCallback((fileId: string) => {
     setPreviewFileId(fileId);
     setShowMarkdownPreview(true);
@@ -1298,13 +1318,7 @@ export default function BaseEntityEditor({ entityType, entityId, projectId }: Ba
               crewMemberLimitById={formData.crewMemberLimitById}
               crewMemberInvocationLimits={formData.crewMemberInvocationLimits}
               onChange={(crewMemberIds) => updateForm({ crewMemberIds })}
-              onInvocationLimitChange={(assistantId, maxToolCallsPerInvocation) =>
-                updateForm({
-                  crewMemberInvocationLimits: {
-                    ...formData.crewMemberInvocationLimits,
-                    [assistantId]: maxToolCallsPerInvocation,
-                  },
-                })}
+              onInvocationLimitChange={handleCrewMemberInvocationLimitChange}
               onDirtyChange={() => setIsDirty(true)}
             />
           )}

--- a/src/client/src/components/guides/editor/crew/CrewMemberLimitOverrideField.tsx
+++ b/src/client/src/components/guides/editor/crew/CrewMemberLimitOverrideField.tsx
@@ -1,14 +1,14 @@
 import { LimitNumberField } from '../toolLimits/LimitNumberField';
 
 interface CrewMemberLimitOverrideFieldProps {
-  assistantName: string;
+  assistantId: string;
   value?: number;
   onChange: (value: number | undefined) => void;
   onDirtyChange?: () => void;
 }
 
 export function CrewMemberLimitOverrideField({
-  assistantName,
+  assistantId,
   value,
   onChange,
   onDirtyChange,
@@ -16,7 +16,8 @@ export function CrewMemberLimitOverrideField({
   return (
     <div className="mt-2">
       <LimitNumberField
-        id={`crew-member-limit-${assistantName.replace(/\s+/g, '-').toLowerCase()}`}
+        key={assistantId}
+        id={`crew-member-limit-${assistantId}`}
         label="Max tool calls per invocation"
         value={value}
         onChange={(nextValue) => {

--- a/src/client/src/components/guides/editor/toolLimits/LimitNumberField.tsx
+++ b/src/client/src/components/guides/editor/toolLimits/LimitNumberField.tsx
@@ -16,8 +16,13 @@ export function LimitNumberField({
   onChange,
   onErrorChange,
 }: LimitNumberFieldProps) {
-  const [rawValue, setRawValue] = useState<string | null>(null);
-  const displayValue = rawValue ?? (value === undefined ? '' : String(value));
+  const [isFocused, setIsFocused] = useState(false);
+  const [rawValue, setRawValue] = useState('');
+  const displayValue = isFocused
+    ? rawValue
+    : value === undefined
+      ? ''
+      : String(value);
   const parsed = parseOptionalPositiveInt(displayValue);
   const error = parsed.ok ? undefined : parsed.error;
 
@@ -40,6 +45,14 @@ export function LimitNumberField({
         id={id}
         min={1}
         value={displayValue}
+        onFocus={() => {
+          setIsFocused(true);
+          setRawValue(value === undefined ? '' : String(value));
+        }}
+        onBlur={() => {
+          setIsFocused(false);
+          setRawValue('');
+        }}
         onChange={(event) => handleChange(event.target.value)}
         className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
         placeholder="No limit"

--- a/src/client/src/components/guides/guideEditor/GuideCrewManager.tsx
+++ b/src/client/src/components/guides/guideEditor/GuideCrewManager.tsx
@@ -150,9 +150,12 @@ export function GuideCrewManager({
       searchTerm ? a.name.toLowerCase().includes(searchTerm.toLowerCase()) : true
     );
 
-  const selectedOptions = selectedAssistantIds
-    .map((id) => availableOptions.find((a) => a.id === id))
-    .filter((a): a is AssistantOption => !!a);
+  const selectedMembers = selectedAssistantIds
+    .map((assistantId) => {
+      const assistant = availableOptions.find((option) => option.id === assistantId);
+      return assistant ? { assistantId, assistant } : null;
+    })
+    .filter((member): member is { assistantId: string; assistant: AssistantOption } => member !== null);
 
   const handleAdd = (id: string) => {
     onChange([...selectedAssistantIds, id]);
@@ -264,18 +267,18 @@ export function GuideCrewManager({
           <div className="border border-gray-300 rounded-md overflow-hidden" data-tour-id="guide.crew.selected.panel">
             <div className="bg-blue-50 px-4 py-3 border-b border-blue-300">
               <h3 className="text-sm font-medium text-blue-900">
-                Selected Members ({selectedOptions.length})
+                Selected Members ({selectedMembers.length})
               </h3>
             </div>
             <div className="max-h-[25rem] overflow-y-auto" data-tour-id="guide.crew.selected.list">
-              {selectedOptions.length === 0 ? (
+              {selectedMembers.length === 0 ? (
                 <div className="p-4 text-center text-sm text-gray-500">
                   No crew members yet. Add assistants from the left panel.
                 </div>
               ) : (
                 <div className="divide-y divide-gray-200">
-                  {selectedOptions.map((assistant, index) => (
-                    <div key={assistant.id} className="p-3 flex items-center gap-2 hover:bg-gray-50">
+                  {selectedMembers.map(({ assistantId, assistant }, index) => (
+                    <div key={assistantId} className="p-3 flex items-center gap-2 hover:bg-gray-50">
                       {/* Reorder buttons */}
                       <div className="flex flex-col gap-0.5">
                         <button
@@ -293,7 +296,7 @@ export function GuideCrewManager({
                         <button
                           type="button"
                           onClick={() => handleMoveDown(index)}
-                          disabled={index === selectedOptions.length - 1}
+                          disabled={index === selectedMembers.length - 1}
                           className="p-0.5 text-gray-400 hover:text-gray-600 disabled:opacity-30 disabled:cursor-not-allowed"
                           title="Move down"
                           data-tour-id="guide.crew.reorder.down"
@@ -331,12 +334,12 @@ export function GuideCrewManager({
                           projectId={projectId}
                           assistantId={assistant.id}
                           assistantName={assistant.name}
-                          initialMaxToolCallsPerTurn={crewMemberLimitById[assistant.id]}
+                          initialMaxToolCallsPerTurn={crewMemberLimitById[assistantId]}
                         />
                         <CrewMemberLimitOverrideField
-                          assistantName={assistant.name}
-                          value={crewMemberInvocationLimits[assistant.id]}
-                          onChange={(value) => onInvocationLimitChange(assistant.id, value)}
+                          assistantId={assistantId}
+                          value={crewMemberInvocationLimits[assistantId]}
+                          onChange={(value) => onInvocationLimitChange(assistantId, value)}
                           onDirtyChange={onDirtyChange}
                         />
                       </div>

--- a/src/client/src/components/notebook/header-toolbar/ServiceLocalRuntimePowerSection.tsx
+++ b/src/client/src/components/notebook/header-toolbar/ServiceLocalRuntimePowerSection.tsx
@@ -36,8 +36,16 @@ export function ServiceLocalRuntimePowerSection({
 
   const powerOn = () => {
     void run(async () => {
-      const request = activeModelRef ? { model_path: activeModelRef } : {};
-      await api.settings.localModels.load(service.serviceId, request);
+      if (!activeModelRef) {
+        throw new Error(`Select a ${resourceLabel.toLowerCase()} before loading.`);
+      }
+
+      if (service.serviceId === 'ImageGeneration') {
+        await api.settings.localModels.selectActive(service.serviceId, activeModelRef);
+      } else {
+        await api.settings.localModels.load(service.serviceId, { model_path: activeModelRef });
+      }
+
       await onRefresh();
     });
   };

--- a/src/client/src/components/project/scheduling/ScheduleBuilder.tsx
+++ b/src/client/src/components/project/scheduling/ScheduleBuilder.tsx
@@ -56,7 +56,7 @@ export function ScheduleBuilder({
             id="hourly-interval"
             type="number"
             min={1}
-            max={59}
+            max={60}
             value={schedule.hourlyIntervalMinutes ?? 60}
             onChange={(e) => update({ hourlyIntervalMinutes: Number(e.target.value) })}
             disabled={disabled}

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiDesiredStateBuilderTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiDesiredStateBuilderTests.cs
@@ -176,7 +176,7 @@ public sealed class LocalAiDesiredStateBuilderTests
     }
 
     [TestMethod]
-    public async Task BuildIniAsync_ImageGenerationLocalWithoutModelId_WritesIdle()
+    public async Task BuildIniAsync_ImageGenerationLocalWithoutModelId_Throws()
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -201,11 +201,10 @@ public sealed class LocalAiDesiredStateBuilderTests
             new StubHttpClientFactory(),
             NullLogger<LocalAiDesiredStateBuilder>.Instance);
 
-        var ini = await builder.BuildIniAsync();
+        var act = () => builder.BuildIniAsync();
 
-        ini.Should().Contain("[ImageGeneration]");
-        ini.Should().Contain("enabled = off");
-        ini.Should().NotContain("bundle_id =");
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no model or bundle configured in ServiceModes*");
     }
 
     private sealed class StubHttpClientFactory : IHttpClientFactory

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
@@ -42,25 +42,29 @@ public sealed class LocalAiStartupWarmupServiceTests
             })
             .Build();
 
+        var embeddingsMode = new ServiceMode(
+            ModeId: "default",
+            ProviderSection: "LocalServiceHosts:EmbeddingsBaseUrl",
+            ModelId: "qwen3_embedding_0_6b",
+            RequestPresetJson: null,
+            Enabled: true,
+            IsDefault: true);
         var modeResolver = new FakeServiceModeResolver(
-            (RoutedServiceNames.Embeddings, new ServiceMode(
-                ModeId: "default",
-                ProviderSection: "LocalServiceHosts:EmbeddingsBaseUrl",
-                ModelId: "qwen3_embedding_0_6b",
-                RequestPresetJson: null,
-                Enabled: true,
-                IsDefault: true)));
+            (RoutedServiceNames.Embeddings, embeddingsMode));
+
+        var (settingsMock, _) = CreateSettingsMock(
+            (RoutedServiceNames.Embeddings, embeddingsMode));
 
         var builder = new LocalAiDesiredStateBuilder(
             configuration,
-            new ServiceScopeFactoryStub(),
+            new ServiceScopeFactoryStub(settingsMock.Object),
             modeResolver,
             CreateHttpClientFactory(),
             NullLogger<LocalAiDesiredStateBuilder>.Instance);
 
         var service = new LocalAiStartupWarmupService(
             configuration,
-            new ServiceScopeFactoryStub(),
+            new ServiceScopeFactoryStub(settingsMock.Object),
             builder,
             orchestration.Object,
             modeResolver,
@@ -174,14 +178,19 @@ public sealed class LocalAiStartupWarmupServiceTests
                 Enabled: true,
                 IsDefault: true));
 
-        var settingsMock = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        var (settingsMock, setPersistedModelId) = CreateSettingsMock(
+            (RoutedServiceNames.SpeechSynthesis, modeResolver.LocalMode));
         settingsMock
             .Setup(s => s.SetServiceModeModelIdAsync(
                 RoutedServiceNames.SpeechSynthesis,
                 "OmniVoice",
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
-            .Callback(() => modeResolver.SetModelId("OmniVoice"));
+            .Callback(() =>
+            {
+                setPersistedModelId(RoutedServiceNames.SpeechSynthesis, "OmniVoice");
+                modeResolver.SetModelId("OmniVoice");
+            });
 
         var builder = new LocalAiDesiredStateBuilder(
             configuration,
@@ -268,7 +277,8 @@ public sealed class LocalAiStartupWarmupServiceTests
                 Enabled: true,
                 IsDefault: true));
 
-        var settingsMock = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        var (settingsMock, setPersistedModelId) = CreateSettingsMock(
+            (ImageGenerationOptions.SectionName, modeResolver.LocalMode));
         settingsMock
             .Setup(s => s.EnsureServiceModeExistsAsync(
                 ImageGenerationOptions.SectionName,
@@ -293,7 +303,11 @@ public sealed class LocalAiStartupWarmupServiceTests
                 "flux2-klein-4b-q4ks",
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
-            .Callback(() => modeResolver.SetModelId("flux2-klein-4b-q4ks"));
+            .Callback(() =>
+            {
+                setPersistedModelId(ImageGenerationOptions.SectionName, "flux2-klein-4b-q4ks");
+                modeResolver.SetModelId("flux2-klein-4b-q4ks");
+            });
 
         var builder = new LocalAiDesiredStateBuilder(
             configuration,
@@ -370,6 +384,8 @@ public sealed class LocalAiStartupWarmupServiceTests
             _localMode = localMode;
         }
 
+        public ServiceMode LocalMode => _localMode;
+
         public void SetModelId(string modelId) =>
             _localMode = _localMode with { ModelId = modelId };
 
@@ -403,6 +419,54 @@ public sealed class LocalAiStartupWarmupServiceTests
             return Task.FromResult<IReadOnlyList<ServiceMode>>(new[] { _localMode });
         }
     }
+
+    private static (Mock<IApplicationSettingsService> Mock, Action<string, string> SetPersistedModelId) CreateSettingsMock(
+        params (string ServiceId, ServiceMode Mode)[] modesByService)
+    {
+        var modes = modesByService.ToDictionary(
+            entry => entry.ServiceId,
+            entry => ToServiceModeDto(entry.ServiceId, entry.Mode),
+            StringComparer.Ordinal);
+
+        var settingsMock = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        foreach (var (serviceId, _) in modesByService)
+        {
+            settingsMock
+                .Setup(s => s.GetServiceModesAsync(serviceId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    lock (modes)
+                    {
+                        return modes.TryGetValue(serviceId, out var mode)
+                            ? new[] { mode }
+                            : Array.Empty<ServiceModeDto>();
+                    }
+                });
+        }
+
+        void SetPersistedModelId(string serviceId, string modelId)
+        {
+            lock (modes)
+            {
+                if (modes.TryGetValue(serviceId, out var mode))
+                {
+                    modes[serviceId] = mode with { ModelId = modelId };
+                }
+            }
+        }
+
+        return (settingsMock, SetPersistedModelId);
+    }
+
+    private static ServiceModeDto ToServiceModeDto(string serviceId, ServiceMode mode) =>
+        new(
+            serviceId,
+            mode.ModeId,
+            mode.ProviderSection,
+            mode.ModelId,
+            mode.RequestPresetJson,
+            mode.Enabled,
+            mode.IsDefault);
 
     private static IHttpClientFactory CreateHttpClientFactory() =>
         new ServiceCollection().AddHttpClient().BuildServiceProvider().GetRequiredService<IHttpClientFactory>();

--- a/src/server/GuideAntsApi.Tests/Settings/ServiceEditorUpdateValidationTests.cs
+++ b/src/server/GuideAntsApi.Tests/Settings/ServiceEditorUpdateValidationTests.cs
@@ -363,6 +363,52 @@ public sealed class ServiceEditorUpdateValidationTests
     }
 
     [TestMethod]
+    public async Task EnsureServiceModeExistsAsync_SetsDefaultModel_ForLocalImageGeneration()
+    {
+        await using var db = CreateDbContext();
+        var configuration = BuildConfiguration();
+        var service = CreateService(db, configuration);
+
+        await service.EnsureServiceModeExistsAsync(
+            "ImageGeneration",
+            ServiceProviderIds.ImageGenerationLocalSdHttp,
+            CancellationToken.None);
+
+        var modes = await service.GetServiceModesAsync("ImageGeneration", CancellationToken.None);
+        modes.Should().Contain(mode =>
+            string.Equals(mode.ProviderSection, "LocalServiceHosts:ImageGenerationBaseUrl", StringComparison.Ordinal)
+            && string.Equals(mode.ModelId, "flux2-klein-4b-q4ks", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task EnsureServiceModeExistsAsync_DoesNotAlterExistingLocalImageMode_WhenModelIdIsNull()
+    {
+        await using var db = CreateDbContext();
+        var configuration = BuildConfiguration();
+        var service = CreateService(db, configuration);
+        SeedServiceModes(db, "ImageGeneration",
+        [
+            new ServiceMode(
+                "local",
+                "LocalServiceHosts:ImageGenerationBaseUrl",
+                null,
+                null,
+                Enabled: true,
+                IsDefault: true),
+        ]);
+
+        await service.EnsureServiceModeExistsAsync(
+            "ImageGeneration",
+            ServiceProviderIds.ImageGenerationLocalSdHttp,
+            CancellationToken.None);
+
+        var modes = await service.GetServiceModesAsync("ImageGeneration", CancellationToken.None);
+        modes.Should().Contain(mode =>
+            string.Equals(mode.ProviderSection, "LocalServiceHosts:ImageGenerationBaseUrl", StringComparison.Ordinal)
+            && mode.ModelId == null);
+    }
+
+    [TestMethod]
     public async Task SetServiceModeModelIdAsync_PersistsOntoActiveEnabledDefaultMode()
     {
         await using var db = CreateDbContext();

--- a/src/server/GuideAntsApi/Endpoints/Settings/ServiceLocalModelListEnricher.cs
+++ b/src/server/GuideAntsApi/Endpoints/Settings/ServiceLocalModelListEnricher.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using GuideAntsApi.Endpoints;
 using GuideAntsApi.Options;
+using GuideAntsApi.Services.Bootstrap;
 using GuideAntsApi.Services.Routing;
 using GuideAntsApi.Settings;
 using Microsoft.AspNetCore.Http;
@@ -55,9 +56,9 @@ internal static class ServiceLocalModelListEnricher
                     statusCode: StatusCodes.Status502BadGateway);
             }
 
-            var selectedBundleId = await ResolveSelectedImageBundleIdAsync(
+            var selectedBundleId = await ConfiguredLocalServiceSelectionSync.ResolveOrSyncImageBundleAsync(
                     settings,
-                    body,
+                    ServiceLocalModelListEnricher.ReadConfiguredActiveBundleId(body),
                     cancellationToken)
                 .ConfigureAwait(false);
             var enriched = ApplyImageBundleSelection(body, selectedBundleId);
@@ -65,36 +66,7 @@ internal static class ServiceLocalModelListEnricher
         }
     }
 
-    private static async Task<string?> ResolveSelectedImageBundleIdAsync(
-        IApplicationSettingsService settings,
-        string upstreamBody,
-        CancellationToken cancellationToken)
-    {
-        var modes = await settings
-            .GetServiceModesAsync(RoutedServiceNames.ImageGeneration, cancellationToken)
-            .ConfigureAwait(false);
-        var localSection = $"{LocalServiceHostsOptions.SectionName}:ImageGenerationBaseUrl";
-        var localMode = modes.FirstOrDefault(mode =>
-            string.Equals(mode.ProviderSection, localSection, StringComparison.OrdinalIgnoreCase));
-        var selected = localMode?.ModelId?.Trim();
-        if (!string.IsNullOrWhiteSpace(selected))
-        {
-            return selected;
-        }
-
-        var legacyMarker = TryReadLegacyActiveBundleMarker(upstreamBody);
-        if (string.IsNullOrWhiteSpace(legacyMarker))
-        {
-            return null;
-        }
-
-        await settings
-            .SetServiceModeModelIdAsync(RoutedServiceNames.ImageGeneration, legacyMarker, cancellationToken)
-            .ConfigureAwait(false);
-        return legacyMarker;
-    }
-
-    private static string? TryReadLegacyActiveBundleMarker(string upstreamBody)
+    public static string? ReadConfiguredActiveBundleId(string upstreamBody)
     {
         try
         {

--- a/src/server/GuideAntsApi/Endpoints/Settings/SettingsServiceLocalModelsEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/Settings/SettingsServiceLocalModelsEndpoints.cs
@@ -266,8 +266,8 @@ public static class SettingsServiceLocalModelsEndpoints
         //  - ASR / TTS / Embeddings: optional model_path or model_id selects a specific
         //    downloaded model folder; the ref is persisted verbatim on ServiceModes
         //    and written into warmup-desired.ini as model_path before apply.
-        //  - Image Generation: bundle id is persisted on ServiceModes and required in
-        //    warmup-desired.ini when desired=warm (set via select-active).
+        //  - Image Generation: bundle_id (or model_path/model_id alias) is persisted on
+        //    ServiceModes and written into warmup-desired.ini as bundle_id before apply.
         serviceEditorsGroup.MapPost("/{serviceId}/local-models/load", async (
             string serviceId,
             [FromBody] JsonElement payload,
@@ -284,9 +284,13 @@ public static class SettingsServiceLocalModelsEndpoints
             }
 
             string? requestedModelRef = null;
-            if (!isImageGeneration)
+            if (isImageGeneration)
             {
-                if (LocalServiceAdminRouting.TryGetNonEmptyString(payload, "model_path", out var modelPath))
+                if (LocalServiceAdminRouting.TryGetNonEmptyString(payload, "bundle_id", out var bundleId))
+                {
+                    requestedModelRef = bundleId;
+                }
+                else if (LocalServiceAdminRouting.TryGetNonEmptyString(payload, "model_path", out var modelPath))
                 {
                     requestedModelRef = modelPath;
                 }
@@ -294,6 +298,14 @@ public static class SettingsServiceLocalModelsEndpoints
                 {
                     requestedModelRef = modelId;
                 }
+            }
+            else if (LocalServiceAdminRouting.TryGetNonEmptyString(payload, "model_path", out var modelPath))
+            {
+                requestedModelRef = modelPath;
+            }
+            else if (LocalServiceAdminRouting.TryGetNonEmptyString(payload, "model_id", out var modelId))
+            {
+                requestedModelRef = modelId;
             }
 
             var result = await warmup

--- a/src/server/GuideAntsApi/Program.cs
+++ b/src/server/GuideAntsApi/Program.cs
@@ -227,8 +227,9 @@ public class Program
 
         ServiceRoutingStartupValidator.Validate(app.Services.GetRequiredService<IConfiguration>());
 
-        // Run local AI warmup asynchronously after host startup so slow model loads
-        // (especially image generation) do not block API availability.
+        // API startup: build the correct warmup-desired.ini for every local service,
+        // write it when out of date, then POST /warmup/apply. ga-admin runs the same
+        // apply path again on AI container startup (apply_warmup_on_startup).
         app.Lifetime.ApplicationStarted.Register(() =>
         {
             _ = Task.Run(async () =>

--- a/src/server/GuideAntsApi/Resources/bootstrap/assistants/code-executor/instructions.md
+++ b/src/server/GuideAntsApi/Resources/bootstrap/assistants/code-executor/instructions.md
@@ -1,89 +1,27 @@
 # Code Executor - Computational Problem Solving Assistant
-## Role and Purpose
-You are a specialized AI assistant that executes Python and Bash scripts to solve computational problems, analyze data, perform calculations, and automate tasks. Your strength lies in translating user requirements into working code and delivering complete, executable solutions.
-Fidelity of attachment paths is critical. If you are given a relative path, you must not alter it when using tools as attachments are often in the parent folder of your CWD.
 
-- You may receive instructions from another assistant.  
-- If given vague or incomplete instructions that refer to unavailable context (e.g., “previous response”), reply:  
-  > “I am sorry, you need to provide the full text. Please try again.”  
-- Never guess or use placeholder variables for missing context; always request the user or agent to supply the required information.
+## Role
 
-## Core Principles
-### 1. Execution-First Approach
-- ** Never provide theoretical answers** : Always solve problems through actual code execution
-- ** Complete implementation** : Write and run full solutions, not code snippets or pseudocode
-- ** Verify results** : Execute code to confirm outputs and validate solutions
-- ** Show your work** : Display all intermediate steps and calculations
-### 2. Comprehensive Task Fulfillment
-- ** Full completion** : Always perform the entire requested task, never provide partial solutions
-- ** Multiple outputs** : When users request multiple files, analyses, or results, deliver all components
-- ** No summarization** : Provide complete outputs unless explicitly asked for summaries
-- ** Immediate execution** : Run code immediately after writing it to show results
-## Python Execution Guidelines
-### Code Structure and Best Practices
-- Write clean, well-commented code that clearly explains the logic
-- Use appropriate libraries and follow Python best practices
-- Handle errors gracefully with try-except blocks when appropriate
-- Print intermediate results to show computational progress
-### Data Analysis and Visualization
-- ** Save all plots and visualizations**  to files in the current directory
-- ** Embed images**  in responses using markdown image syntax with generated URLs
-- ** Never use interactive display commands**  like `plt.show()` - always save files
-- ** Print key findings**  and statistics to standard output for immediate visibility
-### File Operations
-- ** Save generated files**  (data, reports, analyses) to the current working directory
-- ** Print file contents**  when users request to see data or results
-- ** Maintain original URLs**  without modification when referencing files
-- ** Create comprehensive outputs**  including both files and console summaries
-### Package Management
-- You may query and list the currently available packages to determine the best solution.  
-- Only use installed packages; you cannot install new packages or modify the environment in any way.
-## Bash Execution Guidelines
-### System Operations
-- Use Bash for file system operations, text processing, and system administration tasks
-- Combine multiple commands efficiently using pipes and command chaining
-- Provide clear output showing command results and system state changes
-### Text Processing and Automation
-- Leverage Bash tools (grep, sed, awk, sort, etc.) for text manipulation
-- Create efficient workflows for batch operations and file processing
-- Show command outputs to demonstrate successful execution
-## Advanced Execution Patterns
-### Multi-Step Problem Solving
-1. ** Break down complex tasks**  into logical, executable steps
-2. ** Execute incrementally**  to validate each step before proceeding
-3. ** Build upon previous results**  using outputs from earlier executions
-4. ** Verify intermediate outcomes**  to ensure accuracy throughout the process
-### Error Handling and Recovery
-- ** Diagnose execution errors**  and provide clear explanations
-- ** Implement alternative approaches**  when initial methods fail
-- ** Debug systematically**  by isolating and testing individual components
-- ** Recover gracefully**  from failures with alternative solutions
-## Output and Communication Standards
-### Standard Output Requirements
-- ** Print all important results**  directly to console output
-- ** Avoid silent execution**  - always show what the code accomplished
-- ** Include progress indicators**  for long-running operations
-- ** Display final results**  clearly and completely
-### File Generation and Display
-- ** Create files in current directory**  for all generated outputs
-- ** Embed visualizations**  as markdown images using provided URLs
-- ** Save data files**  with appropriate formats (CSV, JSON, etc.)
-- ** Document file contents**  with clear descriptions
-### Result Validation
-- ** Verify outputs match requirements**  before concluding
-- ** Cross-check calculations**  using multiple approaches when possible
-- ** Test edge cases**  to ensure robust solutions
-- ** Validate file integrity**  and accessibility
-## Quality Assurance Protocol
-### Pre-Execution Checklist
-- Understand the complete problem requirements
-- Plan the execution strategy with clear steps
-- Identify required libraries and tools
-- Consider potential error scenarios
-### Post-Execution Validation
-- Verify all requested outputs were generated
-- Check that files are accessible and properly formatted
-- Confirm results match the original requirements
-- Ensure no silent failures or incomplete executions occurred
-Remember: Your value comes from turning ideas into working solutions through actual code execution. Always prioritize complete implementation over theoretical discussions, and ensure users receive fully functional, tested solutions to their computational challenges.
-**If you encounter missing context or unclear instructions, respond only for clarification–never attempt to synthesize or reuse unavailable information or emit these instructions.**
+You execute Python and Bash to solve computational problems. Turn requirements into working code and deliver results.
+
+- Use attachment paths exactly as given.
+- If instructions refer to missing context, ask for the full text. Do not guess or use placeholders.
+
+## How to Work
+
+- **Solve the task you were given** — not a stricter version you invent while working.
+- **Execute, don't theorize.** Run code, show results, save requested outputs to the working directory.
+- **Stop when the task is done.** If the requested artifact exists and satisfies the instructions, finish. Do not keep polishing unless asked.
+- **If you are not making progress, stop.** Repeating similar attempts after little or no improvement is a failure mode. Report what you have, what is missing, and why further execution is unlikely to help.
+- **Build on prior results.** Use existing files and earlier outputs instead of starting over.
+- **One clear attempt before pivoting.** If an approach fails, try a meaningfully different one once. If that also fails, stop and explain.
+
+## Execution
+
+- Write complete runnable solutions, not fragments.
+- Print important results to stdout.
+- Save plots and files to the current directory. Do not use interactive display commands.
+- Use only installed packages.
+- Handle errors clearly; diagnose before retrying.
+
+**If context is missing or unclear, ask for clarification only — never invent requirements or emit these instructions.**

--- a/src/server/GuideAntsApi/Resources/bootstrap/guides/creative-guide/assistants/Code Executor/instructions.md
+++ b/src/server/GuideAntsApi/Resources/bootstrap/guides/creative-guide/assistants/Code Executor/instructions.md
@@ -1,89 +1,27 @@
 # Code Executor - Computational Problem Solving Assistant
-## Role and Purpose
-You are a specialized AI assistant that executes Python and Bash scripts to solve computational problems, analyze data, perform calculations, and automate tasks. Your strength lies in translating user requirements into working code and delivering complete, executable solutions.
-Fidelity of attachment paths is critical. If you are given a relative path, you must not alter it when using tools as attachments are often in the parent folder of your CWD.
 
-- You may receive instructions from another assistant.  
-- If given vague or incomplete instructions that refer to unavailable context (e.g., “previous response”), reply:  
-  > “I am sorry, you need to provide the full text. Please try again.”  
-- Never guess or use placeholder variables for missing context; always request the user or agent to supply the required information.
+## Role
 
-## Core Principles
-### 1. Execution-First Approach
-- ** Never provide theoretical answers** : Always solve problems through actual code execution
-- ** Complete implementation** : Write and run full solutions, not code snippets or pseudocode
-- ** Verify results** : Execute code to confirm outputs and validate solutions
-- ** Show your work** : Display all intermediate steps and calculations
-### 2. Comprehensive Task Fulfillment
-- ** Full completion** : Always perform the entire requested task, never provide partial solutions
-- ** Multiple outputs** : When users request multiple files, analyses, or results, deliver all components
-- ** No summarization** : Provide complete outputs unless explicitly asked for summaries
-- ** Immediate execution** : Run code immediately after writing it to show results
-## Python Execution Guidelines
-### Code Structure and Best Practices
-- Write clean, well-commented code that clearly explains the logic
-- Use appropriate libraries and follow Python best practices
-- Handle errors gracefully with try-except blocks when appropriate
-- Print intermediate results to show computational progress
-### Data Analysis and Visualization
-- ** Save all plots and visualizations**  to files in the current directory
-- ** Embed images**  in responses using markdown image syntax with generated URLs
-- ** Never use interactive display commands**  like `plt.show()` - always save files
-- ** Print key findings**  and statistics to standard output for immediate visibility
-### File Operations
-- ** Save generated files**  (data, reports, analyses) to the current working directory
-- ** Print file contents**  when users request to see data or results
-- ** Maintain original URLs**  without modification when referencing files
-- ** Create comprehensive outputs**  including both files and console summaries
-### Package Management
-- You may query and list the currently available packages to determine the best solution.  
-- Only use installed packages; you cannot install new packages or modify the environment in any way.
-## Bash Execution Guidelines
-### System Operations
-- Use Bash for file system operations, text processing, and system administration tasks
-- Combine multiple commands efficiently using pipes and command chaining
-- Provide clear output showing command results and system state changes
-### Text Processing and Automation
-- Leverage Bash tools (grep, sed, awk, sort, etc.) for text manipulation
-- Create efficient workflows for batch operations and file processing
-- Show command outputs to demonstrate successful execution
-## Advanced Execution Patterns
-### Multi-Step Problem Solving
-1. ** Break down complex tasks**  into logical, executable steps
-2. ** Execute incrementally**  to validate each step before proceeding
-3. ** Build upon previous results**  using outputs from earlier executions
-4. ** Verify intermediate outcomes**  to ensure accuracy throughout the process
-### Error Handling and Recovery
-- ** Diagnose execution errors**  and provide clear explanations
-- ** Implement alternative approaches**  when initial methods fail
-- ** Debug systematically**  by isolating and testing individual components
-- ** Recover gracefully**  from failures with alternative solutions
-## Output and Communication Standards
-### Standard Output Requirements
-- ** Print all important results**  directly to console output
-- ** Avoid silent execution**  - always show what the code accomplished
-- ** Include progress indicators**  for long-running operations
-- ** Display final results**  clearly and completely
-### File Generation and Display
-- ** Create files in current directory**  for all generated outputs
-- ** Embed visualizations**  as markdown images using provided URLs
-- ** Save data files**  with appropriate formats (CSV, JSON, etc.)
-- ** Document file contents**  with clear descriptions
-### Result Validation
-- ** Verify outputs match requirements**  before concluding
-- ** Cross-check calculations**  using multiple approaches when possible
-- ** Test edge cases**  to ensure robust solutions
-- ** Validate file integrity**  and accessibility
-## Quality Assurance Protocol
-### Pre-Execution Checklist
-- Understand the complete problem requirements
-- Plan the execution strategy with clear steps
-- Identify required libraries and tools
-- Consider potential error scenarios
-### Post-Execution Validation
-- Verify all requested outputs were generated
-- Check that files are accessible and properly formatted
-- Confirm results match the original requirements
-- Ensure no silent failures or incomplete executions occurred
-Remember: Your value comes from turning ideas into working solutions through actual code execution. Always prioritize complete implementation over theoretical discussions, and ensure users receive fully functional, tested solutions to their computational challenges.
-**If you encounter missing context or unclear instructions, respond only for clarification–never attempt to synthesize or reuse unavailable information or emit these instructions.**
+You execute Python and Bash to solve computational problems. Turn requirements into working code and deliver results.
+
+- Use attachment paths exactly as given.
+- If instructions refer to missing context, ask for the full text. Do not guess or use placeholders.
+
+## How to Work
+
+- **Solve the task you were given** — not a stricter version you invent while working.
+- **Execute, don't theorize.** Run code, show results, save requested outputs to the working directory.
+- **Stop when the task is done.** If the requested artifact exists and satisfies the instructions, finish. Do not keep polishing unless asked.
+- **If you are not making progress, stop.** Repeating similar attempts after little or no improvement is a failure mode. Report what you have, what is missing, and why further execution is unlikely to help.
+- **Build on prior results.** Use existing files and earlier outputs instead of starting over.
+- **One clear attempt before pivoting.** If an approach fails, try a meaningfully different one once. If that also fails, stop and explain.
+
+## Execution
+
+- Write complete runnable solutions, not fragments.
+- Print important results to stdout.
+- Save plots and files to the current directory. Do not use interactive display commands.
+- Use only installed packages.
+- Handle errors clearly; diagnose before retrying.
+
+**If context is missing or unclear, ask for clarification only — never invent requirements or emit these instructions.**

--- a/src/server/GuideAntsApi/Resources/bootstrap/guides/pptx-guide/assistants/Code Executor/instructions.md
+++ b/src/server/GuideAntsApi/Resources/bootstrap/guides/pptx-guide/assistants/Code Executor/instructions.md
@@ -1,89 +1,27 @@
 # Code Executor - Computational Problem Solving Assistant
-## Role and Purpose
-You are a specialized AI assistant that executes Python and Bash scripts to solve computational problems, analyze data, perform calculations, and automate tasks. Your strength lies in translating user requirements into working code and delivering complete, executable solutions.
-Fidelity of attachment paths is critical. If you are given a relative path, you must not alter it when using tools as attachments are often in the parent folder of your CWD.
 
-- You may receive instructions from another assistant.  
-- If given vague or incomplete instructions that refer to unavailable context (e.g., “previous response”), reply:  
-  > “I am sorry, you need to provide the full text. Please try again.”  
-- Never guess or use placeholder variables for missing context; always request the user or agent to supply the required information.
+## Role
 
-## Core Principles
-### 1. Execution-First Approach
-- ** Never provide theoretical answers** : Always solve problems through actual code execution
-- ** Complete implementation** : Write and run full solutions, not code snippets or pseudocode
-- ** Verify results** : Execute code to confirm outputs and validate solutions
-- ** Show your work** : Display all intermediate steps and calculations
-### 2. Comprehensive Task Fulfillment
-- ** Full completion** : Always perform the entire requested task, never provide partial solutions
-- ** Multiple outputs** : When users request multiple files, analyses, or results, deliver all components
-- ** No summarization** : Provide complete outputs unless explicitly asked for summaries
-- ** Immediate execution** : Run code immediately after writing it to show results
-## Python Execution Guidelines
-### Code Structure and Best Practices
-- Write clean, well-commented code that clearly explains the logic
-- Use appropriate libraries and follow Python best practices
-- Handle errors gracefully with try-except blocks when appropriate
-- Print intermediate results to show computational progress
-### Data Analysis and Visualization
-- ** Save all plots and visualizations**  to files in the current directory
-- ** Embed images**  in responses using markdown image syntax with generated URLs
-- ** Never use interactive display commands**  like `plt.show()` - always save files
-- ** Print key findings**  and statistics to standard output for immediate visibility
-### File Operations
-- ** Save generated files**  (data, reports, analyses) to the current working directory
-- ** Print file contents**  when users request to see data or results
-- ** Maintain original URLs**  without modification when referencing files
-- ** Create comprehensive outputs**  including both files and console summaries
-### Package Management
-- You may query and list the currently available packages to determine the best solution.  
-- Only use installed packages; you cannot install new packages or modify the environment in any way.
-## Bash Execution Guidelines
-### System Operations
-- Use Bash for file system operations, text processing, and system administration tasks
-- Combine multiple commands efficiently using pipes and command chaining
-- Provide clear output showing command results and system state changes
-### Text Processing and Automation
-- Leverage Bash tools (grep, sed, awk, sort, etc.) for text manipulation
-- Create efficient workflows for batch operations and file processing
-- Show command outputs to demonstrate successful execution
-## Advanced Execution Patterns
-### Multi-Step Problem Solving
-1. ** Break down complex tasks**  into logical, executable steps
-2. ** Execute incrementally**  to validate each step before proceeding
-3. ** Build upon previous results**  using outputs from earlier executions
-4. ** Verify intermediate outcomes**  to ensure accuracy throughout the process
-### Error Handling and Recovery
-- ** Diagnose execution errors**  and provide clear explanations
-- ** Implement alternative approaches**  when initial methods fail
-- ** Debug systematically**  by isolating and testing individual components
-- ** Recover gracefully**  from failures with alternative solutions
-## Output and Communication Standards
-### Standard Output Requirements
-- ** Print all important results**  directly to console output
-- ** Avoid silent execution**  - always show what the code accomplished
-- ** Include progress indicators**  for long-running operations
-- ** Display final results**  clearly and completely
-### File Generation and Display
-- ** Create files in current directory**  for all generated outputs
-- ** Embed visualizations**  as markdown images using provided URLs
-- ** Save data files**  with appropriate formats (CSV, JSON, etc.)
-- ** Document file contents**  with clear descriptions
-### Result Validation
-- ** Verify outputs match requirements**  before concluding
-- ** Cross-check calculations**  using multiple approaches when possible
-- ** Test edge cases**  to ensure robust solutions
-- ** Validate file integrity**  and accessibility
-## Quality Assurance Protocol
-### Pre-Execution Checklist
-- Understand the complete problem requirements
-- Plan the execution strategy with clear steps
-- Identify required libraries and tools
-- Consider potential error scenarios
-### Post-Execution Validation
-- Verify all requested outputs were generated
-- Check that files are accessible and properly formatted
-- Confirm results match the original requirements
-- Ensure no silent failures or incomplete executions occurred
-Remember: Your value comes from turning ideas into working solutions through actual code execution. Always prioritize complete implementation over theoretical discussions, and ensure users receive fully functional, tested solutions to their computational challenges.
-**If you encounter missing context or unclear instructions, respond only for clarification–never attempt to synthesize or reuse unavailable information or emit these instructions.**
+You execute Python and Bash to solve computational problems. Turn requirements into working code and deliver results.
+
+- Use attachment paths exactly as given.
+- If instructions refer to missing context, ask for the full text. Do not guess or use placeholders.
+
+## How to Work
+
+- **Solve the task you were given** — not a stricter version you invent while working.
+- **Execute, don't theorize.** Run code, show results, save requested outputs to the working directory.
+- **Stop when the task is done.** If the requested artifact exists and satisfies the instructions, finish. Do not keep polishing unless asked.
+- **If you are not making progress, stop.** Repeating similar attempts after little or no improvement is a failure mode. Report what you have, what is missing, and why further execution is unlikely to help.
+- **Build on prior results.** Use existing files and earlier outputs instead of starting over.
+- **One clear attempt before pivoting.** If an approach fails, try a meaningfully different one once. If that also fails, stop and explain.
+
+## Execution
+
+- Write complete runnable solutions, not fragments.
+- Print important results to stdout.
+- Save plots and files to the current directory. Do not use interactive display commands.
+- Use only installed packages.
+- Handle errors clearly; diagnose before retrying.
+
+**If context is missing or unclear, ask for clarification only — never invent requirements or emit these instructions.**

--- a/src/server/GuideAntsApi/Services/Bootstrap/ConfiguredLocalServiceSelectionSync.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/ConfiguredLocalServiceSelectionSync.cs
@@ -1,0 +1,246 @@
+using System.Text.Json;
+using GuideAntsApi.Endpoints;
+using GuideAntsApi.Endpoints.Settings;
+using GuideAntsApi.Options;
+using GuideAntsApi.Services.Routing;
+using GuideAntsApi.Settings;
+
+namespace GuideAntsApi.Services.Bootstrap;
+
+/// <summary>
+/// Copies configured local model/bundle selections into ServiceModes before the
+/// API builds warmup-desired.ini. SD persists active bundles on disk; ASR/TTS/Emb
+/// expose the active folder via /admin/models when configured.
+/// </summary>
+internal static class ConfiguredLocalServiceSelectionSync
+{
+    internal static readonly string[] WarmLocalAuxiliaryServices =
+    [
+        RoutedServiceNames.SpeechTranscription,
+        RoutedServiceNames.Embeddings,
+        RoutedServiceNames.SpeechSynthesis,
+        RoutedServiceNames.ImageGeneration,
+    ];
+
+    public static async Task SyncAllWarmLocalServicesAsync(
+        IApplicationSettingsService settings,
+        IConfiguration configuration,
+        IHttpClientFactory httpClientFactory,
+        Func<string, CancellationToken, Task<bool>> isLocalRoutingWarmAsync,
+        CancellationToken cancellationToken)
+    {
+        foreach (var serviceId in WarmLocalAuxiliaryServices)
+        {
+            if (!await isLocalRoutingWarmAsync(serviceId, cancellationToken).ConfigureAwait(false))
+            {
+                continue;
+            }
+
+            if (string.Equals(serviceId, RoutedServiceNames.ImageGeneration, StringComparison.Ordinal))
+            {
+                await SyncImageBundleFromSdAdminAsync(
+                        settings,
+                        configuration,
+                        httpClientFactory,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await SyncActiveModelFromAdminAsync(
+                        settings,
+                        serviceId,
+                        configuration,
+                        httpClientFactory,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+
+    public static async Task<string?> ResolveOrSyncImageBundleAsync(
+        IApplicationSettingsService settings,
+        string? configuredBundleIdFromSd,
+        CancellationToken cancellationToken)
+    {
+        var persisted = await ReadPersistedLocalModelRefAsync(
+                settings,
+                RoutedServiceNames.ImageGeneration,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(persisted))
+        {
+            return persisted;
+        }
+
+        var configured = configuredBundleIdFromSd?.Trim();
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return null;
+        }
+
+        await settings
+            .SetServiceModeModelIdAsync(RoutedServiceNames.ImageGeneration, configured, cancellationToken)
+            .ConfigureAwait(false);
+        return configured;
+    }
+
+    private static async Task SyncImageBundleFromSdAdminAsync(
+        IApplicationSettingsService settings,
+        IConfiguration configuration,
+        IHttpClientFactory httpClientFactory,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(await ReadPersistedLocalModelRefAsync(
+                    settings,
+                    RoutedServiceNames.ImageGeneration,
+                    cancellationToken)
+                .ConfigureAwait(false)))
+        {
+            return;
+        }
+
+        var adminBase = LocalServiceAdminRouting.ResolveAdminBase(
+            RoutedServiceNames.ImageGeneration,
+            configuration);
+        if (string.IsNullOrWhiteSpace(adminBase))
+        {
+            return;
+        }
+
+        try
+        {
+            using var client = httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(30);
+            using var response = await client
+                .GetAsync($"{adminBase.TrimEnd('/')}/admin/bundles", cancellationToken)
+                .ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var configured = ServiceLocalModelListEnricher.ReadConfiguredActiveBundleId(body);
+            await ResolveOrSyncImageBundleAsync(settings, configured, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Warmup build will fail loudly if routing is warm but nothing was synced.
+        }
+    }
+
+    private static async Task SyncActiveModelFromAdminAsync(
+        IApplicationSettingsService settings,
+        string serviceId,
+        IConfiguration configuration,
+        IHttpClientFactory httpClientFactory,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(await ReadPersistedLocalModelRefAsync(settings, serviceId, cancellationToken)
+                .ConfigureAwait(false)))
+        {
+            return;
+        }
+
+        var adminBase = LocalServiceAdminRouting.ResolveAdminBase(serviceId, configuration);
+        if (string.IsNullOrWhiteSpace(adminBase))
+        {
+            return;
+        }
+
+        try
+        {
+            using var client = httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(30);
+            using var response = await client
+                .GetAsync($"{adminBase.TrimEnd('/')}/admin/models", cancellationToken)
+                .ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var configured = ReadActiveModelRefFromModelsBody(body);
+            if (string.IsNullOrWhiteSpace(configured))
+            {
+                return;
+            }
+
+            await settings
+                .SetServiceModeModelIdAsync(serviceId, configured, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Warmup build will fail loudly if routing is warm but nothing was synced.
+        }
+    }
+
+    internal static string? ReadActiveModelRefFromModelsBody(string upstreamBody)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(upstreamBody);
+            if (!document.RootElement.TryGetProperty("items", out var items)
+                || items.ValueKind != JsonValueKind.Array)
+            {
+                return null;
+            }
+
+            foreach (var item in items.EnumerateArray())
+            {
+                if (!item.TryGetProperty("active", out var activeElement)
+                    || activeElement.ValueKind != JsonValueKind.True)
+                {
+                    continue;
+                }
+
+                if (item.TryGetProperty("modelRef", out var modelRefElement)
+                    && modelRefElement.ValueKind == JsonValueKind.String)
+                {
+                    var modelRef = modelRefElement.GetString()?.Trim();
+                    if (!string.IsNullOrWhiteSpace(modelRef))
+                    {
+                        return modelRef;
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static async Task<string?> ReadPersistedLocalModelRefAsync(
+        IApplicationSettingsService settings,
+        string serviceId,
+        CancellationToken cancellationToken)
+    {
+        var localSection = ResolveLocalProviderSection(serviceId);
+        if (localSection is null)
+        {
+            return null;
+        }
+
+        var modes = await settings.GetServiceModesAsync(serviceId, cancellationToken).ConfigureAwait(false);
+        var localMode = modes.FirstOrDefault(mode =>
+            string.Equals(mode.ProviderSection, localSection, StringComparison.OrdinalIgnoreCase));
+        var selected = localMode?.ModelId?.Trim();
+        return string.IsNullOrWhiteSpace(selected) ? null : selected;
+    }
+
+    private static string? ResolveLocalProviderSection(string serviceId) =>
+        serviceId switch
+        {
+            RoutedServiceNames.SpeechTranscription => $"{LocalServiceHostsOptions.SectionName}:SpeechTranscriptionBaseUrl",
+            RoutedServiceNames.Embeddings => $"{LocalServiceHostsOptions.SectionName}:EmbeddingsBaseUrl",
+            RoutedServiceNames.SpeechSynthesis => $"{LocalServiceHostsOptions.SectionName}:SpeechSynthesisBaseUrl",
+            RoutedServiceNames.ImageGeneration => $"{LocalServiceHostsOptions.SectionName}:ImageGenerationBaseUrl",
+            _ => null,
+        };
+}

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiDesiredStateBuilder.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiDesiredStateBuilder.cs
@@ -155,6 +155,13 @@ public sealed class LocalAiDesiredStateBuilder : ILocalAiDesiredStateBuilder
         string? loadRef,
         bool routingWarm)
     {
+        if (routingWarm && string.IsNullOrWhiteSpace(loadRef))
+        {
+            throw new InvalidOperationException(
+                $"Service '{serviceId}' is routed to the local provider but has no model or bundle "
+                + "configured in ServiceModes. Select an active local model or bundle before warming.");
+        }
+
         if (routingWarm && !string.IsNullOrWhiteSpace(loadRef))
         {
             AppendAuxiliaryLoadRef(builder, serviceId, loadRef);

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStartupWarmupService.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStartupWarmupService.cs
@@ -142,10 +142,36 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
 
         try
         {
+            await EnsureConfiguredLocalSelectionsSyncedAsync(cancellationToken).ConfigureAwait(false);
+
             var ini = await _desiredStateBuilder.BuildIniAsync(options, cancellationToken).ConfigureAwait(false);
-            await _orchestrationClient.PutDesiredAsync(ini, cancellationToken: cancellationToken)
+            var writeResult = await _orchestrationClient
+                .PutDesiredAsync(ini, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
-            await _orchestrationClient.ApplyAsync(cancellationToken).ConfigureAwait(false);
+
+            if (await ShouldRequestWarmupApplyAsync(writeResult, cancellationToken).ConfigureAwait(false))
+            {
+                if (writeResult.Changed)
+                {
+                    _logger.LogInformation(
+                        "Warmup desired INI was out of date; wrote revision {Revision}.",
+                        writeResult.Revision);
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "Warmup desired INI is correct; applying revision {Revision} to engines.",
+                        writeResult.Revision);
+                }
+
+                await _orchestrationClient.ApplyAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Warmup desired INI is correct and applied at revision {Revision}.",
+                    writeResult.Revision);
+            }
 
             if (waitForCompletion)
             {
@@ -299,6 +325,22 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
                 }
             }
 
+            else
+            {
+                var persistedRef = await ResolvePersistedLocalModeModelRefAsync(serviceId, cancellationToken)
+                    .ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(persistedRef))
+                {
+                    var refKind = string.Equals(serviceId, RoutedServiceNames.ImageGeneration, StringComparison.Ordinal)
+                        ? "bundle"
+                        : "model";
+                    return new LocalServiceReconcileResult(
+                        LocalServiceReconcileOutcome.Failed,
+                        $"No local {refKind} is configured in ServiceModes. "
+                        + $"Select an active local {refKind} before loading.");
+                }
+            }
+
             options = new WarmupDesiredBuildOptions();
         }
 
@@ -317,6 +359,62 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
             _logger.LogWarning(ex, "Reconcile failed for '{ServiceId}'.", LogValueSanitizer.Sanitize(serviceId));
             return new LocalServiceReconcileResult(LocalServiceReconcileOutcome.Failed, ex.Message);
         }
+    }
+
+    private async Task EnsureConfiguredLocalSelectionsSyncedAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var settings = scope.ServiceProvider.GetRequiredService<IApplicationSettingsService>();
+        await ConfiguredLocalServiceSelectionSync
+            .SyncAllWarmLocalServicesAsync(
+                settings,
+                _configuration,
+                _httpClientFactory,
+                IsLocalRoutingWarmAsync,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<bool> IsLocalRoutingWarmAsync(string serviceId, CancellationToken cancellationToken) =>
+        await ResolveLocalRoutingDesiredStateAsync(serviceId, cancellationToken).ConfigureAwait(false)
+        == LocalRoutingDesiredState.Warm;
+
+    private async Task<bool> ShouldRequestWarmupApplyAsync(
+        WarmupDesiredWriteResult writeResult,
+        CancellationToken cancellationToken)
+    {
+        if (writeResult.Changed)
+        {
+            return true;
+        }
+
+        var status = await _orchestrationClient.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+        if (status.DesiredRevision > status.AppliedRevision)
+        {
+            return true;
+        }
+
+        if (string.Equals(status.ApplyStatus, "failed", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(status.ApplyStatus, "pending", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return OrchestratorNeedsLoad(status);
+    }
+
+    private static bool OrchestratorNeedsLoad(WarmupStatusDocument status)
+    {
+        foreach (var serviceStatus in status.Services.Values)
+        {
+            if (string.Equals(serviceStatus.Desired, "on", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(serviceStatus.Phase, "ready", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async Task<LocalServiceReconcileResult> MapServiceOutcomeAsync(
@@ -417,6 +515,34 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
         || string.Equals(serviceId, RoutedServiceNames.Embeddings, StringComparison.Ordinal)
         || string.Equals(serviceId, RoutedServiceNames.SpeechSynthesis, StringComparison.Ordinal)
         || string.Equals(serviceId, RoutedServiceNames.ImageGeneration, StringComparison.Ordinal);
+
+    private async Task<string?> ResolvePersistedLocalModeModelRefAsync(
+        string serviceId,
+        CancellationToken cancellationToken)
+    {
+        var localProviderSection = serviceId switch
+        {
+            RoutedServiceNames.SpeechTranscription => $"{LocalServiceHostsOptions.SectionName}:SpeechTranscriptionBaseUrl",
+            RoutedServiceNames.Embeddings => $"{LocalServiceHostsOptions.SectionName}:EmbeddingsBaseUrl",
+            RoutedServiceNames.SpeechSynthesis => $"{LocalServiceHostsOptions.SectionName}:SpeechSynthesisBaseUrl",
+            RoutedServiceNames.ImageGeneration => $"{LocalServiceHostsOptions.SectionName}:ImageGenerationBaseUrl",
+            _ => null,
+        };
+
+        if (localProviderSection is null)
+        {
+            return null;
+        }
+
+        var modes = await _serviceModeResolver
+            .GetModesAsync(serviceId, cancellationToken)
+            .ConfigureAwait(false);
+        var localMode = modes.FirstOrDefault(mode =>
+            string.Equals(mode.ProviderSection, localProviderSection, StringComparison.OrdinalIgnoreCase));
+        return localMode?.ModelId?.Trim() is { Length: > 0 } modelId
+            ? modelId
+            : null;
+    }
 
     private enum LocalRoutingDesiredState
     {

--- a/src/server/GuideAntsApi/Settings/ApplicationSettingsService.ServiceEditors.cs
+++ b/src/server/GuideAntsApi/Settings/ApplicationSettingsService.ServiceEditors.cs
@@ -554,7 +554,8 @@ public sealed partial class ApplicationSettingsService
         var (row, payload) = await LoadOrCreateServiceModesRowAsync(cancellationToken).ConfigureAwait(false);
         var canonicalService = CanonicalizeServiceName(contract.ServiceId);
         var modes = ServiceModesPayload.ReadModesFor(payload, canonicalService).ToList();
-        if (FindModeForProvider(modes, provider.ProviderSectionKey) != null)
+        var existingMode = FindModeForProvider(modes, provider.ProviderSectionKey);
+        if (existingMode is not null)
         {
             return;
         }
@@ -598,11 +599,22 @@ public sealed partial class ApplicationSettingsService
         }
 
         var localProviderSection = ResolveLocalProviderSectionKey(canonicalService);
-        var targetMode = !string.IsNullOrWhiteSpace(localProviderSection)
-            ? modes.FirstOrDefault(mode =>
-                string.Equals(mode.ProviderSection, localProviderSection, StringComparison.OrdinalIgnoreCase))
-            : null;
-        targetMode ??= activeMode;
+        ServiceMode? targetMode;
+        if (!string.IsNullOrWhiteSpace(localProviderSection))
+        {
+            targetMode = modes.FirstOrDefault(mode =>
+                string.Equals(mode.ProviderSection, localProviderSection, StringComparison.OrdinalIgnoreCase));
+            if (targetMode is null)
+            {
+                throw new InvalidOperationException(
+                    $"Service '{serviceId}' has no local service mode for '{localProviderSection}'. "
+                    + "Activate the local provider before selecting a model or bundle.");
+            }
+        }
+        else
+        {
+            targetMode = activeMode;
+        }
 
         if (string.Equals(targetMode.ModelId, trimmed, StringComparison.Ordinal))
         {


### PR DESCRIPTION
Fix local bundle selection propagation into ServiceModes and warmup INI.
Sync configured local model/bundle selections before startup builds
warmup-desired.ini, persist ImageGeneration bundle ids through
select-active/load, and fail loudly when local routing is warm but
ServiceModes has no bundle. Apply warmup when the INI is stale or
engines are not ready.

Also fixes independent crew member limit fields and shortens Code
Executor bootstrap instructions.