### PR TITLE
Improve scheduled jobs live UX, assistant cache invalidation, and in-…

### DIFF
--- a/docker/docker-compose.cpu.api-only-local-build.yml
+++ b/docker/docker-compose.cpu.api-only-local-build.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/docker/docker-compose.cpu.yml
+++ b/docker/docker-compose.cpu.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/docker/docker-compose.cuda.api-only-local-build.yml
+++ b/docker/docker-compose.cuda.api-only-local-build.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/docker/docker-compose.cuda.yml
+++ b/docker/docker-compose.cuda.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/docker/docker-compose.ghcr-cpu.yml
+++ b/docker/docker-compose.ghcr-cpu.yml
@@ -8,6 +8,7 @@ services:
     container_name: mssql-express
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/docker/docker-compose.ghcr-cuda13.yml
+++ b/docker/docker-compose.ghcr-cuda13.yml
@@ -7,6 +7,7 @@ services:
     container_name: mssql-express
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/docker/docker-compose.ghcr-rocm.yml
+++ b/docker/docker-compose.ghcr-rocm.yml
@@ -7,6 +7,7 @@ services:
     container_name: mssql-express
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/docker/docker-compose.ghcr-slim.yml
+++ b/docker/docker-compose.ghcr-slim.yml
@@ -92,6 +92,7 @@ services:
         target: /app/ContentFiles
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
       - MSSQL_DB_NAME=${GA_DB_NAME:-guideants-dev}
       - ASPNETCORE_ENVIRONMENT=Development

--- a/docker/docker-compose.ghcr-vulkan.yml
+++ b/docker/docker-compose.ghcr-vulkan.yml
@@ -7,6 +7,7 @@ services:
     container_name: mssql-express
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/docker/docker-compose.mssql.yml
+++ b/docker/docker-compose.mssql.yml
@@ -28,6 +28,7 @@ services:
       - guideants_mssql_content_files:/app/ContentFiles
     environment:
       ACCEPT_EULA: "Y"
+      MSSQL_PID: Developer
       MSSQL_SA_PASSWORD: ${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
       MSSQL_DB_NAME: ${GA_DB_NAME:-guideants-dev}
       ASPNETCORE_ENVIRONMENT: Development

--- a/docker/docker-compose.rocm.yml
+++ b/docker/docker-compose.rocm.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/docker/docker-compose.slim.yml
+++ b/docker/docker-compose.slim.yml
@@ -93,6 +93,7 @@ services:
         target: /app/ContentFiles
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
       - MSSQL_DB_NAME=${GA_DB_NAME:-guideants-dev}
       - ASPNETCORE_ENVIRONMENT=Development

--- a/docker/docker-compose.vulkan.yml
+++ b/docker/docker-compose.vulkan.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/installer/docker/docker-compose.cpu.yml
+++ b/installer/docker/docker-compose.cpu.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/installer/docker/docker-compose.cuda.yml
+++ b/installer/docker/docker-compose.cuda.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/installer/docker/docker-compose.ghcr-cpu.yml
+++ b/installer/docker/docker-compose.ghcr-cpu.yml
@@ -8,6 +8,7 @@ services:
     container_name: mssql-express
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/installer/docker/docker-compose.ghcr-cuda13.yml
+++ b/installer/docker/docker-compose.ghcr-cuda13.yml
@@ -7,6 +7,7 @@ services:
     container_name: mssql-express
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/installer/docker/docker-compose.ghcr-rocm.yml
+++ b/installer/docker/docker-compose.ghcr-rocm.yml
@@ -7,6 +7,7 @@ services:
     container_name: mssql-express
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/installer/docker/docker-compose.ghcr-slim.yml
+++ b/installer/docker/docker-compose.ghcr-slim.yml
@@ -92,6 +92,7 @@ services:
         target: /app/ContentFiles
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
       - MSSQL_DB_NAME=${GA_DB_NAME:-guideants-dev}
       - ASPNETCORE_ENVIRONMENT=Development

--- a/installer/docker/docker-compose.ghcr-vulkan.yml
+++ b/installer/docker/docker-compose.ghcr-vulkan.yml
@@ -7,6 +7,7 @@ services:
     container_name: mssql-express
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/installer/docker/docker-compose.rocm.yml
+++ b/installer/docker/docker-compose.rocm.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/installer/docker/docker-compose.slim.yml
+++ b/installer/docker/docker-compose.slim.yml
@@ -93,6 +93,7 @@ services:
         target: /app/ContentFiles
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=${GA_SQL_SA_PASSWORD:-YourStrong!Passw0rd}
       - MSSQL_DB_NAME=${GA_DB_NAME:-guideants-dev}
       - ASPNETCORE_ENVIRONMENT=Development

--- a/installer/docker/docker-compose.vulkan.yml
+++ b/installer/docker/docker-compose.vulkan.yml
@@ -7,6 +7,7 @@ services:
     image: mssql2025-express-fts
     environment:
       - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
       - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -Q 'SELECT 1' -C -No | grep -q 1"]

--- a/src/client/src/components/common/ImageUpload.tsx
+++ b/src/client/src/components/common/ImageUpload.tsx
@@ -10,13 +10,16 @@ interface ImageUploadProps {
 export function ImageUpload({ currentImageUrl, onChange, label }: ImageUploadProps) {
   const [preview, setPreview] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [fileTypeError, setFileTypeError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileSelect = async (file: File) => {
     if (!file.type.startsWith('image/')) {
-      alert('Please select an image file');
+      setFileTypeError('Please select an image file (PNG, JPG, GIF, or similar).');
       return;
     }
+
+    setFileTypeError(null);
 
     // Create preview
     const reader = new FileReader();
@@ -52,6 +55,7 @@ export function ImageUpload({ currentImageUrl, onChange, label }: ImageUploadPro
 
   const handleClear = () => {
     setPreview(null);
+    setFileTypeError(null);
     onChange(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
@@ -63,6 +67,11 @@ export function ImageUpload({ currentImageUrl, onChange, label }: ImageUploadPro
   return (
     <div className="space-y-2">
       {label && <label className="block text-sm font-medium text-gray-700">{label}</label>}
+      {fileTypeError ? (
+        <p className="text-sm text-red-700" role="alert">
+          {fileTypeError}
+        </p>
+      ) : null}
       
       {displayImage ? (
         <div className="relative inline-block">

--- a/src/client/src/components/guides/PublishGuideDialog.tsx
+++ b/src/client/src/components/guides/PublishGuideDialog.tsx
@@ -99,6 +99,7 @@ export function PublishGuideDialog({
   const isEditMode = !!publishedGuide;
   const [activeTab, setActiveTab] = useState<TabId>('general');
   const [showDeactivateConfirm, setShowDeactivateConfirm] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   
   // General
   const [friendlyName, setFriendlyName] = useState(publishedGuide?.friendlyName || '');
@@ -218,6 +219,10 @@ export function PublishGuideDialog({
     return () => clearTimeout(timer);
   }, [friendlyName, validateFriendlyName]);
 
+  useEffect(() => {
+    setSubmitError(null);
+  }, [friendlyName, authWebhookUrl, hasApiKey]);
+
   const setWireApiEndpointFlag = (key: WireApiEndpointFlagKey, value: boolean) => {
     setWireApiEndpointFlags((prev) => ({ ...prev, [key]: value }));
   };
@@ -245,9 +250,14 @@ export function PublishGuideDialog({
 
     // Prevent both friendly name and authentication (webhook or API key)
     if (friendlyName.trim() && (authWebhookUrl.trim() || hasApiKey)) {
-      alert('A Published Guide cannot have both a Public URL (Friendly Name) and Authentication. Public URLs are for anonymous access only. Please clear one of them.');
+      setSubmitError(
+        'A published guide cannot have both a public URL (friendly name) and authentication. Public URLs are for anonymous access only — clear the friendly name or remove authentication.',
+      );
+      setActiveTab('auth');
       return;
     }
+
+    setSubmitError(null);
 
     const isAppIdentityAuth = publishedGuide?.authMode === 'AppIdentity';
 
@@ -467,6 +477,12 @@ export function PublishGuideDialog({
               </div>
             </div>
           )}
+
+          {submitError ? (
+            <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800" role="alert">
+              {submitError}
+            </div>
+          ) : null}
 
           {/* Read-only Info (edit mode only) */}
           {isEditMode && publishedGuide && (

--- a/src/client/src/components/guides/__tests__/PublishGuideDialog.general.test.tsx
+++ b/src/client/src/components/guides/__tests__/PublishGuideDialog.general.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { PublishGuideDialog } from '../PublishGuideDialog';
 
@@ -71,5 +71,40 @@ describe('PublishGuideDialog general flow', () => {
     await user.click(screen.getAllByRole('button', { name: 'Deactivate' })[0]);
     await user.click(screen.getAllByRole('button', { name: 'Deactivate' })[1]);
     expect(onDeactivate).toHaveBeenCalled();
+  });
+
+  it('shows an inline validation error when public URL and auth conflict on form submit', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+
+    render(
+      <PublishGuideDialog
+        guideName="Demo Guide"
+        guideId="guide-1"
+        publishedGuide={{
+          id: 'pub-1',
+          guideId: 'guide-1',
+          guideName: 'Demo Guide',
+          notebookId: 'notebook-1',
+          projectId: 'project-1',
+          friendlyName: 'demo-guide',
+          created: '2026-01-01T00:00:00Z',
+          active: true,
+        }}
+        onUpdate={onUpdate}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Auth' }));
+    const webhookInput = screen.getByLabelText(/authentication webhook url/i);
+    await user.type(webhookInput, 'https://example.com/auth');
+
+    const form = document.querySelector('form');
+    expect(form).toBeTruthy();
+    fireEvent.submit(form!);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/cannot have both a public url/i);
+    expect(onUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/client/src/components/guides/editor/Files.tsx
+++ b/src/client/src/components/guides/editor/Files.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import { FaFile, FaCode, FaTimes, FaPlus, FaEye, FaSpinner, FaExclamationTriangle, FaCheckCircle, FaDownload } from 'react-icons/fa';
+import { useToast } from '../../common/Toast';
 import { FileUploadDto, FileDto, MarkdownExtractionStatus } from '../../../types/guides';
 import { isMarkdownExtractionSupported, SUPPORTED_MARKDOWN_EXTRACTION_EXTENSIONS } from '../../../utils/fileTypeSupport';
 import { isMaterializableSkillPayloadPath } from './executablePayload';
@@ -14,6 +15,7 @@ interface FilesProps {
 }
 
 export function Files({ existingFiles, newFiles, onExistingFilesChange, onNewFilesChange, onPreviewMarkdown, onDownloadFile }: FilesProps) {
+  const { showToast } = useToast();
   const vectorStoreInputRef = useRef<HTMLInputElement>(null);
   const codeInterpreterInputRef = useRef<HTMLInputElement>(null);
 
@@ -81,12 +83,11 @@ export function Files({ existingFiles, newFiles, onExistingFilesChange, onNewFil
     try {
       // Validate file type for VectorStore
       if (folderKind === 'VectorStore' && !isMarkdownExtractionSupported(file.name, file.type)) {
-        alert(
-          `File type not supported for content extraction.\n\n` +
-          `Supported types: PDF, Word (.docx), Excel (.xlsx), PowerPoint (.pptx), ` +
-          `Images (JPEG, PNG, BMP, TIFF, HEIF), Text files (.txt, .md, .html, .json, .xml, .csv, .tsv)\n\n` +
-          `File: ${file.name}`
-        );
+        showToast({
+          type: 'warning',
+          title: 'Unsupported file type',
+          message: `${file.name} cannot be extracted for search. Supported types include PDF, Office documents, images, and common text formats.`,
+        });
         return null;
       }
 
@@ -114,7 +115,11 @@ export function Files({ existingFiles, newFiles, onExistingFilesChange, onNewFil
       return fileUpload;
     } catch (error) {
       console.error('File upload error:', error);
-      alert(`Failed to upload file: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      showToast({
+        type: 'error',
+        title: 'Failed to upload file',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
       return null;
     }
   };

--- a/src/client/src/components/home/AddAiServicesWizard.tsx
+++ b/src/client/src/components/home/AddAiServicesWizard.tsx
@@ -14,6 +14,7 @@ import {
   OPENAI_CORE_SECTION,
   OPENROUTER_SECTION,
   WIZARD_STEPS,
+  DEFAULT_WIZARD_PROVIDER,
 } from './addAiServicesWizard/constants';
 import { CoreConnectionStep } from './addAiServicesWizard/steps/CoreConnectionStep';
 import { FinishStep } from './addAiServicesWizard/steps/FinishStep';
@@ -148,7 +149,7 @@ const OPTIONAL_SERVICE_KEYS: OptionalServiceKey[] = [
 
 export default function AddAiServicesWizard({ isOpen, onDismiss, onOpenSettings }: AddAiServicesWizardProps) {
   const [step, setStep] = useState<AddAiServicesWizardStep>('provider');
-  const [provider, setProvider] = useState<AddAiServicesWizardProvider>('foundry');
+  const [provider, setProvider] = useState<AddAiServicesWizardProvider>(DEFAULT_WIZARD_PROVIDER);
   const [dontAutoOpenAgain, setDontAutoOpenAgain] = useState(false);
 
   const [snapshot, setSnapshot] = useState<WizardLoadSnapshot | null>(null);
@@ -390,7 +391,7 @@ export default function AddAiServicesWizard({ isOpen, onDismiss, onOpenSettings 
     setLoading(true);
     setGlobalError(null);
     setStep('provider');
-    setProvider('foundry');
+    setProvider(DEFAULT_WIZARD_PROVIDER);
     setDontAutoOpenAgain(false);
 
     void (async () => {

--- a/src/client/src/components/home/__tests__/AddAiServicesWizard.test.tsx
+++ b/src/client/src/components/home/__tests__/AddAiServicesWizard.test.tsx
@@ -411,6 +411,7 @@ describe('AddAiServicesWizard', () => {
     );
 
     const providerSelect = await screen.findByLabelText(/provider/i);
+    expect(providerSelect).toHaveValue('local-ai');
     expect(within(providerSelect).getByRole('option', { name: 'Microsoft Foundry' })).toBeInTheDocument();
     expect(within(providerSelect).getByRole('option', { name: 'Google Gemini' })).toBeInTheDocument();
   });
@@ -449,6 +450,7 @@ describe('AddAiServicesWizard', () => {
     await screen.findByLabelText(/provider/i);
     expect(screen.getByRole('button', { name: 'Finish' })).toBeDisabled();
 
+    fireEvent.change(screen.getByLabelText(/provider/i), { target: { value: 'foundry' } });
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
 
     await screen.findByRole('heading', { name: /Microsoft Foundry connection details/i });
@@ -518,6 +520,7 @@ describe('AddAiServicesWizard', () => {
     );
 
     await screen.findByLabelText(/provider/i);
+    fireEvent.change(screen.getByLabelText(/provider/i), { target: { value: 'foundry' } });
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
     await screen.findByRole('heading', { name: /Microsoft Foundry connection details/i });
     fireEvent.change(screen.getByLabelText(/resource/i), { target: { value: 'my-foundry-resource' } });

--- a/src/client/src/components/home/addAiServicesWizard/constants.ts
+++ b/src/client/src/components/home/addAiServicesWizard/constants.ts
@@ -59,6 +59,8 @@ export const WIZARD_PROVIDER_OPTIONS: readonly {
   },
 ] as const;
 
+export const DEFAULT_WIZARD_PROVIDER: AddAiServicesWizardProvider = WIZARD_PROVIDER_OPTIONS[0].id;
+
 export const FOUNDRY_CORE_SECTION = 'AzureOpenAI';
 export const GEMINI_CORE_SECTION = 'GoogleGeminiApi';
 export const OPENAI_CORE_SECTION = 'OpenAI';

--- a/src/client/src/components/project/content/ScheduledJobContent.tsx
+++ b/src/client/src/components/project/content/ScheduledJobContent.tsx
@@ -1,194 +1,411 @@
-import { useCallback, useEffect, useState } from 'react';
-import LoadingSpinner from '../../LoadingSpinner';
-import { scheduledJobsApi } from '../../../services/scheduledJobs';
-import type { ProjectScheduledJobDetailDto } from '../../../types/scheduledJob';
-import { ScheduledJobRunHistory } from './ScheduledJobRunHistory';
-
-interface ScheduledJobContentProps {
-  projectId: string;
-  jobId: string;
-  canRun?: boolean;
-}
-
-function formatUtc(value?: string | null): string {
-  if (!value) {
-    return '—';
-  }
-  return new Date(value).toLocaleString();
-}
-
-function jobTypeLabel(jobType: ProjectScheduledJobDetailDto['jobType']): string {
-  return jobType === 'NewConversation' ? 'New conversation in notebook' : 'Run Python script in notebook';
-}
-
-export function ScheduledJobContent({ projectId, jobId, canRun = false }: ScheduledJobContentProps) {
-  const [job, setJob] = useState<ProjectScheduledJobDetailDto | null>(null);
-  const [isLoadingJob, setIsLoadingJob] = useState(true);
-  const [isRunningNow, setIsRunningNow] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    setIsLoadingJob(true);
-    setError(null);
-
-    scheduledJobsApi.get(projectId, jobId)
-      .then((detail) => {
-        if (!cancelled) {
-          setJob(detail);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setJob(null);
-          setError(err instanceof Error ? err.message : 'Failed to load scheduled job');
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoadingJob(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [projectId, jobId]);
-
-  const handleTimingFieldsUpdate = useCallback((
-    fields: Pick<ProjectScheduledJobDetailDto, 'lastRunUtc' | 'lastRunStatus' | 'nextRunUtc'>
-  ) => {
-    setJob((current) => (current ? { ...current, ...fields } : current));
-  }, []);
-
-  const handleRunHistoryError = useCallback((message: string) => {
-    setError(message);
-  }, []);
-
-  const handleRunNow = async () => {
-    if (!canRun || isRunningNow) {
-      return;
-    }
-
-    setIsRunningNow(true);
-    setError(null);
-    try {
-      await scheduledJobsApi.runNow(projectId, jobId);
-      window.dispatchEvent(new CustomEvent('scheduled-job-run-triggered', { detail: { jobId } }));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to start job run');
-    } finally {
-      setIsRunningNow(false);
-    }
-  };
-
-  if (isLoadingJob) {
-    return <LoadingSpinner message="Loading scheduled job…" />;
-  }
-
-  if (!job) {
-    return (
-      <div className="p-6">
-        <p className="text-sm text-red-700">{error ?? 'Scheduled job not found.'}</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="p-6 max-w-4xl space-y-6">
-      <div>
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-xl font-semibold text-gray-900">{job.name}</h2>
-            <p className="mt-1 text-sm text-gray-500">{job.scheduleSummary}</p>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            {canRun && (
-              <button
-                type="button"
-                onClick={handleRunNow}
-                disabled={isRunningNow}
-                className="px-3 py-1.5 text-sm text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
-              >
-                {isRunningNow ? 'Starting…' : 'Run now'}
-              </button>
-            )}
-            <span
-              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                job.isEnabled ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800'
-              }`}
-            >
-              {job.isEnabled ? 'Enabled' : 'Disabled'}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      {error && (
-        <div className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2" role="alert">
-          {error}
-        </div>
-      )}
-
-      <div className="border border-gray-200 rounded-lg p-4 space-y-3">
-        <h3 className="text-sm font-medium text-gray-900">Configuration</h3>
-        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
-          <div>
-            <dt className="text-gray-500">Job type</dt>
-            <dd className="text-gray-900">{jobTypeLabel(job.jobType)}</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500">Notebook</dt>
-            <dd className="text-gray-900">{job.notebookTitle}</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500">Time zone</dt>
-            <dd className="text-gray-900">{job.timeZoneId}</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500">Next run</dt>
-            <dd className="text-gray-900">{formatUtc(job.nextRunUtc)}</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500">Last run</dt>
-            <dd className="text-gray-900">
-              {formatUtc(job.lastRunUtc)}
-              {job.lastRunStatus ? ` (${job.lastRunStatus})` : ''}
-            </dd>
-          </div>
-          {job.jobType === 'NewConversation' && (
-            <>
-              <div className="sm:col-span-2">
-                <dt className="text-gray-500">Conversation title</dt>
-                <dd className="text-gray-900">{job.conversationTitle ?? '—'}</dd>
-              </div>
-              <div>
-                <dt className="text-gray-500">Assistant</dt>
-                <dd className="text-gray-900">{job.assistantName ?? '—'}</dd>
-              </div>
-              <div className="sm:col-span-2">
-                <dt className="text-gray-500">Prompt</dt>
-                <dd className="text-gray-900 whitespace-pre-wrap">{job.prompt ?? '—'}</dd>
-              </div>
-            </>
-          )}
-          {job.jobType === 'RunPythonScript' && (
-            <div className="sm:col-span-2">
-              <dt className="text-gray-500">Script</dt>
-              <dd className="text-gray-900 font-mono text-xs">{job.scriptRelativePath ?? '—'}</dd>
-            </div>
-          )}
-        </dl>
-      </div>
-
-      <ScheduledJobRunHistory
-        projectId={projectId}
-        jobId={jobId}
-        notebookId={job.notebookId}
-        jobType={job.jobType}
-        onTimingFieldsUpdate={handleTimingFieldsUpdate}
-        onError={handleRunHistoryError}
-      />
-    </div>
-  );
-}
+import { useCallback, useState } from 'react';
+
+import LoadingSpinner from '../../LoadingSpinner';
+
+import type { ProjectScheduledJobDetailDto } from '../../../types/scheduledJob';
+
+import { formatInUserLocal, formatNextRun } from '../../../lib/scheduledJobDateTime';
+
+import { ScheduledJobRunHistoryDialog } from '../dialogs/ScheduledJobRunHistoryDialog';
+
+
+
+interface ScheduledJobContentProps {
+
+  projectId: string;
+
+  jobId: string;
+
+  job: ProjectScheduledJobDetailDto | null;
+
+  isLoading?: boolean;
+
+  error?: string | null;
+
+  canRun?: boolean;
+
+  onRefresh?: () => void;
+
+  onJobFieldsPatch?: (
+
+    fields: Partial<Pick<ProjectScheduledJobDetailDto, 'lastRunUtc' | 'lastRunStatus' | 'nextRunUtc' | 'isEnabled'>>
+
+  ) => void;
+
+}
+
+
+
+function jobTypeLabel(jobType: ProjectScheduledJobDetailDto['jobType']): string {
+
+  return jobType === 'NewConversation' ? 'New conversation in notebook' : 'Run Python script in notebook';
+
+}
+
+
+
+export function ScheduledJobContent({
+
+  projectId,
+
+  jobId,
+
+  job,
+
+  isLoading = false,
+
+  error = null,
+
+  canRun = false,
+
+  onRefresh,
+
+  onJobFieldsPatch,
+
+}: ScheduledJobContentProps) {
+
+  const [runDialog, setRunDialog] = useState<{ runOnOpen: boolean } | null>(null);
+
+
+
+  const handleTimingFieldsUpdate = useCallback((
+
+    fields: Pick<ProjectScheduledJobDetailDto, 'lastRunUtc' | 'lastRunStatus' | 'nextRunUtc'>
+
+  ) => {
+
+    onJobFieldsPatch?.(fields);
+
+  }, [onJobFieldsPatch]);
+
+
+
+  const handleCloseRunDialog = useCallback(() => {
+
+    setRunDialog(null);
+
+    onRefresh?.();
+
+  }, [onRefresh]);
+
+
+
+  if (isLoading && !job) {
+
+    return <LoadingSpinner message="Loading scheduled job…" />;
+
+  }
+
+
+
+  if (!job || job.id !== jobId) {
+
+    return (
+
+      <div className="p-6">
+
+        <p className="text-sm text-red-700">{error ?? 'Scheduled job not found.'}</p>
+
+      </div>
+
+    );
+
+  }
+
+
+
+  const isRunActive = job.lastRunStatus === 'Running';
+
+
+
+  return (
+
+    <>
+
+      <div className="p-6 max-w-4xl space-y-6">
+
+        <div>
+
+          <div className="flex items-start justify-between gap-4">
+
+            <div>
+
+              <h2 className="text-xl font-semibold text-gray-900">{job.name}</h2>
+
+              <p className="mt-1 text-sm text-gray-500">{job.scheduleSummary}</p>
+
+            </div>
+
+            <div className="flex items-center gap-2 shrink-0">
+
+              {canRun && job.isEnabled && (
+
+                <button
+
+                  type="button"
+
+                  onClick={() => setRunDialog({ runOnOpen: true })}
+
+                  className="px-3 py-1.5 text-sm text-white bg-blue-600 rounded-md hover:bg-blue-700"
+
+                >
+
+                  Run now
+
+                </button>
+
+              )}
+
+              <button
+
+                type="button"
+
+                onClick={() => setRunDialog({ runOnOpen: false })}
+
+                className="px-3 py-1.5 text-sm text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50"
+
+              >
+
+                View history
+
+              </button>
+
+              <span
+
+                className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+
+                  job.isEnabled ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800'
+
+                }`}
+
+              >
+
+                {job.isEnabled ? 'Enabled' : 'Disabled'}
+
+              </span>
+
+            </div>
+
+          </div>
+
+        </div>
+
+
+
+        {error && (
+
+          <div className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2" role="alert">
+
+            {error}
+
+          </div>
+
+        )}
+
+
+
+        {!job.isEnabled && (
+
+          <div className="p-4 bg-amber-50 border border-amber-200 rounded-md" role="status">
+
+            <p className="text-sm font-medium text-amber-900">This job is disabled</p>
+
+            <p className="text-xs text-amber-800 mt-1">
+
+              It will not run on schedule. Enable it from the sidebar context menu to resume automatic runs.
+
+            </p>
+
+          </div>
+
+        )}
+
+
+
+        {isRunActive && (
+
+          <div className="p-4 bg-blue-50 border border-blue-200 rounded-md flex items-start gap-3" role="status">
+
+            <svg className="w-5 h-5 text-blue-600 animate-spin mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+
+            </svg>
+
+            <div>
+
+              <p className="text-sm font-medium text-blue-900">Run in progress</p>
+
+              <p className="text-xs text-blue-700 mt-1">
+
+                Last run and next run update automatically while this job is running.
+
+              </p>
+
+            </div>
+
+          </div>
+
+        )}
+
+
+
+        <div className="border border-gray-200 rounded-lg p-4 space-y-3">
+
+          <h3 className="text-sm font-medium text-gray-900">Configuration</h3>
+
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+
+            <div>
+
+              <dt className="text-gray-500">Status</dt>
+
+              <dd className={job.isEnabled ? 'text-green-700 font-medium' : 'text-amber-700 font-medium'}>
+
+                {job.isEnabled ? 'Enabled — runs on schedule' : 'Disabled — automatic runs paused'}
+
+              </dd>
+
+            </div>
+
+            <div>
+
+              <dt className="text-gray-500">Job type</dt>
+
+              <dd className="text-gray-900">{jobTypeLabel(job.jobType)}</dd>
+
+            </div>
+
+            <div>
+
+              <dt className="text-gray-500">Notebook</dt>
+
+              <dd className="text-gray-900">{job.notebookTitle}</dd>
+
+            </div>
+
+            <div>
+
+              <dt className="text-gray-500">Time zone</dt>
+
+              <dd className="text-gray-900">{job.timeZoneId}</dd>
+
+            </div>
+
+            <div className="sm:col-span-2">
+
+              <dt className="text-gray-500">Next run</dt>
+
+              <dd className={job.isEnabled ? 'text-gray-900' : 'text-gray-500'}>
+
+                {formatNextRun(job.nextRunUtc, job.timeZoneId, job.isEnabled)}
+
+              </dd>
+
+              {job.isEnabled && job.nextRunUtc && (
+
+                <p className="text-xs text-gray-500 mt-0.5">
+
+                  Scheduled in {job.timeZoneId}
+
+                </p>
+
+              )}
+
+            </div>
+
+            <div>
+
+              <dt className="text-gray-500">Last run</dt>
+
+              <dd className="text-gray-900">
+
+                {formatInUserLocal(job.lastRunUtc)}
+
+                {job.lastRunStatus ? ` (${job.lastRunStatus})` : ''}
+
+              </dd>
+
+            </div>
+
+            {job.jobType === 'NewConversation' && (
+
+              <>
+
+                <div className="sm:col-span-2">
+
+                  <dt className="text-gray-500">Conversation title</dt>
+
+                  <dd className="text-gray-900">{job.conversationTitle ?? '—'}</dd>
+
+                </div>
+
+                <div>
+
+                  <dt className="text-gray-500">Assistant</dt>
+
+                  <dd className="text-gray-900">{job.assistantName ?? '—'}</dd>
+
+                </div>
+
+                <div className="sm:col-span-2">
+
+                  <dt className="text-gray-500">Prompt</dt>
+
+                  <dd className="text-gray-900 whitespace-pre-wrap">{job.prompt ?? '—'}</dd>
+
+                </div>
+
+              </>
+
+            )}
+
+            {job.jobType === 'RunPythonScript' && (
+
+              <div className="sm:col-span-2">
+
+                <dt className="text-gray-500">Script</dt>
+
+                <dd className="text-gray-900 font-mono text-xs">{job.scriptRelativePath ?? '—'}</dd>
+
+              </div>
+
+            )}
+
+          </dl>
+
+        </div>
+
+      </div>
+
+
+
+      {runDialog && (
+
+        <ScheduledJobRunHistoryDialog
+
+          projectId={projectId}
+
+          job={job}
+
+          isOpen
+
+          runOnOpen={runDialog.runOnOpen}
+
+          canRun={canRun && runDialog.runOnOpen}
+
+          onClose={handleCloseRunDialog}
+
+          onTimingFieldsUpdate={handleTimingFieldsUpdate}
+
+        />
+
+      )}
+
+    </>
+
+  );
+
+}

--- a/src/client/src/components/project/content/ScheduledJobRunHistory.tsx
+++ b/src/client/src/components/project/content/ScheduledJobRunHistory.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { scheduledJobsApi } from '../../../services/scheduledJobs';
 import type {
@@ -7,23 +7,36 @@ import type {
   ProjectScheduledJobRunSummaryDto,
   ScheduledJobType,
 } from '../../../types/scheduledJob';
+import { formatInUserLocal } from '../../../lib/scheduledJobDateTime';
 
 interface ScheduledJobRunHistoryProps {
   projectId: string;
   jobId: string;
   notebookId: string;
   jobType: ScheduledJobType;
+  runOnOpen?: boolean;
+  canRun?: boolean;
+  embedded?: boolean;
   onTimingFieldsUpdate?: (
     fields: Pick<ProjectScheduledJobDetailDto, 'lastRunUtc' | 'lastRunStatus' | 'nextRunUtc'>
   ) => void;
   onError?: (message: string) => void;
+  onActivityChange?: (active: boolean) => void;
 }
 
-function formatUtc(value?: string | null): string {
-  if (!value) {
-    return '—';
+function statusClassName(status: ProjectScheduledJobRunSummaryDto['status']): string {
+  switch (status) {
+    case 'Running':
+      return 'text-blue-700 font-medium';
+    case 'Succeeded':
+      return 'text-green-700';
+    case 'Failed':
+      return 'text-red-700';
+    case 'Cancelled':
+      return 'text-amber-700';
+    default:
+      return 'text-gray-900';
   }
-  return new Date(value).toLocaleString();
 }
 
 export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
@@ -31,8 +44,12 @@ export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
   jobId,
   notebookId,
   jobType,
+  runOnOpen = false,
+  canRun = false,
+  embedded = false,
   onTimingFieldsUpdate,
   onError,
+  onActivityChange,
 }: ScheduledJobRunHistoryProps) {
   const navigate = useNavigate();
   const [runs, setRuns] = useState<ProjectScheduledJobRunSummaryDto[]>([]);
@@ -40,7 +57,12 @@ export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
   const [page, setPage] = useState(1);
   const [selectedRun, setSelectedRun] = useState<ProjectScheduledJobRunDetailDto | null>(null);
   const [isLoadingRuns, setIsLoadingRuns] = useState(true);
+  const [isStartingRun, setIsStartingRun] = useState(false);
   const [pollRunsUntil, setPollRunsUntil] = useState<number | null>(null);
+  const runOnOpenSessionRef = useRef<{ jobId: string | null; triggered: boolean }>({
+    jobId: null,
+    triggered: false,
+  });
   const pageSize = 10;
 
   const refreshTimingFields = useCallback(async () => {
@@ -80,10 +102,48 @@ export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
     }
   }, [projectId, jobId, page, onError]);
 
+  const openRunDetail = useCallback(async (runId: string, options?: { silent?: boolean }) => {
+    try {
+      const detail = await scheduledJobsApi.getRun(projectId, jobId, runId);
+      setSelectedRun(detail);
+      return detail;
+    } catch (err) {
+      if (!options?.silent) {
+        onError?.(err instanceof Error ? err.message : 'Failed to load run details');
+      }
+      return null;
+    }
+  }, [projectId, jobId, onError]);
+
+  const beginPolling = useCallback(() => {
+    setPollRunsUntil(Date.now() + 120_000);
+    setPage(1);
+  }, []);
+
+  const triggerRunNow = useCallback(async () => {
+    if (!canRun || isStartingRun) {
+      return;
+    }
+
+    setIsStartingRun(true);
+    try {
+      await scheduledJobsApi.runNow(projectId, jobId);
+      beginPolling();
+      window.dispatchEvent(new CustomEvent('scheduled-job-run-triggered', { detail: { jobId } }));
+      void loadRuns({ silent: true });
+      void refreshTimingFields();
+    } catch (err) {
+      onError?.(err instanceof Error ? err.message : 'Failed to start job run');
+    } finally {
+      setIsStartingRun(false);
+    }
+  }, [beginPolling, canRun, isStartingRun, jobId, loadRuns, onError, projectId, refreshTimingFields]);
+
   useEffect(() => {
     setPage(1);
     setSelectedRun(null);
     setPollRunsUntil(null);
+    runOnOpenSessionRef.current = { jobId: null, triggered: false };
   }, [projectId, jobId]);
 
   useEffect(() => {
@@ -91,25 +151,44 @@ export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
   }, [loadRuns]);
 
   useEffect(() => {
+    if (!runOnOpen || !canRun) {
+      return;
+    }
+
+    const session = runOnOpenSessionRef.current;
+    if (session.jobId === jobId && session.triggered) {
+      return;
+    }
+
+    runOnOpenSessionRef.current = { jobId, triggered: true };
+    void triggerRunNow();
+  }, [runOnOpen, canRun, jobId, triggerRunNow]);
+
+  useEffect(() => {
     const handleRunTriggered = (event: Event) => {
       const detail = (event as CustomEvent<{ jobId: string }>).detail;
       if (detail?.jobId !== jobId) {
         return;
       }
-      setPollRunsUntil(Date.now() + 120_000);
-      setPage(1);
+      beginPolling();
       void loadRuns({ silent: true });
       void refreshTimingFields();
     };
 
     window.addEventListener('scheduled-job-run-triggered', handleRunTriggered);
     return () => window.removeEventListener('scheduled-job-run-triggered', handleRunTriggered);
-  }, [jobId, loadRuns, refreshTimingFields]);
+  }, [beginPolling, jobId, loadRuns, refreshTimingFields]);
 
   const hasRunningRun = runs.some((run) => run.status === 'Running');
+  const latestRun = runs[0] ?? null;
+  const isActive = isStartingRun || hasRunningRun || (pollRunsUntil != null && Date.now() < pollRunsUntil);
 
   useEffect(() => {
-    const shouldPoll = hasRunningRun || (pollRunsUntil != null && Date.now() < pollRunsUntil);
+    onActivityChange?.(isActive);
+  }, [isActive, onActivityChange]);
+
+  useEffect(() => {
+    const shouldPoll = hasRunningRun || isStartingRun || (pollRunsUntil != null && Date.now() < pollRunsUntil);
     if (!shouldPoll) {
       return;
     }
@@ -117,49 +196,88 @@ export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
     const intervalId = window.setInterval(() => {
       void loadRuns({ silent: true });
       void refreshTimingFields();
-      if (pollRunsUntil != null && Date.now() >= pollRunsUntil && !hasRunningRun) {
+      if (selectedRun?.status === 'Running') {
+        void openRunDetail(selectedRun.id, { silent: true });
+      }
+      if (pollRunsUntil != null && Date.now() >= pollRunsUntil && !hasRunningRun && !isStartingRun) {
         setPollRunsUntil(null);
       }
     }, 3000);
 
     return () => window.clearInterval(intervalId);
-  }, [hasRunningRun, pollRunsUntil, loadRuns, refreshTimingFields]);
+  }, [
+    hasRunningRun,
+    isStartingRun,
+    pollRunsUntil,
+    loadRuns,
+    openRunDetail,
+    refreshTimingFields,
+    selectedRun,
+  ]);
 
-  const openRunDetail = async (runId: string) => {
-    try {
-      const detail = await scheduledJobsApi.getRun(projectId, jobId, runId);
-      setSelectedRun(detail);
-    } catch (err) {
-      onError?.(err instanceof Error ? err.message : 'Failed to load run details');
-    }
-  };
-
-  const openConversation = () => {
-    if (!selectedRun?.createdConversationId) {
+  useEffect(() => {
+    const runningRun = runs.find((run) => run.status === 'Running');
+    if (!runningRun) {
       return;
     }
 
+    if (selectedRun?.id === runningRun.id && selectedRun.status === 'Running') {
+      return;
+    }
+
+    void openRunDetail(runningRun.id, { silent: true });
+  }, [openRunDetail, runs, selectedRun]);
+
+  const openConversation = (conversationId: string) => {
     navigate(`/projects/${projectId}/notebooks/${notebookId}`, {
-      state: { conversationId: selectedRun.createdConversationId },
+      state: { conversationId },
     });
   };
 
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const activeConversationId = selectedRun?.createdConversationId
+    ?? latestRun?.createdConversationId
+    ?? null;
 
-  return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden">
-      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
-        <h3 className="text-sm font-medium text-gray-900">Run history</h3>
-        {(hasRunningRun || pollRunsUntil != null) && (
-          <span className="text-xs text-blue-600">Refreshing…</span>
-        )}
-      </div>
+  const content = (
+    <>
+      {(isStartingRun || hasRunningRun) && (
+        <div className={`${embedded ? 'px-6' : 'px-4'} pt-4`}>
+          <div className="p-4 bg-blue-50 border border-blue-200 rounded-md flex items-start gap-3">
+            <svg className="w-5 h-5 text-blue-600 animate-spin mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+            </svg>
+            <div className="min-w-0 flex-1 space-y-2">
+              <div>
+                <p className="text-sm font-medium text-blue-900">
+                  {isStartingRun ? 'Starting run…' : 'Run in progress'}
+                </p>
+                <p className="text-xs text-blue-700">
+                  Status updates automatically. You can close this dialog and the job will keep running.
+                </p>
+              </div>
+              {jobType === 'NewConversation' && activeConversationId && (
+                <button
+                  type="button"
+                  className="text-sm font-medium text-blue-700 hover:underline"
+                  onClick={() => openConversation(activeConversationId)}
+                >
+                  Open conversation
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
-      <div className="px-4 py-4">
+      <div className={`${embedded ? 'px-6 py-4' : 'px-4 py-4'}`}>
         {isLoadingRuns ? (
           <p className="text-sm text-gray-500">Loading runs…</p>
         ) : runs.length === 0 ? (
-          <p className="text-sm text-gray-500">No runs recorded yet.</p>
+          <p className="text-sm text-gray-500">
+            {isStartingRun ? 'Waiting for the run to appear…' : 'No runs recorded yet.'}
+          </p>
         ) : (
           <table className="min-w-full text-sm">
             <thead>
@@ -172,9 +290,12 @@ export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
             </thead>
             <tbody>
               {runs.map((run) => (
-                <tr key={run.id} className="border-b border-gray-100">
-                  <td className="py-2 pr-4">{formatUtc(run.startedUtc)}</td>
-                  <td className="py-2 pr-4">{run.status}</td>
+                <tr
+                  key={run.id}
+                  className={`border-b border-gray-100 ${run.status === 'Running' ? 'bg-blue-50/60' : ''}`}
+                >
+                  <td className="py-2 pr-4">{formatInUserLocal(run.startedUtc)}</td>
+                  <td className={`py-2 pr-4 ${statusClassName(run.status)}`}>{run.status}</td>
                   <td className="py-2 pr-4">{run.triggeredBy}</td>
                   <td className="py-2 pr-4">
                     <button
@@ -210,7 +331,7 @@ export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
               <button
                 type="button"
                 className="text-sm text-blue-600 hover:underline"
-                onClick={openConversation}
+                onClick={() => openConversation(selectedRun.createdConversationId!)}
               >
                 Open conversation
               </button>
@@ -231,7 +352,7 @@ export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
         )}
       </div>
 
-      <div className="px-4 py-3 border-t border-gray-200 flex items-center justify-between bg-gray-50">
+      <div className={`${embedded ? 'px-6 py-3' : 'px-4 py-3'} border-t border-gray-200 flex items-center justify-between bg-gray-50`}>
         <span className="text-sm text-gray-500">
           Page {page} of {totalPages} ({totalCount} runs)
         </span>
@@ -254,6 +375,22 @@ export const ScheduledJobRunHistory = memo(function ScheduledJobRunHistory({
           </button>
         </div>
       </div>
+    </>
+  );
+
+  if (embedded) {
+    return content;
+  }
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
+      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-900">Run history</h3>
+        {isActive && (
+          <span className="text-xs text-blue-600">Refreshing…</span>
+        )}
+      </div>
+      {content}
     </div>
   );
 });

--- a/src/client/src/components/project/dialogs/CreateEditScheduledJobDialog.tsx
+++ b/src/client/src/components/project/dialogs/CreateEditScheduledJobDialog.tsx
@@ -20,7 +20,7 @@ interface CreateEditScheduledJobDialogProps {
   projectId: string;
   isOpen: boolean;
   onClose: () => void;
-  onSaved: () => void;
+  onSaved: (job: ProjectScheduledJobDetailDto) => void;
   notebooks: ProjectNotebook[];
   job?: ProjectScheduledJobDetailDto | null;
   disabled?: boolean;
@@ -293,12 +293,10 @@ export function CreateEditScheduledJobDialog({
     setIsSubmitting(true);
     setError(null);
     try {
-      if (job) {
-        await scheduledJobsApi.update(projectId, job.id, payload);
-      } else {
-        await scheduledJobsApi.create(projectId, payload);
-      }
-      onSaved();
+      const saved = job
+        ? await scheduledJobsApi.update(projectId, job.id, payload)
+        : await scheduledJobsApi.create(projectId, payload);
+      onSaved(saved);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save scheduled job');

--- a/src/client/src/components/project/dialogs/ScheduledJobRunHistoryDialog.tsx
+++ b/src/client/src/components/project/dialogs/ScheduledJobRunHistoryDialog.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { scheduledJobsApi } from '../../../services/scheduledJobs';
+import { ScheduledJobRunHistory } from '../content/ScheduledJobRunHistory';
 import type {
-  ProjectScheduledJobRunDetailDto,
-  ProjectScheduledJobRunSummaryDto,
+  ProjectScheduledJobDetailDto,
   ProjectScheduledJobSummaryDto,
 } from '../../../types/scheduledJob';
 
@@ -12,6 +11,11 @@ interface ScheduledJobRunHistoryDialogProps {
   job: ProjectScheduledJobSummaryDto;
   isOpen: boolean;
   onClose: () => void;
+  runOnOpen?: boolean;
+  canRun?: boolean;
+  onTimingFieldsUpdate?: (
+    fields: Pick<ProjectScheduledJobDetailDto, 'lastRunUtc' | 'lastRunStatus' | 'nextRunUtc'>
+  ) => void;
 }
 
 export function ScheduledJobRunHistoryDialog({
@@ -19,35 +23,19 @@ export function ScheduledJobRunHistoryDialog({
   job,
   isOpen,
   onClose,
+  runOnOpen = false,
+  canRun = false,
+  onTimingFieldsUpdate,
 }: ScheduledJobRunHistoryDialogProps) {
-  const [runs, setRuns] = useState<ProjectScheduledJobRunSummaryDto[]>([]);
-  const [totalCount, setTotalCount] = useState(0);
-  const [page, setPage] = useState(1);
-  const [selectedRun, setSelectedRun] = useState<ProjectScheduledJobRunDetailDto | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const pageSize = 10;
-
-  const loadRuns = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const result = await scheduledJobsApi.listRuns(projectId, job.id, page, pageSize);
-      setRuns(result.items);
-      setTotalCount(result.totalCount);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load run history');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [projectId, job.id, page]);
+  const [isActive, setIsActive] = useState(false);
 
   useEffect(() => {
     if (!isOpen) {
-      return;
+      setError(null);
+      setIsActive(false);
     }
-    loadRuns();
-  }, [isOpen, loadRuns]);
+  }, [isOpen]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -59,20 +47,17 @@ export function ScheduledJobRunHistoryDialog({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, onClose]);
 
-  const openRunDetail = async (runId: string) => {
-    try {
-      const detail = await scheduledJobsApi.getRun(projectId, job.id, runId);
-      setSelectedRun(detail);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load run details');
-    }
-  };
+  const handleActivityChange = useCallback((active: boolean) => {
+    setIsActive(active);
+  }, []);
 
   if (!isOpen) {
     return null;
   }
 
-  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const title = runOnOpen && isActive
+    ? `Running — ${job.name}`
+    : `Run history — ${job.name}`;
 
   return createPortal(
     <div
@@ -85,7 +70,7 @@ export function ScheduledJobRunHistoryDialog({
         <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
           <div>
             <h2 id="scheduled-job-history-title" className="text-lg font-semibold text-gray-900">
-              Run history — {job.name}
+              {title}
             </h2>
             <p className="text-sm text-gray-500">{job.scheduleSummary}</p>
           </div>
@@ -105,96 +90,19 @@ export function ScheduledJobRunHistoryDialog({
           </div>
         )}
 
-        <div className="flex-1 overflow-auto px-6 py-4">
-          {isLoading ? (
-            <p className="text-sm text-gray-500">Loading runs…</p>
-          ) : runs.length === 0 ? (
-            <p className="text-sm text-gray-500">No runs recorded yet.</p>
-          ) : (
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr className="text-left text-gray-500 border-b">
-                  <th className="py-2 pr-4">Started</th>
-                  <th className="py-2 pr-4">Status</th>
-                  <th className="py-2 pr-4">Trigger</th>
-                  <th className="py-2 pr-4">Details</th>
-                </tr>
-              </thead>
-              <tbody>
-                {runs.map((run) => (
-                  <tr key={run.id} className="border-b border-gray-100">
-                    <td className="py-2 pr-4">{new Date(run.startedUtc).toLocaleString()}</td>
-                    <td className="py-2 pr-4">{run.status}</td>
-                    <td className="py-2 pr-4">{run.triggeredBy}</td>
-                    <td className="py-2 pr-4">
-                      <button
-                        type="button"
-                        className="text-blue-600 hover:underline"
-                        onClick={() => openRunDetail(run.id)}
-                      >
-                        View output
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-
-          {selectedRun && (
-            <div className="mt-6 border border-gray-200 rounded-md p-4 space-y-3">
-              <div className="flex items-center justify-between">
-                <h3 className="font-medium text-gray-900">Run details</h3>
-                <button type="button" className="text-sm text-gray-500 hover:text-gray-700" onClick={() => setSelectedRun(null)}>
-                  Close details
-                </button>
-              </div>
-              {selectedRun.errorMessage && (
-                <p className="text-sm text-red-700">{selectedRun.errorMessage}</p>
-              )}
-              {selectedRun.createdConversationId && (
-                <p className="text-sm text-gray-700">
-                  Conversation ID: <code>{selectedRun.createdConversationId}</code>
-                </p>
-              )}
-              <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">stdout</label>
-                <pre className="text-xs bg-gray-50 border rounded p-3 overflow-auto max-h-48 whitespace-pre-wrap">
-                  {selectedRun.standardOutput || '(empty)'}
-                </pre>
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">stderr</label>
-                <pre className="text-xs bg-gray-50 border rounded p-3 overflow-auto max-h-48 whitespace-pre-wrap">
-                  {selectedRun.standardError || '(empty)'}
-                </pre>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="px-6 py-3 border-t border-gray-200 flex items-center justify-between">
-          <span className="text-sm text-gray-500">
-            Page {page} of {totalPages} ({totalCount} runs)
-          </span>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              disabled={page <= 1}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              className="px-3 py-1 text-sm border rounded disabled:opacity-50"
-            >
-              Previous
-            </button>
-            <button
-              type="button"
-              disabled={page >= totalPages}
-              onClick={() => setPage((p) => p + 1)}
-              className="px-3 py-1 text-sm border rounded disabled:opacity-50"
-            >
-              Next
-            </button>
-          </div>
+        <div className="flex-1 overflow-auto">
+          <ScheduledJobRunHistory
+            projectId={projectId}
+            jobId={job.id}
+            notebookId={job.notebookId}
+            jobType={job.jobType}
+            runOnOpen={runOnOpen}
+            canRun={canRun}
+            embedded
+            onTimingFieldsUpdate={onTimingFieldsUpdate}
+            onError={setError}
+            onActivityChange={handleActivityChange}
+          />
         </div>
       </div>
     </div>,

--- a/src/client/src/components/project/dialogs/__tests__/CreateEditScheduledJobDialog.test.tsx
+++ b/src/client/src/components/project/dialogs/__tests__/CreateEditScheduledJobDialog.test.tsx
@@ -101,7 +101,7 @@ describe('CreateEditScheduledJobDialog', () => {
         }),
       );
     });
-    expect(onSaved).toHaveBeenCalled();
+    expect(onSaved).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-new' }));
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/src/client/src/components/project/dialogs/__tests__/ScheduledJobRunHistoryDialog.test.tsx
+++ b/src/client/src/components/project/dialogs/__tests__/ScheduledJobRunHistoryDialog.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ComponentProps } from 'react';
 import { ScheduledJobRunHistoryDialog } from '../ScheduledJobRunHistoryDialog';
 import { scheduledJobsApi } from '../../../../services/scheduledJobs';
 import type { ProjectScheduledJobSummaryDto } from '../../../../types/scheduledJob';
@@ -9,6 +11,8 @@ vi.mock('../../../../services/scheduledJobs', () => ({
   scheduledJobsApi: {
     listRuns: vi.fn(),
     getRun: vi.fn(),
+    get: vi.fn(),
+    runNow: vi.fn(),
   },
 }));
 
@@ -30,19 +34,42 @@ const job: ProjectScheduledJobSummaryDto = {
   updatedUtc: '2026-01-01T00:00:00Z',
 };
 
+function renderDialog(props: Partial<ComponentProps<typeof ScheduledJobRunHistoryDialog>> = {}) {
+  return render(
+    <MemoryRouter>
+      <ScheduledJobRunHistoryDialog
+        projectId="project-1"
+        job={job}
+        isOpen
+        onClose={vi.fn()}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+}
+
 describe('ScheduledJobRunHistoryDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(scheduledJobsApi.listRuns).mockResolvedValue({
+      items: [],
+      totalCount: 0,
+      page: 1,
+      pageSize: 10,
+    });
+    vi.mocked(scheduledJobsApi.runNow).mockResolvedValue(undefined);
   });
 
   it('renders nothing when closed', () => {
     const { container } = render(
-      <ScheduledJobRunHistoryDialog
-        projectId="project-1"
-        job={job}
-        isOpen={false}
-        onClose={vi.fn()}
-      />,
+      <MemoryRouter>
+        <ScheduledJobRunHistoryDialog
+          projectId="project-1"
+          job={job}
+          isOpen={false}
+          onClose={vi.fn()}
+        />
+      </MemoryRouter>,
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -50,27 +77,30 @@ describe('ScheduledJobRunHistoryDialog', () => {
   });
 
   it('shows empty state when no runs exist', async () => {
-    vi.mocked(scheduledJobsApi.listRuns).mockResolvedValue({
-      items: [],
-      totalCount: 0,
-      page: 1,
-      pageSize: 10,
-    });
-
-    render(
-      <ScheduledJobRunHistoryDialog
-        projectId="project-1"
-        job={job}
-        isOpen
-        onClose={vi.fn()}
-      />,
-    );
+    renderDialog();
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /Run history — Morning briefing/i })).toBeInTheDocument();
     expect(screen.getByText('Daily at 09:00 (UTC)')).toBeInTheDocument();
     expect(await screen.findByText('No runs recorded yet.')).toBeInTheDocument();
     expect(scheduledJobsApi.listRuns).toHaveBeenCalledWith('project-1', 'job-1', 1, 10);
+  });
+
+  it('starts a run when opened with runOnOpen', async () => {
+    let resolveRun: (() => void) | undefined;
+    vi.mocked(scheduledJobsApi.runNow).mockImplementation(
+      () => new Promise<void>((resolve) => {
+        resolveRun = resolve;
+      }),
+    );
+
+    renderDialog({ runOnOpen: true, canRun: true });
+
+    expect(await screen.findByText('Starting run…')).toBeInTheDocument();
+    expect(scheduledJobsApi.runNow).toHaveBeenCalledWith('project-1', 'job-1');
+
+    resolveRun?.();
+    expect(await screen.findByRole('heading', { name: /Running — Morning briefing/i })).toBeInTheDocument();
   });
 
   it('lists runs and opens run details', async () => {
@@ -100,14 +130,7 @@ describe('ScheduledJobRunHistoryDialog', () => {
 
     const onClose = vi.fn();
 
-    render(
-      <ScheduledJobRunHistoryDialog
-        projectId="project-1"
-        job={job}
-        isOpen
-        onClose={onClose}
-      />,
-    );
+    renderDialog({ onClose });
 
     expect(await screen.findByText('Succeeded')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'View output' }));
@@ -116,7 +139,7 @@ describe('ScheduledJobRunHistoryDialog', () => {
       expect(scheduledJobsApi.getRun).toHaveBeenCalledWith('project-1', 'job-1', 'run-1');
     });
     expect(await screen.findByText('hello stdout')).toBeInTheDocument();
-    expect(screen.getByText('conv-1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open conversation' })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Close run history' }));
     expect(onClose).toHaveBeenCalled();

--- a/src/client/src/components/project/sidebar/ProjectSidebar.tsx
+++ b/src/client/src/components/project/sidebar/ProjectSidebar.tsx
@@ -23,6 +23,7 @@ import { CreateEditScheduledJobDialog } from '../dialogs/CreateEditScheduledJobD
 import { ScheduledJobRunHistoryDialog } from '../dialogs/ScheduledJobRunHistoryDialog';
 import { scheduledJobsApi } from '../../../services/scheduledJobs';
 import type { ProjectScheduledJobDetailDto, ProjectScheduledJobSummaryDto } from '../../../types/scheduledJob';
+import { formatNextRun } from '../../../lib/scheduledJobDateTime';
 
 // Props for the extracted NotebookListItem component
 interface NotebookListItemProps {
@@ -215,6 +216,17 @@ interface ProjectSidebarProps {
     onSetHomePage?: (fileId: string | null) => Promise<void>;
     // File version change notification
     onFileContentChanged?: (fileId: string, newVersion: number) => void;
+    // Scheduled jobs — when provided, sidebar shares the parent's polled state
+    scheduledJobs?: ProjectScheduledJobSummaryDto[];
+    isLoadingScheduledJobs?: boolean;
+    refreshScheduledJobs?: () => void;
+    onScheduledJobDialogOpenChange?: (open: boolean) => void;
+    applyScheduledJobDetail?: (job: ProjectScheduledJobDetailDto) => void;
+    patchScheduledJob?: (
+        jobId: string,
+        fields: Partial<Pick<ProjectScheduledJobSummaryDto, 'isEnabled' | 'nextRunUtc' | 'lastRunUtc' | 'lastRunStatus' | 'scheduleSummary' | 'updatedUtc' | 'name'>>
+    ) => void;
+    selectedScheduledJobDetail?: ProjectScheduledJobDetailDto | null;
 }
 
 // NOTE: Historical helper removed. We now rely on the real tree everywhere.
@@ -249,7 +261,14 @@ export function ProjectSidebar({
     onCreateNotebookFromFiles,
     homePageContentFileId,
     onSetHomePage,
-    onFileContentChanged
+    onFileContentChanged,
+    scheduledJobs: scheduledJobsOverride,
+    isLoadingScheduledJobs: isLoadingScheduledJobsOverride,
+    refreshScheduledJobs: refreshScheduledJobsOverride,
+    onScheduledJobDialogOpenChange,
+    applyScheduledJobDetail,
+    patchScheduledJob,
+    selectedScheduledJobDetail,
 }: ProjectSidebarProps) {
     const { showToast } = useToast();
     const navigate = useNavigate();
@@ -372,19 +391,31 @@ export function ProjectSidebar({
 
     const [showCreateScheduledJobDialog, setShowCreateScheduledJobDialog] = useState(false);
     const [editingScheduledJob, setEditingScheduledJob] = useState<ProjectScheduledJobDetailDto | null>(null);
-    const [historyScheduledJob, setHistoryScheduledJob] = useState<ProjectScheduledJobSummaryDto | null>(null);
+    const [historyScheduledJob, setHistoryScheduledJob] = useState<{
+        job: ProjectScheduledJobSummaryDto;
+        runOnOpen: boolean;
+    } | null>(null);
 
     const isScheduledJobDialogOpen =
         showCreateScheduledJobDialog || Boolean(historyScheduledJob);
 
-    const {
-        jobs: scheduledJobs,
-        isLoading: isLoadingScheduledJobs,
-        refresh: refreshScheduledJobs,
-    } = useProjectScheduledJobsPolling({
+    const internalScheduledJobsPolling = useProjectScheduledJobsPolling({
         projectId: project.id,
-        enabled: isCurrentUserOwner && !isScheduledJobDialogOpen,
+        enabled:
+            isCurrentUserOwner &&
+            !isScheduledJobDialogOpen &&
+            scheduledJobsOverride === undefined,
     });
+
+    const scheduledJobs = scheduledJobsOverride ?? internalScheduledJobsPolling.jobs;
+    const isLoadingScheduledJobs =
+        isLoadingScheduledJobsOverride ?? internalScheduledJobsPolling.isLoading;
+    const refreshScheduledJobs =
+        refreshScheduledJobsOverride ?? internalScheduledJobsPolling.refresh;
+
+    useEffect(() => {
+        onScheduledJobDialogOpenChange?.(isScheduledJobDialogOpen);
+    }, [isScheduledJobDialogOpen, onScheduledJobDialogOpenChange]);
     const [showScheduledJobContextMenu, setShowScheduledJobContextMenu] = useState(false);
     const [scheduledJobContextMenuPos, setScheduledJobContextMenuPos] = useState({ x: 0, y: 0 });
     const [selectedContextScheduledJobId, setSelectedContextScheduledJobId] = useState<string | null>(null);
@@ -591,14 +622,33 @@ export function ProjectSidebar({
             setShowScheduledJobContextMenu(false);
             return;
         }
+
+        const jobId = selectedScheduledJob.id;
+        const previousState = {
+            isEnabled: selectedScheduledJob.isEnabled,
+            nextRunUtc: selectedScheduledJob.nextRunUtc,
+        };
+        const nextEnabled = !previousState.isEnabled;
+
+        patchScheduledJob?.(jobId, {
+            isEnabled: nextEnabled,
+            nextRunUtc: nextEnabled ? previousState.nextRunUtc : null,
+        });
+
         setIsScheduledJobActionPending(true);
         try {
-            const detail = await scheduledJobsApi.get(project.id, selectedScheduledJob.id);
-            await scheduledJobsApi.update(project.id, selectedScheduledJob.id, {
+            const cachedDetail =
+                selectedScheduledJobDetail?.id === jobId
+                    ? selectedScheduledJobDetail
+                    : editingScheduledJob?.id === jobId
+                        ? editingScheduledJob
+                        : null;
+            const detail = cachedDetail ?? await scheduledJobsApi.get(project.id, jobId);
+            const updated = await scheduledJobsApi.update(project.id, jobId, {
                 name: detail.name,
                 jobType: detail.jobType,
                 notebookId: detail.notebookId,
-                isEnabled: !detail.isEnabled,
+                isEnabled: nextEnabled,
                 timeZoneId: detail.timeZoneId,
                 schedule: detail.friendlySchedule,
                 conversationTitle: detail.conversationTitle,
@@ -606,8 +656,16 @@ export function ProjectSidebar({
                 assistantName: detail.assistantName,
                 scriptNotebookFileId: detail.scriptNotebookFileId,
             });
-            refreshScheduledJobs();
+            applyScheduledJobDetail?.(updated);
+            showToast({
+                type: 'success',
+                title: updated.isEnabled ? 'Job enabled' : 'Job disabled',
+                message: updated.isEnabled
+                    ? `Next run: ${formatNextRun(updated.nextRunUtc, updated.timeZoneId, true)}`
+                    : 'Automatic runs are paused until you enable this job again.',
+            });
         } catch (error) {
+            patchScheduledJob?.(jobId, previousState);
             showToast({
                 type: 'error',
                 title: 'Failed to update scheduled job',
@@ -619,33 +677,15 @@ export function ProjectSidebar({
         }
     };
 
-    const handleRunScheduledJobNow = async () => {
-        if (!selectedContextScheduledJobId) {
+    const handleRunScheduledJobNow = () => {
+        if (!selectedScheduledJob) {
             setShowScheduledJobContextMenu(false);
             return;
         }
-        const jobId = selectedContextScheduledJobId;
-        setIsScheduledJobActionPending(true);
-        try {
-            await scheduledJobsApi.runNow(project.id, jobId);
-            onItemSelect('jobSchedule', jobId);
-            window.dispatchEvent(new CustomEvent('scheduled-job-run-triggered', { detail: { jobId } }));
-            showToast({
-                type: 'success',
-                title: 'Run started',
-                message: 'The job is running. Check run history for status and output.',
-            });
-            refreshScheduledJobs();
-        } catch (error) {
-            showToast({
-                type: 'error',
-                title: 'Failed to run job',
-                message: error instanceof Error ? error.message : 'Please try again.',
-            });
-        } finally {
-            setIsScheduledJobActionPending(false);
-            setShowScheduledJobContextMenu(false);
-        }
+
+        onItemSelect('jobSchedule', selectedScheduledJob.id);
+        setHistoryScheduledJob({ job: selectedScheduledJob, runOnOpen: true });
+        setShowScheduledJobContextMenu(false);
     };
 
     const handleDeleteScheduledJobRequest = () => {
@@ -682,7 +722,7 @@ export function ProjectSidebar({
             setShowScheduledJobContextMenu(false);
             return;
         }
-        setHistoryScheduledJob(selectedScheduledJob);
+        setHistoryScheduledJob({ job: selectedScheduledJob, runOnOpen: false });
         setShowScheduledJobContextMenu(false);
     };
 
@@ -1204,7 +1244,7 @@ export function ProjectSidebar({
                                 setShowCreateScheduledJobDialog(true);
                             }}
                             showAddButton
-                            disabled={disabled || isLoadingScheduledJobs || isScheduledJobActionPending}
+                            disabled={disabled || (isLoadingScheduledJobs && scheduledJobs.length === 0) || isScheduledJobActionPending}
                             data-tour-id="sidebar.section.jobSchedule"
                         >
                             {scheduledJobs.length === 0 ? (
@@ -1405,7 +1445,10 @@ export function ProjectSidebar({
                             setShowCreateScheduledJobDialog(false);
                             setEditingScheduledJob(null);
                         }}
-                        onSaved={refreshScheduledJobs}
+                        onSaved={(savedJob) => {
+                            applyScheduledJobDetail?.(savedJob);
+                            refreshScheduledJobs();
+                        }}
                         notebooks={currentNotebooks}
                         job={editingScheduledJob}
                         disabled={disabled || isScheduledJobActionPending}
@@ -1414,9 +1457,19 @@ export function ProjectSidebar({
                     {historyScheduledJob && (
                         <ScheduledJobRunHistoryDialog
                             projectId={project.id}
-                            job={historyScheduledJob}
-                            isOpen={Boolean(historyScheduledJob)}
-                            onClose={() => setHistoryScheduledJob(null)}
+                            job={historyScheduledJob.job}
+                            isOpen
+                            runOnOpen={historyScheduledJob.runOnOpen}
+                            canRun={historyScheduledJob.runOnOpen}
+                            onClose={() => {
+                                setHistoryScheduledJob(null);
+                                refreshScheduledJobs();
+                            }}
+                            onTimingFieldsUpdate={(fields) => {
+                                if (historyScheduledJob) {
+                                    patchScheduledJob?.(historyScheduledJob.job.id, fields);
+                                }
+                            }}
                         />
                     )}
 

--- a/src/client/src/features/localModelOnboarding/installed/AliasPresetSavePanel.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/AliasPresetSavePanel.tsx
@@ -1,181 +1,169 @@
-import { useEffect, useMemo, useState } from 'react';
-import { api } from '../../../services/api';
-import type { LlamaRouterEntryDto } from '../../../types/settings';
-import { getErrorMessage } from '../../../pages/settings/utils';
-import { TextActionButton } from '../../../pages/settings/components/shared/ActionButtons';
-import { AliasPresetEditor } from '../advanced/AliasPresetEditor';
-import {
-  buildEffectivePresetRecord,
-  filterManagedPresetRows,
-  splitManagedPresetFromRecord,
-  validateAliasPresetRows,
-  type PresetKeyValue,
-} from '../routerPreset';
-
-function parseOptionalPositiveInt(raw: string): number | null {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const value = Number(trimmed);
-  if (!Number.isInteger(value) || value <= 0) {
-    return null;
-  }
-  return value;
-}
-
-function resolveManagedDrafts(
-  preset: Record<string, string>,
-  routerEntry: LlamaRouterEntryDto | null,
-): { ctxSizeDraft: string; cacheRamDraft: string; rows: PresetKeyValue[] } {
-  const split = splitManagedPresetFromRecord(preset);
-  return {
-    ctxSizeDraft: split.ctxSize || (routerEntry?.contextSize?.toString() ?? ''),
-    cacheRamDraft: split.cacheRam || (routerEntry?.cacheRamMib?.toString() ?? ''),
-    rows: split.rows,
-  };
-}
-
-export interface AliasPresetSavePanelProps {
-  alias: string;
-  routerEntry: LlamaRouterEntryDto | null;
-  /** Fallback when router entry is unavailable (e.g. provenance snapshot). */
-  fallbackPreset?: Record<string, string>;
-  onSaved?: () => Promise<void>;
-}
-
-export function AliasPresetSavePanel({
-  alias,
-  routerEntry,
-  fallbackPreset = {},
-  onSaved,
-}: AliasPresetSavePanelProps) {
-  const authoritativePreset = useMemo(() => {
-    if (routerEntry?.preset && Object.keys(routerEntry.preset).length > 0) {
-      return routerEntry.preset;
-    }
-    return fallbackPreset;
-  }, [fallbackPreset, routerEntry?.preset]);
-
-  const [rows, setRows] = useState<PresetKeyValue[]>(() =>
-    resolveManagedDrafts(authoritativePreset, routerEntry).rows,
-  );
-  const [ctxSizeDraft, setCtxSizeDraft] = useState(
-    () => resolveManagedDrafts(authoritativePreset, routerEntry).ctxSizeDraft,
-  );
-  const [cacheRamDraft, setCacheRamDraft] = useState(
-    () => resolveManagedDrafts(authoritativePreset, routerEntry).cacheRamDraft,
-  );
-  const [presetMode, setPresetMode] = useState<'replace' | 'merge'>('merge');
-  const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const [saveMessage, setSaveMessage] = useState<string | null>(null);
-
-  useEffect(() => {
-    const next = resolveManagedDrafts(authoritativePreset, routerEntry);
-    setRows(next.rows);
-    setCtxSizeDraft(next.ctxSizeDraft);
-    setCacheRamDraft(next.cacheRamDraft);
-    setSaveError(null);
-    setSaveMessage(null);
-  }, [alias, authoritativePreset, routerEntry]);
-
-  const effectivePreset = useMemo(
-    () => buildEffectivePresetRecord(rows, ctxSizeDraft, cacheRamDraft),
-    [cacheRamDraft, ctxSizeDraft, rows],
-  );
-  const validationErrors = useMemo(() => validateAliasPresetRows(rows), [rows]);
-  const canSave = !!routerEntry && validationErrors.length === 0 && !saving;
-
-  const save = async () => {
-    if (!routerEntry) {
-      setSaveError('Router entry is unavailable. Refresh and try again.');
-      return;
-    }
-    if (validationErrors.length > 0) {
-      setSaveError(validationErrors[0] ?? 'Fix preset validation errors before saving.');
-      return;
-    }
-
-    setSaving(true);
-    setSaveError(null);
-    setSaveMessage(null);
-    try {
-      await api.settings.putLlamaRouterEntry(alias, {
-        alias,
-        modelPath: routerEntry.modelPath,
-        mmprojPath: routerEntry.mmprojPath ?? '',
-        preset: effectivePreset,
-        presetMode,
-        contextSize: parseOptionalPositiveInt(ctxSizeDraft),
-        cacheRamMib: parseOptionalPositiveInt(cacheRamDraft),
-      });
-      setSaveMessage('Router preset saved. Loaded models may restart to apply changes.');
-      await onSaved?.();
-    } catch (error) {
-      setSaveError(getErrorMessage(error, 'Failed to save router preset.'));
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div data-testid="alias-preset-save-panel" className="space-y-4 rounded border border-gray-200 bg-white p-4">
-      <div>
-        <h3 className="text-sm font-semibold text-gray-900">Router preset</h3>
-        <p className="mt-1 text-xs text-gray-600">
-          llama-server switches for <span className="font-mono">{alias}</span>. Save applies this model&apos;s preset to
-          the router.
-        </p>
-      </div>
-
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <label className="space-y-1 text-sm text-gray-700">
-          <span className="text-xs font-medium uppercase tracking-wide text-gray-600">Context size (tokens)</span>
-          <input
-            type="text"
-            inputMode="numeric"
-            value={ctxSizeDraft}
-            onChange={(event) => setCtxSizeDraft(event.target.value)}
-            className="w-full rounded border border-gray-300 px-3 py-2 font-mono text-sm"
-            placeholder="e.g. 131072"
-            spellCheck={false}
-          />
-        </label>
-        <label className="space-y-1 text-sm text-gray-700">
-          <span className="text-xs font-medium uppercase tracking-wide text-gray-600">Prompt cache RAM (MiB)</span>
-          <input
-            type="text"
-            inputMode="numeric"
-            value={cacheRamDraft}
-            onChange={(event) => setCacheRamDraft(event.target.value)}
-            className="w-full rounded border border-gray-300 px-3 py-2 font-mono text-sm"
-            placeholder="optional"
-            spellCheck={false}
-          />
-        </label>
-      </div>
-
-      <AliasPresetEditor
-        rows={rows}
-        onChange={(nextRows) => setRows(filterManagedPresetRows(nextRows))}
-        alias={alias}
-        previewPreset={effectivePreset}
-        presetMode={presetMode}
-        onPresetModeChange={setPresetMode}
-      />
-
-      <div className="flex flex-wrap items-center gap-2">
-        <TextActionButton tone="primary" onClick={() => void save()} disabled={!canSave} title="Save router preset">
-          Save router preset
-        </TextActionButton>
-        {!routerEntry ? (
-          <span className="text-xs text-amber-800">Live router entry not loaded — refresh catalog edit.</span>
-        ) : null}
-      </div>
-
-      {saveMessage ? <p className="text-sm text-emerald-800">{saveMessage}</p> : null}
-      {saveError ? <p className="text-sm text-red-700">{saveError}</p> : null}
-    </div>
-  );
-}
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
+import { api } from '../../../services/api';
+import type { LlamaRouterEntryDto } from '../../../types/settings';
+import { AliasPresetEditor } from '../advanced/AliasPresetEditor';
+import {
+  buildEffectivePresetRecord,
+  isManagedPresetKey,
+  splitManagedPresetFromRecord,
+  validateAliasPresetRows,
+  type PresetKeyValue,
+} from '../routerPreset';
+
+function parseOptionalPositiveInt(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const value = Number(trimmed);
+  if (!Number.isInteger(value) || value <= 0) {
+    return null;
+  }
+  return value;
+}
+
+function resolveManagedDrafts(
+  preset: Record<string, string>,
+  routerEntry: LlamaRouterEntryDto | null,
+): { ctxSizeDraft: string; cacheRamDraft: string; rows: PresetKeyValue[] } {
+  const split = splitManagedPresetFromRecord(preset);
+  return {
+    ctxSizeDraft: split.ctxSize || (routerEntry?.contextSize?.toString() ?? ''),
+    cacheRamDraft: split.cacheRam || (routerEntry?.cacheRamMib?.toString() ?? ''),
+    rows: split.rows,
+  };
+}
+
+export interface AliasPresetSavePanelHandle {
+  saveRouterPreset: () => Promise<void>;
+}
+
+export interface AliasPresetSavePanelProps {
+  alias: string;
+  routerEntry: LlamaRouterEntryDto | null;
+  /** Fallback when router entry is unavailable (e.g. provenance snapshot). */
+  fallbackPreset?: Record<string, string>;
+}
+
+export const AliasPresetSavePanel = forwardRef<AliasPresetSavePanelHandle, AliasPresetSavePanelProps>(
+  function AliasPresetSavePanel({ alias, routerEntry, fallbackPreset = {} }, ref) {
+    const authoritativePreset = useMemo(() => {
+      if (routerEntry?.preset && Object.keys(routerEntry.preset).length > 0) {
+        return routerEntry.preset;
+      }
+      return fallbackPreset;
+    }, [fallbackPreset, routerEntry?.preset]);
+
+    const [rows, setRows] = useState<PresetKeyValue[]>(() =>
+      resolveManagedDrafts(authoritativePreset, routerEntry).rows,
+    );
+    const [ctxSizeDraft, setCtxSizeDraft] = useState(
+      () => resolveManagedDrafts(authoritativePreset, routerEntry).ctxSizeDraft,
+    );
+    const [cacheRamDraft, setCacheRamDraft] = useState(
+      () => resolveManagedDrafts(authoritativePreset, routerEntry).cacheRamDraft,
+    );
+    const [presetMode, setPresetMode] = useState<'replace' | 'merge'>('merge');
+
+    useEffect(() => {
+      const next = resolveManagedDrafts(authoritativePreset, routerEntry);
+      setRows(next.rows);
+      setCtxSizeDraft(next.ctxSizeDraft);
+      setCacheRamDraft(next.cacheRamDraft);
+    }, [alias, authoritativePreset, routerEntry]);
+
+    const effectivePreset = useMemo(
+      () => buildEffectivePresetRecord(rows, ctxSizeDraft, cacheRamDraft),
+      [cacheRamDraft, ctxSizeDraft, rows],
+    );
+    const validationErrors = useMemo(() => validateAliasPresetRows(rows), [rows]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        async saveRouterPreset() {
+          if (!routerEntry) {
+            throw new Error('Router entry is unavailable. Refresh and try again.');
+          }
+          if (validationErrors.length > 0) {
+            throw new Error(validationErrors[0] ?? 'Fix preset validation errors before saving.');
+          }
+
+          await api.settings.putLlamaRouterEntry(alias, {
+            alias,
+            modelPath: routerEntry.modelPath,
+            mmprojPath: routerEntry.mmprojPath ?? '',
+            preset: effectivePreset,
+            presetMode,
+            contextSize: parseOptionalPositiveInt(ctxSizeDraft),
+            cacheRamMib: parseOptionalPositiveInt(cacheRamDraft),
+          });
+        },
+      }),
+      [
+        alias,
+        cacheRamDraft,
+        ctxSizeDraft,
+        effectivePreset,
+        presetMode,
+        routerEntry,
+        validationErrors,
+      ],
+    );
+
+    return (
+      <div data-testid="alias-preset-save-panel" className="space-y-4 rounded border border-gray-200 bg-white p-4">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">Router preset</h3>
+          <p className="mt-1 text-xs text-gray-600">
+            llama-server switches for <span className="font-mono">{alias}</span>. Use Save below to apply this
+            model&apos;s preset to the router.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <label className="space-y-1 text-sm text-gray-700">
+            <span className="text-xs font-medium uppercase tracking-wide text-gray-600">Context size (tokens)</span>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={ctxSizeDraft}
+              onChange={(event) => setCtxSizeDraft(event.target.value)}
+              className="w-full rounded border border-gray-300 px-3 py-2 font-mono text-sm"
+              placeholder="e.g. 131072"
+              spellCheck={false}
+            />
+          </label>
+          <label className="space-y-1 text-sm text-gray-700">
+            <span className="text-xs font-medium uppercase tracking-wide text-gray-600">Prompt cache RAM (MiB)</span>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={cacheRamDraft}
+              onChange={(event) => setCacheRamDraft(event.target.value)}
+              className="w-full rounded border border-gray-300 px-3 py-2 font-mono text-sm"
+              placeholder="optional"
+              spellCheck={false}
+            />
+          </label>
+        </div>
+
+        <AliasPresetEditor
+          rows={rows}
+          onChange={(nextRows) =>
+            setRows(nextRows.filter((row) => !isManagedPresetKey(row.key)))
+          }
+          alias={alias}
+          previewPreset={effectivePreset}
+          presetMode={presetMode}
+          onPresetModeChange={setPresetMode}
+        />
+
+        {!routerEntry ? (
+          <p className="text-xs text-amber-800">Live router entry not loaded — refresh catalog edit.</p>
+        ) : null}
+      </div>
+    );
+  },
+);
+

--- a/src/client/src/features/localModelOnboarding/installed/LlamaInstalledSummary.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/LlamaInstalledSummary.tsx
@@ -1,12 +1,16 @@
-import { useCallback, useEffect, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { api } from '../../../services/api';
 import type { LlamaInstallationDetailDto, LlamaRouterEntryDto } from '../../../types/settings';
 import { getErrorMessage } from '../../../pages/settings/utils';
 import { formatBytes } from '../curated/format';
 import { ChangeQuantModal } from './ChangeQuantModal';
-import { AliasPresetSavePanel } from './AliasPresetSavePanel';
+import { AliasPresetSavePanel, type AliasPresetSavePanelHandle } from './AliasPresetSavePanel';
 import { ModelChatBehaviorPanel } from './ModelChatBehaviorPanel';
 import { TextActionButton } from '../../../pages/settings/components/shared/ActionButtons';
+
+export interface LlamaInstalledSummaryHandle {
+  saveRouterPreset: () => Promise<void>;
+}
 
 export interface LlamaInstalledSummaryProps {
   modelId: string;
@@ -14,7 +18,9 @@ export interface LlamaInstalledSummaryProps {
   onChanged?: () => Promise<void>;
 }
 
-export function LlamaInstalledSummary({ modelId, sharedProfileModelCount, onChanged }: LlamaInstalledSummaryProps) {
+export const LlamaInstalledSummary = forwardRef<LlamaInstalledSummaryHandle, LlamaInstalledSummaryProps>(
+  function LlamaInstalledSummary({ modelId, sharedProfileModelCount, onChanged }, ref) {
+  const presetPanelRef = useRef<AliasPresetSavePanelHandle>(null);
   const [detail, setDetail] = useState<LlamaInstallationDetailDto | null>(null);
   const [routerEntry, setRouterEntry] = useState<LlamaRouterEntryDto | null>(null);
   const [loading, setLoading] = useState(true);
@@ -47,6 +53,20 @@ export function LlamaInstalledSummary({ modelId, sharedProfileModelCount, onChan
     await onChanged?.();
   };
 
+  useImperativeHandle(
+    ref,
+    () => ({
+      saveRouterPreset: async () => {
+        const panel = presetPanelRef.current;
+        if (!panel) {
+          throw new Error('Router preset editor is still loading.');
+        }
+        await panel.saveRouterPreset();
+      },
+    }),
+    [],
+  );
+
   if (loading) {
     return <p className="text-sm text-gray-600">Loading installation detail…</p>;
   }
@@ -64,10 +84,10 @@ export function LlamaInstalledSummary({ modelId, sharedProfileModelCount, onChan
   return (
     <div className="space-y-4">
       <AliasPresetSavePanel
+        ref={presetPanelRef}
         alias={detail.routerModelId}
         routerEntry={routerEntry}
         fallbackPreset={detail.routerPresetSnapshot}
-        onSaved={handleChanged}
       />
 
       <ModelChatBehaviorPanel
@@ -148,4 +168,5 @@ export function LlamaInstalledSummary({ modelId, sharedProfileModelCount, onChan
       />
     </div>
   );
-}
+},
+);

--- a/src/client/src/features/localModelOnboarding/installed/ModelChatBehaviorPanel.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/ModelChatBehaviorPanel.tsx
@@ -6,6 +6,7 @@ import {
   buildProfileUpdateRequest,
   createProfileFormFromContractShape,
 } from '../../../pages/settings/utils';
+import { ConfirmationDialog } from '../../../components/common/ConfirmationDialog';
 import { RuntimeProfileEditor } from '../../../pages/settings/components/RuntimeProfileEditor';
 import { TextActionButton } from '../../../pages/settings/components/shared/ActionButtons';
 import type { ProfileFormState } from '../../../pages/settings/types';
@@ -32,6 +33,7 @@ export function ModelChatBehaviorPanel({
   const [documentError, setDocumentError] = useState<string | null>(null);
   const [repairOpen, setRepairOpen] = useState(false);
   const [adoptOpen, setAdoptOpen] = useState(false);
+  const [sharedProfileSaveConfirmOpen, setSharedProfileSaveConfirmOpen] = useState(false);
 
   const isCurated = !!detail.catalogId;
 
@@ -64,15 +66,6 @@ export function ModelChatBehaviorPanel({
       return;
     }
 
-    if (sharedProfileModelCount > 1) {
-      const confirmed = window.confirm(
-        `This updates chat behavior for all models using profile ${detail.runtimeProfileId}. Continue?`,
-      );
-      if (!confirmed) {
-        return;
-      }
-    }
-
     setDocumentSaving(true);
     setDocumentError(null);
     setDocumentMessage(null);
@@ -86,6 +79,17 @@ export function ModelChatBehaviorPanel({
     } finally {
       setDocumentSaving(false);
     }
+  };
+
+  const requestSaveProfileDocument = () => {
+    if (!profileForm) {
+      return;
+    }
+    if (sharedProfileModelCount > 1) {
+      setSharedProfileSaveConfirmOpen(true);
+      return;
+    }
+    void saveProfileDocument();
   };
 
   const handleLifecycleCompleted = async () => {
@@ -137,7 +141,7 @@ export function ModelChatBehaviorPanel({
               value={profileForm}
               onChange={handleProfileFormChange}
               disableIdentityFields
-              onSubmit={() => void saveProfileDocument()}
+              onSubmit={requestSaveProfileDocument}
               submitting={documentSaving}
               submitLabel="Save profile document"
             />
@@ -166,6 +170,19 @@ export function ModelChatBehaviorPanel({
           setAdoptOpen(false);
           await handleLifecycleCompleted();
         }}
+      />
+      <ConfirmationDialog
+        isOpen={sharedProfileSaveConfirmOpen}
+        onClose={() => setSharedProfileSaveConfirmOpen(false)}
+        onConfirm={() => {
+          setSharedProfileSaveConfirmOpen(false);
+          void saveProfileDocument();
+        }}
+        title="Update shared profile"
+        message={`This updates chat behavior for all models using profile ${detail.runtimeProfileId}.`}
+        confirmText="Save profile document"
+        confirmButtonClass="bg-blue-600 hover:bg-blue-700 text-white"
+        isLoading={documentSaving}
       />
     </div>
   );

--- a/src/client/src/features/localModelOnboarding/installed/__tests__/AliasPresetSavePanel.test.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/__tests__/AliasPresetSavePanel.test.tsx
@@ -1,124 +1,159 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { AliasPresetSavePanel } from '../AliasPresetSavePanel';
-
-vi.mock('../../../../services/api', () => ({
-  api: {
-    settings: {
-      putLlamaRouterEntry: vi.fn(),
-    },
-  },
-}));
-
-import { api } from '../../../../services/api';
-
-const routerEntry = {
-  alias: 'Qwen3.5-9B-GGUF',
-  modelPath: '/models-local/llama/Qwen3.5-9B-GGUF/model.gguf',
-  mmprojPath: '',
-  hasModelFile: true,
-  hasMmprojFile: false,
-  contextSize: 131072,
-  cacheRamMib: null,
-  preset: { 'ctx-size': '131072' },
-};
-
-const mtpRouterEntry = {
-  alias: 'Qwen3.6-27B-MTP-GGUF',
-  modelPath: '/models-local/llama/Qwen3.6-27B-MTP-GGUF/model.gguf',
-  mmprojPath: '/models-local/llama/Qwen3.6-27B-MTP-GGUF/mmproj.gguf',
-  hasModelFile: true,
-  hasMmprojFile: true,
-  contextSize: null,
-  cacheRamMib: null,
-  preset: {
-    'image-min-tokens': '1024',
-    'spec-draft-n-max': '2',
-    'spec-type': 'draft-mtp',
-  },
-};
-
-describe('AliasPresetSavePanel', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('saves edited preset through putLlamaRouterEntry', async () => {
-    const user = userEvent.setup();
-    vi.mocked(api.settings.putLlamaRouterEntry).mockResolvedValue(undefined as never);
-
-    render(
-      <AliasPresetSavePanel
-        alias="Qwen3.5-9B-GGUF"
-        routerEntry={routerEntry}
-        fallbackPreset={{}}
-      />,
-    );
-
-    const ctxInput = screen.getByPlaceholderText('e.g. 131072');
-    await user.click(ctxInput);
-    await user.keyboard('{Control>}a{/Control}65536');
-    await user.click(screen.getByRole('button', { name: 'Save router preset' }));
-
-    await waitFor(() => {
-      expect(api.settings.putLlamaRouterEntry).toHaveBeenCalledWith(
-        'Qwen3.5-9B-GGUF',
-        expect.objectContaining({
-          alias: 'Qwen3.5-9B-GGUF',
-          presetMode: 'merge',
-          contextSize: 65536,
-          preset: expect.objectContaining({ 'ctx-size': '65536' }),
-        }),
-      );
-    });
-  });
-
-  it('shows context size in INI preview when only the dedicated field is set', async () => {
-    const user = userEvent.setup();
-    render(
-      <AliasPresetSavePanel
-        alias="Qwen3.6-27B-MTP-GGUF"
-        routerEntry={mtpRouterEntry}
-        fallbackPreset={{}}
-      />,
-    );
-
-    expect(screen.queryByText(/ctx-size = /)).not.toBeInTheDocument();
-
-    const ctxInput = screen.getByPlaceholderText('e.g. 131072');
-    await user.type(ctxInput, '131072');
-
-    const preview = screen.getByText('INI preview').parentElement?.querySelector('pre');
-    expect(preview?.textContent).toContain('ctx-size = 131072');
-    expect(preview?.textContent).toContain('spec-type = draft-mtp');
-  });
-
-  it('clears context size without reusing the prior router entry value', async () => {
-    const user = userEvent.setup();
-    vi.mocked(api.settings.putLlamaRouterEntry).mockResolvedValue(undefined as never);
-
-    render(
-      <AliasPresetSavePanel
-        alias="Qwen3.5-9B-GGUF"
-        routerEntry={routerEntry}
-        fallbackPreset={{}}
-      />,
-    );
-
-    const ctxInput = screen.getByPlaceholderText('e.g. 131072');
-    await user.clear(ctxInput);
-    expect(ctxInput).toHaveValue('');
-    await user.click(screen.getByRole('button', { name: 'Save router preset' }));
-
-    await waitFor(() => {
-      expect(api.settings.putLlamaRouterEntry).toHaveBeenCalledWith(
-        'Qwen3.5-9B-GGUF',
-        expect.objectContaining({
-          contextSize: null,
-          preset: expect.not.objectContaining({ 'ctx-size': expect.anything() }),
-        }),
-      );
-    });
-  });
-});
+import { createRef } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AliasPresetSavePanel, type AliasPresetSavePanelHandle } from '../AliasPresetSavePanel';
+
+vi.mock('../../../../services/api', () => ({
+  api: {
+    settings: {
+      putLlamaRouterEntry: vi.fn(),
+    },
+  },
+}));
+
+import { api } from '../../../../services/api';
+
+const routerEntry = {
+  alias: 'Qwen3.5-9B-GGUF',
+  modelPath: '/models-local/llama/Qwen3.5-9B-GGUF/model.gguf',
+  mmprojPath: '',
+  hasModelFile: true,
+  hasMmprojFile: false,
+  contextSize: 131072,
+  cacheRamMib: null,
+  preset: { 'ctx-size': '131072' },
+};
+
+const mtpRouterEntry = {
+  alias: 'Qwen3.6-27B-MTP-GGUF',
+  modelPath: '/models-local/llama/Qwen3.6-27B-MTP-GGUF/model.gguf',
+  mmprojPath: '/models-local/llama/Qwen3.6-27B-MTP-GGUF/mmproj.gguf',
+  hasModelFile: true,
+  hasMmprojFile: true,
+  contextSize: null,
+  cacheRamMib: null,
+  preset: {
+    'image-min-tokens': '1024',
+    'spec-draft-n-max': '2',
+    'spec-type': 'draft-mtp',
+  },
+};
+
+describe('AliasPresetSavePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('saves edited preset through putLlamaRouterEntry', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.settings.putLlamaRouterEntry).mockResolvedValue(undefined as never);
+    const panelRef = createRef<AliasPresetSavePanelHandle>();
+
+    render(
+      <AliasPresetSavePanel
+        ref={panelRef}
+        alias="Qwen3.5-9B-GGUF"
+        routerEntry={routerEntry}
+        fallbackPreset={{}}
+      />,
+    );
+
+    const ctxInput = screen.getByPlaceholderText('e.g. 131072');
+    await user.click(ctxInput);
+    await user.keyboard('{Control>}a{/Control}65536');
+    await panelRef.current?.saveRouterPreset();
+
+    await waitFor(() => {
+      expect(api.settings.putLlamaRouterEntry).toHaveBeenCalledWith(
+        'Qwen3.5-9B-GGUF',
+        expect.objectContaining({
+          alias: 'Qwen3.5-9B-GGUF',
+          presetMode: 'merge',
+          contextSize: 65536,
+          preset: expect.objectContaining({ 'ctx-size': '65536' }),
+        }),
+      );
+    });
+  });
+
+  it('does not render a separate save button', () => {
+    render(
+      <AliasPresetSavePanel
+        alias="Qwen3.5-9B-GGUF"
+        routerEntry={routerEntry}
+        fallbackPreset={{}}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Save router preset' })).not.toBeInTheDocument();
+  });
+
+  it('shows context size in INI preview when only the dedicated field is set', async () => {
+    const user = userEvent.setup();
+    render(
+      <AliasPresetSavePanel
+        alias="Qwen3.6-27B-MTP-GGUF"
+        routerEntry={mtpRouterEntry}
+        fallbackPreset={{}}
+      />,
+    );
+
+    expect(screen.queryByText(/ctx-size = /)).not.toBeInTheDocument();
+
+    const ctxInput = screen.getByPlaceholderText('e.g. 131072');
+    await user.type(ctxInput, '131072');
+
+    const preview = screen.getByText('INI preview').parentElement?.querySelector('pre');
+    expect(preview?.textContent).toContain('ctx-size = 131072');
+    expect(preview?.textContent).toContain('spec-type = draft-mtp');
+  });
+
+  it('adds a new preset key row when Add preset key is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <AliasPresetSavePanel
+        alias="Qwen3.6-27B-MTP-GGUF"
+        routerEntry={mtpRouterEntry}
+        fallbackPreset={{}}
+      />,
+    );
+
+    const presetKeyInputs = () => screen.getAllByPlaceholderText('ctx-size');
+    expect(presetKeyInputs()).toHaveLength(3);
+
+    await user.click(screen.getByRole('button', { name: 'Add preset key' }));
+
+    expect(presetKeyInputs()).toHaveLength(4);
+  });
+
+  it('clears context size without reusing the prior router entry value', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.settings.putLlamaRouterEntry).mockResolvedValue(undefined as never);
+    const panelRef = createRef<AliasPresetSavePanelHandle>();
+
+    render(
+      <AliasPresetSavePanel
+        ref={panelRef}
+        alias="Qwen3.5-9B-GGUF"
+        routerEntry={routerEntry}
+        fallbackPreset={{}}
+      />,
+    );
+
+    const ctxInput = screen.getByPlaceholderText('e.g. 131072');
+    await user.clear(ctxInput);
+    expect(ctxInput).toHaveValue('');
+    await panelRef.current?.saveRouterPreset();
+
+    await waitFor(() => {
+      expect(api.settings.putLlamaRouterEntry).toHaveBeenCalledWith(
+        'Qwen3.5-9B-GGUF',
+        expect.objectContaining({
+          contextSize: null,
+          preset: expect.not.objectContaining({ 'ctx-size': expect.anything() }),
+        }),
+      );
+    });
+  });
+});

--- a/src/client/src/features/localModelOnboarding/installed/__tests__/ModelChatBehaviorPanel.test.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/__tests__/ModelChatBehaviorPanel.test.tsx
@@ -91,4 +91,34 @@ describe('ModelChatBehaviorPanel', () => {
       );
     });
   });
+
+  it('confirms before saving a shared runtime profile', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.settings.updateRuntimeProfile).mockResolvedValue({
+      profileId: 'qwen3_6',
+      displayName: 'Qwen 3.6',
+      combineSystemAndDeveloperMessages: true,
+      samplingParametersJson: '{}',
+      thinkingControlJson: '{}',
+      requestFieldsWhenToolsPresentJson: '{}',
+      providers: ['llama-cpp'],
+      created: '2026-01-01T00:00:00Z',
+    } as never);
+
+    render(<ModelChatBehaviorPanel detail={detail as never} sharedProfileModelCount={2} />);
+    await screen.findByText('Qwen 3.6');
+
+    await user.click(screen.getByText('Edit profile document (advanced)'));
+    await user.click(screen.getByRole('button', { name: 'Save profile document' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Update shared profile' })).toBeInTheDocument();
+    expect(api.settings.updateRuntimeProfile).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('confirm'));
+
+    await waitFor(() => {
+      expect(api.settings.updateRuntimeProfile).toHaveBeenCalledWith('qwen3_6', expect.any(Object));
+    });
+  });
 });

--- a/src/client/src/hooks/useProjectScheduledJobs.ts
+++ b/src/client/src/hooks/useProjectScheduledJobs.ts
@@ -1,0 +1,315 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { scheduledJobsApi } from '../services/scheduledJobs';
+import type {
+  ProjectScheduledJobDetailDto,
+  ProjectScheduledJobSummaryDto,
+} from '../types/scheduledJob';
+
+interface UseProjectScheduledJobsProps {
+  projectId: string;
+  selectedJobId?: string | null;
+  enabled?: boolean;
+  listPollInterval?: number;
+  detailPollInterval?: number;
+  detailActivePollInterval?: number;
+}
+
+type JobSummaryPatch = Partial<
+  Pick<
+    ProjectScheduledJobSummaryDto,
+    'name' | 'isEnabled' | 'nextRunUtc' | 'lastRunUtc' | 'lastRunStatus' | 'scheduleSummary' | 'updatedUtc'
+  >
+>;
+
+function summaryFieldsFromDetail(
+  detail: ProjectScheduledJobDetailDto
+): JobSummaryPatch {
+  return {
+    name: detail.name,
+    isEnabled: detail.isEnabled,
+    nextRunUtc: detail.nextRunUtc,
+    lastRunUtc: detail.lastRunUtc,
+    lastRunStatus: detail.lastRunStatus,
+    scheduleSummary: detail.scheduleSummary,
+    updatedUtc: detail.updatedUtc,
+  };
+}
+
+function mergeDetailIntoJobs(
+  jobs: ProjectScheduledJobSummaryDto[],
+  detail: ProjectScheduledJobDetailDto
+): ProjectScheduledJobSummaryDto[] {
+  return jobs.map((job) =>
+    job.id === detail.id ? { ...job, ...summaryFieldsFromDetail(detail) } : job
+  );
+}
+
+export function useProjectScheduledJobs({
+  projectId,
+  selectedJobId = null,
+  enabled = true,
+  listPollInterval = 15000,
+  detailPollInterval = 15000,
+  detailActivePollInterval = 3000,
+}: UseProjectScheduledJobsProps) {
+  const [jobs, setJobs] = useState<ProjectScheduledJobSummaryDto[]>([]);
+  const [selectedJobDetail, setSelectedJobDetail] = useState<ProjectScheduledJobDetailDto | null>(null);
+  const [isLoadingJobs, setIsLoadingJobs] = useState(false);
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+  const [jobsError, setJobsError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [detailRunActiveUntil, setDetailRunActiveUntil] = useState<number | null>(null);
+
+  const jobsAbortRef = useRef<AbortController | null>(null);
+  const selectedJobIdRef = useRef<string | null>(selectedJobId ?? null);
+
+  selectedJobIdRef.current = selectedJobId ?? null;
+
+  const fetchJobs = useCallback(
+    async (options?: { signal?: AbortSignal; silent?: boolean }) => {
+      if (!projectId) {
+        return;
+      }
+
+      const silent = options?.silent ?? false;
+      const signal = options?.signal;
+
+      try {
+        if (!silent) {
+          setIsLoadingJobs(true);
+        }
+        setJobsError(null);
+
+        if (signal?.aborted) {
+          return;
+        }
+
+        const result = await scheduledJobsApi.list(projectId);
+
+        if (!signal?.aborted) {
+          setJobs(result);
+          setLastUpdated(new Date());
+        }
+      } catch (err) {
+        if (!signal?.aborted) {
+          setJobsError(err instanceof Error ? err.message : 'Failed to fetch scheduled jobs');
+        }
+      } finally {
+        if (!silent && !signal?.aborted) {
+          setIsLoadingJobs(false);
+        }
+      }
+    },
+    [projectId]
+  );
+
+  const fetchDetail = useCallback(
+    async (jobId: string, options?: { initial?: boolean; silent?: boolean }) => {
+      if (!projectId || !jobId) {
+        return;
+      }
+
+      const isInitial = options?.initial ?? false;
+      const silent = options?.silent ?? false;
+
+      try {
+        if (isInitial) {
+          setIsLoadingDetail(true);
+          setDetailError(null);
+        }
+
+        const detail = await scheduledJobsApi.get(projectId, jobId);
+
+        if (selectedJobIdRef.current !== jobId) {
+          return;
+        }
+
+        setSelectedJobDetail(detail);
+        setJobs((current) => mergeDetailIntoJobs(current, detail));
+
+        if (detail.lastRunStatus === 'Running') {
+          setDetailRunActiveUntil(Date.now() + 120_000);
+        }
+      } catch (err) {
+        if (selectedJobIdRef.current === jobId) {
+          if (!silent) {
+            setDetailError(err instanceof Error ? err.message : 'Failed to load scheduled job');
+          }
+          if (isInitial) {
+            setSelectedJobDetail(null);
+          }
+        }
+      } finally {
+        if (isInitial && selectedJobIdRef.current === jobId) {
+          setIsLoadingDetail(false);
+        }
+      }
+    },
+    [projectId]
+  );
+
+  const applyJobDetail = useCallback((detail: ProjectScheduledJobDetailDto) => {
+    setJobs((current) => mergeDetailIntoJobs(current, detail));
+    setSelectedJobDetail((current) => (current?.id === detail.id ? detail : current));
+    if (detail.lastRunStatus === 'Running') {
+      setDetailRunActiveUntil(Date.now() + 120_000);
+    }
+  }, []);
+
+  const patchJob = useCallback((jobId: string, fields: JobSummaryPatch) => {
+    setJobs((current) =>
+      current.map((job) => (job.id === jobId ? { ...job, ...fields } : job))
+    );
+    setSelectedJobDetail((current) =>
+      current?.id === jobId ? { ...current, ...fields } : current
+    );
+
+    if (fields.lastRunStatus === 'Running') {
+      setDetailRunActiveUntil(Date.now() + 120_000);
+    }
+  }, []);
+
+  const refreshJobs = useCallback(() => {
+    if (jobsAbortRef.current) {
+      jobsAbortRef.current.abort();
+    }
+    const controller = new AbortController();
+    jobsAbortRef.current = controller;
+    void fetchJobs({ signal: controller.signal, silent: true });
+  }, [fetchJobs]);
+
+  const refreshDetail = useCallback(() => {
+    const jobId = selectedJobIdRef.current;
+    if (!jobId) {
+      return;
+    }
+    void fetchDetail(jobId, { silent: true });
+  }, [fetchDetail]);
+
+  const refreshAll = useCallback(() => {
+    refreshJobs();
+    refreshDetail();
+  }, [refreshJobs, refreshDetail]);
+
+  const patchSelectedJobFields = useCallback(
+    (fields: JobSummaryPatch) => {
+      const jobId = selectedJobIdRef.current;
+      if (!jobId) {
+        return;
+      }
+      patchJob(jobId, fields);
+    },
+    [patchJob]
+  );
+
+  const effectiveListPollInterval = selectedJobId ? Math.max(listPollInterval, 60_000) : listPollInterval;
+
+  useEffect(() => {
+    if (!enabled || !projectId) {
+      return;
+    }
+
+    const controller = new AbortController();
+    jobsAbortRef.current = controller;
+    void fetchJobs({ signal: controller.signal, silent: false });
+
+    const intervalId = window.setInterval(() => {
+      void fetchJobs({ silent: true });
+    }, effectiveListPollInterval);
+
+    return () => {
+      window.clearInterval(intervalId);
+      controller.abort();
+      jobsAbortRef.current = null;
+    };
+  }, [enabled, projectId, effectiveListPollInterval, fetchJobs]);
+
+  useEffect(() => {
+    if (!selectedJobId) {
+      setSelectedJobDetail(null);
+      setDetailError(null);
+      setIsLoadingDetail(false);
+      setDetailRunActiveUntil(null);
+      return;
+    }
+
+    void fetchDetail(selectedJobId, { initial: true });
+  }, [selectedJobId, fetchDetail]);
+
+  const selectedSummary =
+    jobs.find((job) => job.id === selectedJobId) ?? null;
+
+  const isDetailRunActive =
+    selectedJobDetail?.lastRunStatus === 'Running' ||
+    selectedSummary?.lastRunStatus === 'Running' ||
+    (detailRunActiveUntil != null && Date.now() < detailRunActiveUntil);
+
+  const activeDetailPollInterval = isDetailRunActive ? detailActivePollInterval : detailPollInterval;
+
+  useEffect(() => {
+    if (!enabled || !projectId || !selectedJobId) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void fetchDetail(selectedJobId, { silent: true });
+      if (
+        detailRunActiveUntil != null &&
+        Date.now() >= detailRunActiveUntil &&
+        selectedJobDetail?.lastRunStatus !== 'Running' &&
+        selectedSummary?.lastRunStatus !== 'Running'
+      ) {
+        setDetailRunActiveUntil(null);
+      }
+    }, activeDetailPollInterval);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [
+    enabled,
+    projectId,
+    selectedJobId,
+    activeDetailPollInterval,
+    detailRunActiveUntil,
+    fetchDetail,
+    selectedJobDetail?.lastRunStatus,
+    selectedSummary?.lastRunStatus,
+  ]);
+
+  useEffect(() => {
+    const handleRunTriggered = (event: Event) => {
+      const detail = (event as CustomEvent<{ jobId: string }>).detail;
+      if (!detail?.jobId) {
+        return;
+      }
+      setDetailRunActiveUntil(Date.now() + 120_000);
+      patchJob(detail.jobId, { lastRunStatus: 'Running' });
+      if (detail.jobId === selectedJobIdRef.current) {
+        void fetchDetail(detail.jobId, { silent: true });
+      } else {
+        void fetchJobs({ silent: true });
+      }
+    };
+
+    window.addEventListener('scheduled-job-run-triggered', handleRunTriggered);
+    return () => window.removeEventListener('scheduled-job-run-triggered', handleRunTriggered);
+  }, [fetchDetail, fetchJobs, patchJob]);
+
+  return {
+    jobs,
+    selectedJobDetail,
+    isLoadingJobs,
+    isLoadingDetail,
+    jobsError,
+    detailError,
+    lastUpdated,
+    refreshJobs,
+    refreshDetail,
+    refreshAll,
+    applyJobDetail,
+    patchJob,
+    patchSelectedJobFields,
+  };
+}

--- a/src/client/src/hooks/useProjectScheduledJobsPolling.ts
+++ b/src/client/src/hooks/useProjectScheduledJobsPolling.ts
@@ -1,6 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
-import { scheduledJobsApi } from '../services/scheduledJobs';
-import type { ProjectScheduledJobSummaryDto } from '../types/scheduledJob';
+import { useProjectScheduledJobs } from './useProjectScheduledJobs';
 
 interface UseProjectScheduledJobsPollingProps {
   projectId: string;
@@ -8,87 +6,23 @@ interface UseProjectScheduledJobsPollingProps {
   pollInterval?: number;
 }
 
+/** List-only polling for surfaces that do not own scheduled-job detail state. */
 export function useProjectScheduledJobsPolling({
   projectId,
   enabled = true,
   pollInterval = 15000,
 }: UseProjectScheduledJobsPollingProps) {
-  const [jobs, setJobs] = useState<ProjectScheduledJobSummaryDto[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-
-  const fetchJobs = useCallback(async (signal?: AbortSignal) => {
-    try {
-      setIsLoading(true);
-      setError(null);
-
-      if (signal?.aborted) {
-        return;
-      }
-
-      const result = await scheduledJobsApi.list(projectId);
-
-      if (!signal?.aborted) {
-        setJobs(result);
-        setLastUpdated(new Date());
-      }
-    } catch (err) {
-      if (!signal?.aborted) {
-        const errorMessage = err instanceof Error ? err.message : 'Failed to fetch scheduled jobs';
-        setError(errorMessage);
-      }
-    } finally {
-      if (!signal?.aborted) {
-        setIsLoading(false);
-      }
-    }
-  }, [projectId]);
-
-  useEffect(() => {
-    if (!enabled || !projectId) {
-      return;
-    }
-
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
-    fetchJobs(controller.signal);
-
-    intervalRef.current = setInterval(() => {
-      const newController = new AbortController();
-      abortControllerRef.current = newController;
-      fetchJobs(newController.signal);
-    }, pollInterval);
-
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null;
-      }
-    };
-  }, [enabled, projectId, pollInterval, fetchJobs]);
-
-  const refresh = useCallback(() => {
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
-    fetchJobs(controller.signal);
-  }, [fetchJobs]);
+  const { jobs, isLoadingJobs, jobsError, lastUpdated, refreshJobs } = useProjectScheduledJobs({
+    projectId,
+    enabled,
+    listPollInterval: pollInterval,
+  });
 
   return {
     jobs,
-    isLoading,
-    error,
+    isLoading: isLoadingJobs,
+    error: jobsError,
     lastUpdated,
-    refresh,
+    refresh: refreshJobs,
   };
 }

--- a/src/client/src/lib/__tests__/scheduledJobDateTime.test.ts
+++ b/src/client/src/lib/__tests__/scheduledJobDateTime.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatInTimeZone,
+  formatInUserLocal,
+  formatNextRun,
+  parseUtcInstant,
+} from '../scheduledJobDateTime';
+
+describe('scheduledJobDateTime', () => {
+  it('parses UTC instants without a Z suffix as UTC', () => {
+    const parsed = parseUtcInstant('2026-07-15T14:30:00');
+    expect(parsed.toISOString()).toBe('2026-07-15T14:30:00.000Z');
+  });
+
+  it('formats next run in the job timezone', () => {
+    const formatted = formatInTimeZone('2026-07-15T14:30:00Z', 'America/New_York', 'en-US');
+    expect(formatted).toMatch(/15/);
+    expect(formatted).toMatch(/10:30/);
+    expect(formatted).toMatch(/EDT|EST/);
+  });
+
+  it('formats disabled next run copy', () => {
+    expect(formatNextRun('2026-07-15T14:30:00Z', 'UTC', false)).toBe('Not scheduled while disabled');
+  });
+
+  it('formats user-local instants', () => {
+    const formatted = formatInUserLocal('2026-07-15T14:30:00Z', 'en-US');
+    expect(formatted).toMatch(/2026|15/);
+  });
+});

--- a/src/client/src/lib/scheduledJobDateTime.ts
+++ b/src/client/src/lib/scheduledJobDateTime.ts
@@ -1,0 +1,83 @@
+/** API stores UTC instants; SQL/JSON may omit the Z suffix. */
+export function parseUtcInstant(value: string): Date {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return new Date(Number.NaN);
+  }
+
+  if (trimmed.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(trimmed)) {
+    return new Date(trimmed);
+  }
+
+  return new Date(`${trimmed}Z`);
+}
+
+export function formatInTimeZone(
+  value: string | null | undefined,
+  timeZoneId: string,
+  locale?: string | string[]
+): string {
+  if (!value) {
+    return '—';
+  }
+
+  const date = parseUtcInstant(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZone: timeZoneId,
+      timeZoneName: 'short',
+    }).format(date);
+  } catch {
+    return date.toLocaleString(locale, { timeZone: timeZoneId, timeZoneName: 'short' });
+  }
+}
+
+/** Historical instants (last run, run history) in the viewer's local timezone. */
+export function formatInUserLocal(
+  value: string | null | undefined,
+  locale?: string | string[]
+): string {
+  if (!value) {
+    return '—';
+  }
+
+  const date = parseUtcInstant(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(date);
+}
+
+export function formatNextRun(
+  value: string | null | undefined,
+  timeZoneId: string,
+  isEnabled: boolean,
+  locale?: string | string[]
+): string {
+  if (!isEnabled) {
+    return 'Not scheduled while disabled';
+  }
+
+  if (!value) {
+    return '—';
+  }
+
+  return formatInTimeZone(value, timeZoneId, locale);
+}

--- a/src/client/src/pages/ProjectDetails.tsx
+++ b/src/client/src/pages/ProjectDetails.tsx
@@ -21,6 +21,7 @@ import { FileInUseDialog } from '../components/common/FileInUseDialog';
 import { FileUsageInNotebookDto } from '../types/api';
 import { useProjectFilesPolling } from '../hooks/useProjectFilesPolling';
 import { useProjectNotebooksPolling } from '../hooks/useProjectNotebooksPolling';
+import { useProjectScheduledJobs } from '../hooks/useProjectScheduledJobs';
 import { useToast } from '../components/common/Toast';
 import MarkdownViewer from '../components/common/MarkdownViewer';
 import DefaultProjectHomeMd from '../content/default-project-home.md?raw';
@@ -246,6 +247,27 @@ export default function ProjectDetails() {
         projectId: projectId || '',
         enabled: !!(projectId && project),
         pollInterval: 60000
+    });
+
+    const [scheduledJobDialogsOpen, setScheduledJobDialogsOpen] = useState(false);
+
+    const selectedScheduledJobId =
+        selectedItem?.type === 'jobSchedule' ? selectedItem.id : null;
+
+    const {
+        jobs: scheduledJobs,
+        selectedJobDetail,
+        isLoadingJobs: isLoadingScheduledJobs,
+        isLoadingDetail: isLoadingScheduledJobDetail,
+        detailError: scheduledJobDetailError,
+        refreshAll: refreshScheduledJobs,
+        applyJobDetail,
+        patchJob,
+        patchSelectedJobFields,
+    } = useProjectScheduledJobs({
+        projectId: projectId || '',
+        selectedJobId: selectedScheduledJobId,
+        enabled: !!(projectId && project && isOwner() && !scheduledJobDialogsOpen),
     });
 
     const [isAddingLink, setIsAddingLink] = useState(false);
@@ -835,7 +857,12 @@ export default function ProjectDetails() {
                     <ScheduledJobContent
                         projectId={project.id}
                         jobId={selectedItem.id}
+                        job={selectedJobDetail}
+                        isLoading={isLoadingScheduledJobDetail}
+                        error={scheduledJobDetailError}
                         canRun={isOwner()}
+                        onRefresh={refreshScheduledJobs}
+                        onJobFieldsPatch={patchSelectedJobFields}
                     />
                 );
             }
@@ -846,7 +873,9 @@ export default function ProjectDetails() {
         isAddingLink, isAddingFolder, selectedItem, project, 
         isAutoHome, canEdit, handleFileDeleted, handleItemSelect, 
         handleAddFolder, isEditing, setIsEditing,
-        isOwner, refreshProject, setSelectedItem
+        isOwner, refreshProject, setSelectedItem,
+        selectedJobDetail, isLoadingScheduledJobDetail, scheduledJobDetailError,
+        refreshScheduledJobs, patchSelectedJobFields
     ]);
 
 
@@ -909,7 +938,13 @@ export default function ProjectDetails() {
                             onCreateNotebook={canEdit() ? handleCreateNotebook : undefined}
                             onCreateNotebookFromFile={canEdit() ? handleCreateNotebookFromFile : undefined}
                             onCreateNotebookFromFiles={canEdit() ? handleCreateNotebookFromFiles : undefined}
-    
+                            scheduledJobs={scheduledJobs}
+                            isLoadingScheduledJobs={isLoadingScheduledJobs}
+                            refreshScheduledJobs={refreshScheduledJobs}
+                            onScheduledJobDialogOpenChange={setScheduledJobDialogsOpen}
+                            applyScheduledJobDetail={applyJobDetail}
+                            patchScheduledJob={patchJob}
+                            selectedScheduledJobDetail={selectedJobDetail}
                                 homePageContentFileId={project.homePageContentFileId}
                                 onSetHomePage={canEdit() ? handleSetHomePage : undefined}
                                 onFileContentChanged={(fileId, newVersion) => {

--- a/src/client/src/pages/settings/components/catalog/CatalogRowEditModal.tsx
+++ b/src/client/src/pages/settings/components/catalog/CatalogRowEditModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState, type RefObject } from 'react';
 import { api } from '../../../../services/api';
 import { LlamaRuntimeInventoryItemDto, SettingsModelDto, SettingsRuntimeProfileDto } from '../../../../types/settings';
 import { CatalogEditState } from '../../types';
@@ -11,7 +11,7 @@ import { AzureOpenAiChatEditForm } from './providers/AzureOpenAiChatForm';
 import { AzureOpenAiResponsesEditForm } from './providers/AzureOpenAiResponsesForm';
 import { GoogleGeminiEditForm } from './providers/GoogleGeminiForm';
 import { HuggingFaceInferenceEditForm } from './providers/HuggingFaceInferenceForm';
-import { LlamaCppEditForm } from './providers/LlamaCppForm';
+import { LlamaCppEditForm, type LlamaCppEditFormHandle } from './providers/LlamaCppForm';
 import { OpenAiChatEditForm } from './providers/OpenAiChatForm';
 import { OpenAiResponsesEditForm } from './providers/OpenAiResponsesForm';
 import { OpenRouterEditForm } from './providers/OpenRouterForm';
@@ -46,7 +46,8 @@ function renderEditForm(
   profilesLoading: boolean,
   inventory: LlamaRuntimeInventoryItemDto[] | undefined,
   sharedProfileModelCount: number,
-  onDetailChanged?: () => Promise<void>
+  onDetailChanged?: () => Promise<void>,
+  llamaFormRef?: RefObject<LlamaCppEditFormHandle | null>,
 ) {
   const props = {
     value,
@@ -69,6 +70,7 @@ function renderEditForm(
     case 'llama-cpp':
       return (
         <LlamaCppEditForm
+          ref={llamaFormRef}
           {...props}
           sharedProfileModelCount={sharedProfileModelCount}
           onDetailChanged={onDetailChanged}
@@ -98,6 +100,7 @@ export function CatalogRowEditModal({
   const [value, setValue] = useState<CatalogEditState | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const llamaFormRef = useRef<LlamaCppEditFormHandle>(null);
 
   useEffect(() => {
     if (!isOpen || !model) {
@@ -118,6 +121,9 @@ export function CatalogRowEditModal({
     setSaving(true);
     setError(null);
     try {
+      if (value.provider === 'llama-cpp') {
+        await llamaFormRef.current?.saveRouterPreset();
+      }
       const selectedProfile = profiles.find((profile) => profile.profileId === value.runtimeProfileId.trim());
       const request = buildCatalogEditRequest(value, {
         runtimeConfigJson: model.runtimeConfigJson ?? undefined,
@@ -222,6 +228,7 @@ export function CatalogRowEditModal({
                 parseRuntimeProfileId(model?.runtimeConfigJson) ?? value.runtimeProfileId,
               ),
               onSaved,
+              llamaFormRef,
             )}
           </div>
 

--- a/src/client/src/pages/settings/components/catalog/__tests__/CatalogRowEditModal.test.tsx
+++ b/src/client/src/pages/settings/components/catalog/__tests__/CatalogRowEditModal.test.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, useImperativeHandle } from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -29,8 +30,15 @@ vi.mock('../providers/AzureOpenAiResponsesForm', () => ({
 vi.mock('../providers/AnthropicForm', () => ({
   AnthropicEditForm: () => <div>anthropic-form</div>,
 }));
+const saveRouterPreset = vi.fn();
+
 vi.mock('../providers/LlamaCppForm', () => ({
-  LlamaCppEditForm: () => <div>llama-cpp-form</div>,
+  LlamaCppEditForm: forwardRef(function MockLlamaCppEditForm(_props, ref) {
+    useImperativeHandle(ref, () => ({
+      saveRouterPreset,
+    }));
+    return <div>llama-cpp-form</div>;
+  }),
 }));
 vi.mock('../providers/GoogleGeminiForm', () => ({
   GoogleGeminiEditForm: () => <div>google-gemini-form</div>,
@@ -53,6 +61,18 @@ const openAiModel: SettingsModelDto = {
   updated: '2026-01-02T00:00:00Z',
 };
 
+const llamaModel: SettingsModelDto = {
+  modelId: 'llama/qwen',
+  displayName: 'Qwen Local',
+  description: 'local model',
+  provider: 'llama-cpp',
+  displayOrder: 2,
+  isActive: true,
+  runtimeConfigJson: JSON.stringify({ runtimeProfileId: 'qwen3_6' }),
+  created: '2026-01-01T00:00:00Z',
+  updated: '2026-01-02T00:00:00Z',
+};
+
 const profile = {
   profileId: 'openai_default',
   displayName: 'OpenAI Default',
@@ -70,6 +90,7 @@ describe('CatalogRowEditModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(api.settings.updateModel).mockResolvedValue(undefined as never);
+    saveRouterPreset.mockResolvedValue(undefined);
   });
 
   it('renders provider form and saves catalog edits', async () => {
@@ -102,6 +123,45 @@ describe('CatalogRowEditModal', () => {
       );
       expect(onSaved).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('saves router preset before catalog metadata for llama-cpp rows', async () => {
+    const user = userEvent.setup();
+    const callOrder: string[] = [];
+    saveRouterPreset.mockImplementation(async () => {
+      callOrder.push('router-preset');
+    });
+    vi.mocked(api.settings.updateModel).mockImplementation(async () => {
+      callOrder.push('catalog');
+      return undefined as never;
+    });
+
+    render(
+      <CatalogRowEditModal
+        model={llamaModel}
+        orderedModels={[llamaModel]}
+        profiles={[]}
+        profilesLoading={false}
+        isOpen
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('llama-cpp-form')).toBeInTheDocument();
+    const displayNameInput = screen.getByDisplayValue('Qwen Local');
+    await user.clear(displayNameInput);
+    await user.type(displayNameInput, 'Updated Qwen');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(saveRouterPreset).toHaveBeenCalled();
+      expect(api.settings.updateModel).toHaveBeenCalledWith(
+        'llama/qwen',
+        expect.objectContaining({ displayName: 'Updated Qwen' }),
+      );
+      expect(callOrder).toEqual(['router-preset', 'catalog']);
     });
   });
 

--- a/src/client/src/pages/settings/components/catalog/providers/LlamaCppForm.tsx
+++ b/src/client/src/pages/settings/components/catalog/providers/LlamaCppForm.tsx
@@ -1,5 +1,9 @@
+import { forwardRef } from 'react';
 import type { CatalogEditState } from '../../../types';
-import { LlamaInstalledSummary } from '../../../../../features/localModelOnboarding/installed/LlamaInstalledSummary';
+import {
+  LlamaInstalledSummary,
+  type LlamaInstalledSummaryHandle,
+} from '../../../../../features/localModelOnboarding/installed/LlamaInstalledSummary';
 import { CustomHfOnboardingForm } from '../../../../../features/localModelOnboarding/advanced/CustomHfOnboardingForm';
 import { AttachAliasOnboardingForm } from '../../../../../features/localModelOnboarding/advanced/AttachAliasOnboardingForm';
 import type { ProviderAddForm, ProviderEditForm } from './types';
@@ -36,23 +40,24 @@ export function LlamaCppAddForm({
   );
 }
 
-export function LlamaCppEditForm({
-  value,
-  onChange,
-  onDetailChanged,
-  sharedProfileModelCount,
-}: Omit<ProviderEditForm, 'profiles' | 'profilesLoading' | 'inventory'> & {
-  onDetailChanged?: () => Promise<void>;
-  sharedProfileModelCount?: number;
-}) {
+export type LlamaCppEditFormHandle = LlamaInstalledSummaryHandle;
+
+export const LlamaCppEditForm = forwardRef<
+  LlamaCppEditFormHandle,
+  Omit<ProviderEditForm, 'profiles' | 'profilesLoading' | 'inventory'> & {
+    onDetailChanged?: () => Promise<void>;
+    sharedProfileModelCount?: number;
+  }
+>(function LlamaCppEditForm({ value, onChange, onDetailChanged, sharedProfileModelCount }, ref) {
   void onChange;
   return (
     <LlamaInstalledSummary
+      ref={ref}
       modelId={value.modelId}
       sharedProfileModelCount={sharedProfileModelCount}
       onChanged={onDetailChanged}
     />
   );
-}
+});
 
 export type { CatalogEditState };

--- a/src/server/AntRunner.Chat/AntRunner.Chat/AntRunner.Chat.csproj
+++ b/src/server/AntRunner.Chat/AntRunner.Chat/AntRunner.Chat.csproj
@@ -27,6 +27,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="GuideAnts.Logging" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GuideAnts.Logging\GuideAnts.Logging.csproj" />
     <ProjectReference Include="..\AntRunner.Chat.Abstractions\AntRunner.Chat.Abstractions.csproj" />
     <ProjectReference Include="..\AntRunner.ToolCalling\AntRunner.ToolCalling.csproj" />
     <ProjectReference Include="..\..\GuideAnts.Usage\GuideAnts.Usage.csproj" />

--- a/src/server/AntRunner.Chat/AntRunner.Chat/AssistantUtility.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat/AssistantUtility.cs
@@ -52,13 +52,13 @@ namespace AntRunner.Chat
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogError(ex, "Failed to load assistant definition for {AssistantName}", assistantName);
+                    Logger.LogError(ex, "Failed to load assistant definition for {AssistantName}", LogValueSanitizer.Sanitize(assistantName));
 
                     if (TryGetCachedDefinition(cacheKey, out cachedDefinition))
                     {
                         Logger.LogWarning(
                             "Serving cached assistant definition for {AssistantName} after load failure",
-                            assistantName);
+                            LogValueSanitizer.Sanitize(assistantName));
                         return cachedDefinition;
                     }
 
@@ -152,7 +152,7 @@ namespace AntRunner.Chat
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogWarning(ex, "Failed to parse context options for assistant {AssistantName}", assistantName);
+                    Logger.LogWarning(ex, "Failed to parse context options for assistant {AssistantName}", LogValueSanitizer.Sanitize(assistantName));
                 }
             }
 
@@ -174,7 +174,7 @@ namespace AntRunner.Chat
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogWarning(ex, "Failed to parse sampling parameters for assistant {AssistantName}", assistantName);
+                    Logger.LogWarning(ex, "Failed to parse sampling parameters for assistant {AssistantName}", LogValueSanitizer.Sanitize(assistantName));
                 }
             }
 
@@ -268,7 +268,7 @@ namespace AntRunner.Chat
                             Logger.LogWarning(
                                 ex,
                                 "Failed to generate schema for tool operation {Operation}",
-                                matchingOperation.Value);
+                                LogValueSanitizer.Sanitize(matchingOperation.Value));
                         }
                     }
                 }
@@ -305,7 +305,7 @@ namespace AntRunner.Chat
             }
             catch (Exception ex)
             {
-                Logger.LogWarning(ex, "Failed to inject registered tool {OperationId}", operationId);
+                Logger.LogWarning(ex, "Failed to inject registered tool {OperationId}", LogValueSanitizer.Sanitize(operationId));
             }
         }
 

--- a/src/server/AntRunner.Chat/AntRunner.Chat/AssistantUtility.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat/AssistantUtility.cs
@@ -4,26 +4,23 @@ using static AntRunner.ToolCalling.AssistantDefinitions.Storage.AssistantDefinit
 using AntRunner.ToolCalling.AssistantDefinitions;
 using System.Text.Json.Serialization;
 using AntRunner.ToolCalling;
+using Microsoft.Extensions.Logging;
 
 namespace AntRunner.Chat
 {
     /// <summary>
     /// Fetches and caches assistants resolved from database-backed definitions.
+    /// Cache entries live until explicitly cleared via <see cref="ClearCache"/> when the API mutates a definition.
     /// </summary>
     public static class AssistantUtility
     {
-        /// <summary>
-        /// Cache entry containing the definition and metadata for invalidation.
-        /// </summary>
-        private record CachedAssistant(
-            AssistantDefinition? Definition,
-            DateTime? Updated,
-            DateTime CachedAt
-        );
+        private static readonly ILogger Logger = ChatDiagnostics.CreateLogger(nameof(AssistantUtility));
 
-        // Cache keyed by assistant name.
+        private record CachedAssistant(AssistantDefinition Definition);
+
+        // Cache keyed by assistant name. Invalidated only via ClearCache / ClearAllCache.
         private static readonly ConcurrentDictionary<string, CachedAssistant> AssistantDefinitionCache = new();
-        private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
+        private static readonly ConcurrentDictionary<string, SemaphoreSlim> LoadLocks = new();
 
         /// <summary>
         /// Reads the assistant definition from database-backed storage.
@@ -34,159 +31,74 @@ namespace AntRunner.Chat
         {
             var cacheKey = GenerateCacheKey(assistantName);
 
-            // Check cache and validate against database if needed
+            if (TryGetCachedDefinition(cacheKey, out var cachedDefinition))
+            {
+                return cachedDefinition;
+            }
+
+            var loadLock = LoadLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+            await loadLock.WaitAsync();
+            try
+            {
+                if (TryGetCachedDefinition(cacheKey, out cachedDefinition))
+                {
+                    return cachedDefinition;
+                }
+
+                AssistantDefinition? loadedDefinition;
+                try
+                {
+                    loadedDefinition = await LoadAssistantDefinitionAsync(assistantName);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Failed to load assistant definition for {AssistantName}", assistantName);
+
+                    if (TryGetCachedDefinition(cacheKey, out cachedDefinition))
+                    {
+                        Logger.LogWarning(
+                            "Serving cached assistant definition for {AssistantName} after load failure",
+                            assistantName);
+                        return cachedDefinition;
+                    }
+
+                    throw;
+                }
+
+                if (loadedDefinition == null)
+                {
+                    return null;
+                }
+
+                await AddFunctionTools(assistantName, loadedDefinition);
+
+                AssistantDefinitionCache[cacheKey] = new CachedAssistant(loadedDefinition);
+                return loadedDefinition;
+            }
+            finally
+            {
+                loadLock.Release();
+            }
+        }
+
+        private static bool TryGetCachedDefinition(string cacheKey, out AssistantDefinition? definition)
+        {
             if (AssistantDefinitionCache.TryGetValue(cacheKey, out var cached))
             {
-                // Check if cache is still valid
-                var isCacheValid = await IsCacheValid(cached, assistantName);
-                if (isCacheValid)
-                {
-                    return cached.Definition;
-                }
-                
-                // Cache is stale, remove it
-                AssistantDefinitionCache.TryRemove(cacheKey, out _);
+                definition = cached.Definition;
+                return true;
             }
 
-            // Load assistant definition
-            AssistantDefinition? definition = null;
-            DateTime? updated = null;
-
-            // Handle dynamic notebook template Guide assistants, e.g. "Creative Guide" or "Creative Guide Guide"
-            if (assistantName.EndsWith(" Guide", StringComparison.OrdinalIgnoreCase))
-            {
-                var guide = await TryBuildGuideFromTemplate(assistantName);
-                if (guide != null)
-                {
-                    definition = guide;
-                }
-            }
-
-            // If not a guide template, load from storage
-            if (definition == null)
-            {
-                var storageMetadata = await GetAssistantComplete(assistantName);
-                
-                if (storageMetadata == null) return null;
-
-                // Deserialize manifest with lenient options that allow integer enum values
-                var lenientOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
-                {
-                    Converters = { new JsonStringEnumConverter(allowIntegerValues: true) }
-                };
-                definition = JsonSerializer.Deserialize<AssistantDefinition>(storageMetadata.ManifestJson, lenientOptions);
-                
-                if (definition != null)
-                {
-                    definition.Name = assistantName;
-                    definition.Id = storageMetadata.Id;  // Set database ID if available
-                    
-                    // Set instructions
-                    if (!string.IsNullOrWhiteSpace(storageMetadata.Instructions))
-                    {
-                        definition.Instructions = storageMetadata.Instructions;
-                    }
-                    
-                    // Set context options
-                    if (!string.IsNullOrWhiteSpace(storageMetadata.ContextOptionsJson))
-                    {
-                        try
-                        {
-                            var contextList = JsonSerializer.Deserialize<List<ContextOptionItem>>(storageMetadata.ContextOptionsJson);
-                            var contextDict = contextList?.ToDictionary(i => i.key, i => i.value ?? string.Empty);
-                            if (contextDict != null && contextDict.Any())
-                            {
-                                definition.ContextOptions = contextDict;
-                            }
-                        }
-                        catch (Exception)
-                        {
-                            // swallow parse errors for now, could log
-                        }
-                    }
-
-                    // Apply additional metadata from database (e.g., crew names)
-                    if (storageMetadata.AdditionalMetadata != null)
-                    {
-                        if (definition.Metadata == null)
-                        {
-                            definition.Metadata = new Dictionary<string, string>();
-                        }
-                        foreach (var kvp in storageMetadata.AdditionalMetadata)
-                        {
-                            definition.Metadata[kvp.Key] = kvp.Value;
-                        }
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(storageMetadata.SamplingParametersJson))
-                    {
-                        try
-                        {
-                            definition.SamplingParameters = JsonSerializer.Deserialize<Dictionary<string, double>>(
-                                storageMetadata.SamplingParametersJson);
-                        }
-                        catch (Exception)
-                        {
-                        }
-                    }
-
-                    updated = storageMetadata.Updated;
-                }
-            }
-
-            if (definition == null) return null;
-
-            // Add function tools (crew bridge, OpenAPI, vector stores, annotation-based)
-            await AddFunctionTools(assistantName, definition);
-
-            // Cache the definition
-            var cachedEntry = new CachedAssistant(definition, updated, DateTime.UtcNow);
-            AssistantDefinitionCache.AddOrUpdate(cacheKey, cachedEntry, (k, v) => cachedEntry);
-
-            return definition;
+            definition = null;
+            return false;
         }
 
-        /// <summary>
-        /// Generates a cache key based on assistant name.
-        /// </summary>
-        private static string GenerateCacheKey(string assistantName)
-        {
-            return assistantName;
-        }
-
-        /// <summary>
-        /// Checks if a cached entry is still valid by comparing timestamps with the database.
-        /// </summary>
-        private static async Task<bool> IsCacheValid(CachedAssistant cached, string assistantName)
-        {
-            // Check cache age
-            if (DateTime.UtcNow - cached.CachedAt > CacheDuration)
-            {
-                // Cache expired by time, but check if database has been updated
-                if (cached.Updated.HasValue)
-                {
-                    var metadata = await GetAssistantMetadata(assistantName);
-                    if (metadata.HasValue)
-                    {
-                        // If database Updated timestamp is newer, cache is invalid
-                        if (metadata.Value.Updated.HasValue && metadata.Value.Updated > cached.Updated)
-                        {
-                            return false;
-                        }
-                    }
-                }
-                // For time-based invalidation of database assistants with no updates, still consider valid.
-                return cached.Updated.HasValue;
-            }
-
-            return true;
-        }
+        private static string GenerateCacheKey(string assistantName) => assistantName;
 
         /// <summary>
         /// Clears a specific assistant from the cache.
-        /// Useful when an assistant is updated and immediate invalidation is needed.
+        /// Called when the API updates or deletes an assistant or guide definition.
         /// </summary>
-        /// <param name="assistantName">The name of the assistant to clear</param>
         public static void ClearCache(string assistantName)
         {
             var cacheKey = GenerateCacheKey(assistantName);
@@ -195,11 +107,78 @@ namespace AntRunner.Chat
 
         /// <summary>
         /// Clears all cached assistants.
-        /// Useful for testing or when bulk updates are made.
         /// </summary>
         public static void ClearAllCache()
         {
             AssistantDefinitionCache.Clear();
+        }
+
+        private static async Task<AssistantDefinition?> LoadAssistantDefinitionAsync(string assistantName)
+        {
+            var storageMetadata = await GetAssistantComplete(assistantName);
+            if (storageMetadata == null)
+            {
+                return null;
+            }
+
+            var lenientOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                Converters = { new JsonStringEnumConverter(allowIntegerValues: true) }
+            };
+            var definition = JsonSerializer.Deserialize<AssistantDefinition>(storageMetadata.ManifestJson, lenientOptions);
+            if (definition == null)
+            {
+                return null;
+            }
+
+            definition.Name = assistantName;
+            definition.Id = storageMetadata.Id;
+
+            if (!string.IsNullOrWhiteSpace(storageMetadata.Instructions))
+            {
+                definition.Instructions = storageMetadata.Instructions;
+            }
+
+            if (!string.IsNullOrWhiteSpace(storageMetadata.ContextOptionsJson))
+            {
+                try
+                {
+                    var contextList = JsonSerializer.Deserialize<List<ContextOptionItem>>(storageMetadata.ContextOptionsJson);
+                    var contextDict = contextList?.ToDictionary(i => i.key, i => i.value ?? string.Empty);
+                    if (contextDict != null && contextDict.Count > 0)
+                    {
+                        definition.ContextOptions = contextDict;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(ex, "Failed to parse context options for assistant {AssistantName}", assistantName);
+                }
+            }
+
+            if (storageMetadata.AdditionalMetadata != null)
+            {
+                definition.Metadata ??= new Dictionary<string, string>();
+                foreach (var kvp in storageMetadata.AdditionalMetadata)
+                {
+                    definition.Metadata[kvp.Key] = kvp.Value;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(storageMetadata.SamplingParametersJson))
+            {
+                try
+                {
+                    definition.SamplingParameters = JsonSerializer.Deserialize<Dictionary<string, double>>(
+                        storageMetadata.SamplingParametersJson);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(ex, "Failed to parse sampling parameters for assistant {AssistantName}", assistantName);
+                }
+            }
+
+            return definition;
         }
 
         private static async Task AddFunctionTools(string assistantName, AssistantDefinition options)
@@ -208,7 +187,7 @@ namespace AntRunner.Chat
             if (options.Metadata != null && options.Metadata.TryGetValue("__crew_names__", out var crewNamesStr))
             {
                 var crewNames = crewNamesStr.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
-                if (crewNames.Any())
+                if (crewNames.Count > 0)
                 {
                     var crewAssistants = new List<AssistantDefinition>();
                     foreach (var crewName in crewNames)
@@ -230,21 +209,17 @@ namespace AntRunner.Chat
                         }
                     }
                 }
-                // Keep the metadata for EnsureRequestBuilderCache to use
             }
 
-            // Add OpenAPI-based function tools
             var openApiToolDefinitions = await GetOpenApiToolDefinitions(assistantName);
             foreach (var toolDefinition in openApiToolDefinitions)
             {
                 options.Tools!.Add(toolDefinition);
             }
 
-            // Add SearchAssistantFiles tool if assistant has indexed content (vector stores)
-            // This tool is annotation-based and will be injected via ToolContractRegistry
-            var hasVectorStores = options.ToolResources?.FileSearch?.VectorStoreIds != null 
+            var hasVectorStores = options.ToolResources?.FileSearch?.VectorStoreIds != null
                 && options.ToolResources.FileSearch.VectorStoreIds.Any();
-            
+
             if (hasVectorStores)
             {
                 TryInjectRegisteredTool(options, "SearchAssistantFiles");
@@ -256,32 +231,28 @@ namespace AntRunner.Chat
                 TryInjectRegisteredTool(options, "skills.read");
             }
 
-            // ---------------------------------------------------------------------
-            // Process dynamic schema placeholders using annotation-driven discovery
-            // ---------------------------------------------------------------------
             var requestedPlaceholders = options.Tools?
                 .Where(t => t.Type != null)
                 .ToList();
 
-            if (requestedPlaceholders?.Any() == true)
+            if (requestedPlaceholders?.Count > 0)
             {
                 var allToolOperations = ToolContractRegistry.GetAllToolOperations();
                 var processedSchemas = new HashSet<string>();
-                
+
                 foreach (var placeholder in requestedPlaceholders.Where(p => p.Type != null))
                 {
-                    // Find the tool operation that matches this placeholder type
-                    var matchingOperation = allToolOperations.FirstOrDefault(kvp => 
+                    var matchingOperation = allToolOperations.FirstOrDefault(kvp =>
                         string.Equals(kvp.Key, placeholder.Type, StringComparison.OrdinalIgnoreCase));
-                    
-                    if (!string.IsNullOrEmpty(matchingOperation.Key) && 
+
+                    if (!string.IsNullOrEmpty(matchingOperation.Key) &&
                         !processedSchemas.Contains(matchingOperation.Value))
                     {
                         try
                         {
                             var schema = ToolContractRegistry.GenerateOpenApiSchema(matchingOperation.Value);
                             var toolDefinitions = OpenApiHelper.GetToolDefinitionsFromJson(schema);
-                            
+
                             foreach (var def in toolDefinitions)
                             {
                                 if (def.Function?.AsObject?.Name == matchingOperation.Key)
@@ -289,18 +260,19 @@ namespace AntRunner.Chat
                                     options.Tools!.Add(def);
                                 }
                             }
-                            
+
                             processedSchemas.Add(matchingOperation.Value);
                         }
                         catch (Exception ex)
                         {
-                            // Log warning but continue processing other tools
-                            Console.WriteLine($"Warning: Failed to generate schema for {matchingOperation.Value}: {ex.Message}");
+                            Logger.LogWarning(
+                                ex,
+                                "Failed to generate schema for tool operation {Operation}",
+                                matchingOperation.Value);
                         }
                     }
                 }
 
-                // Remove all placeholder entries that were successfully processed
                 options.Tools = options.Tools!
                     .Where(t => t.Type == null || !allToolOperations.ContainsKey(t.Type!))
                     .ToList();
@@ -333,17 +305,16 @@ namespace AntRunner.Chat
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Warning: Failed to inject {operationId} tool: {ex.Message}");
+                Logger.LogWarning(ex, "Failed to inject registered tool {OperationId}", operationId);
             }
         }
 
-        // -----------------------------
         private static async Task<List<ToolDefinition>> GetOpenApiToolDefinitions(string assistantName)
         {
             var toolDefinitions = new List<ToolDefinition>();
 
             var storageMetadata = await GetAssistantComplete(assistantName);
-            if (storageMetadata?.OpenApiSchemas == null || !storageMetadata.OpenApiSchemas.Any())
+            if (storageMetadata?.OpenApiSchemas == null || storageMetadata.OpenApiSchemas.Count == 0)
             {
                 return toolDefinitions;
             }
@@ -355,87 +326,6 @@ namespace AntRunner.Chat
             }
 
             return toolDefinitions;
-        }
-        
-        // -----------------------------
-        // Helper methods for Guide load
-        // -----------------------------
-        private static async Task<AssistantDefinition?> TryBuildGuideFromTemplate(string assistantName)
-        {
-            // First, try to load the guide from database
-            var storageMetadata = await GetAssistantComplete(assistantName);
-            if (storageMetadata != null)
-            {
-                // Found in database, deserialize and return
-                // Use lenient options that allow integer enum values from database
-                var lenientOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
-                {
-                    Converters = { new JsonStringEnumConverter(allowIntegerValues: true) }
-                };
-                var definition = JsonSerializer.Deserialize<AssistantDefinition>(storageMetadata.ManifestJson, lenientOptions);
-                if (definition != null)
-                {
-                    definition.Name = assistantName;
-                    definition.Id = storageMetadata.Id;  // Set database ID if available
-                    
-                    // Set instructions
-                    if (!string.IsNullOrWhiteSpace(storageMetadata.Instructions))
-                    {
-                        definition.Instructions = storageMetadata.Instructions;
-                    }
-                    
-                    // Set context options
-                    if (!string.IsNullOrWhiteSpace(storageMetadata.ContextOptionsJson))
-                    {
-                        try
-                        {
-                            var contextList = JsonSerializer.Deserialize<List<ContextOptionItem>>(storageMetadata.ContextOptionsJson);
-                            var contextDict = contextList?.ToDictionary(i => i.key, i => i.value ?? string.Empty);
-                            if (contextDict != null && contextDict.Any())
-                            {
-                                definition.ContextOptions = contextDict;
-                            }
-                        }
-                        catch (Exception)
-                        {
-                            // Swallow context options parsing errors
-                        }
-                    }
-                    
-                    // Set additional metadata (includes __crew_names__ for guides)
-                    if (storageMetadata.AdditionalMetadata != null && storageMetadata.AdditionalMetadata.Any())
-                    {
-                        if (definition.Metadata == null)
-                        {
-                            definition.Metadata = new Dictionary<string, string>(storageMetadata.AdditionalMetadata);
-                        }
-                        else
-                        {
-                            // Merge additional metadata into existing metadata
-                            foreach (var kvp in storageMetadata.AdditionalMetadata)
-                            {
-                                definition.Metadata[kvp.Key] = kvp.Value;
-                            }
-                        }
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(storageMetadata.SamplingParametersJson))
-                    {
-                        try
-                        {
-                            definition.SamplingParameters = JsonSerializer.Deserialize<Dictionary<string, double>>(
-                                storageMetadata.SamplingParametersJson);
-                        }
-                        catch (Exception)
-                        {
-                        }
-                    }
-                    
-                    return definition;
-                }
-            }
-
-            return null;
         }
 
         private record ContextOptionItem(string key, string? value);

--- a/src/server/AntRunner.Chat/AntRunner.ToolCalling/AntRunner.ToolCalling.csproj
+++ b/src/server/AntRunner.Chat/AntRunner.ToolCalling/AntRunner.ToolCalling.csproj
@@ -34,6 +34,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="GuideAnts.Logging" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GuideAnts.Logging\GuideAnts.Logging.csproj" />
     <ProjectReference Include="..\..\GuideAntsApi.DataModel\GuideAntsApi.DataModel.csproj" />
   </ItemGroup>
 

--- a/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/DatabaseStorage.cs
+++ b/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/DatabaseStorage.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using GuideAntsApi.DataModel;
 using GuideAntsApi.DataModel.Models;
 using AntRunner.ToolCalling.Functions;
@@ -14,6 +15,8 @@ namespace AntRunner.ToolCalling.AssistantDefinitions.Storage
     public class DatabaseStorage
     {
         public const int MaxSkillsPerAssistant = 50;
+
+        private static readonly ILogger Logger = ToolCallingDiagnostics.CreateLogger<DatabaseStorage>();
 
         /// <summary>
         /// Creates a new ApplicationDbContext instance using connection string from environment.
@@ -28,7 +31,11 @@ namespace AntRunner.ToolCalling.AssistantDefinitions.Storage
             }
 
             var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
-            optionsBuilder.UseSqlServer(connectionString);
+            optionsBuilder.UseSqlServer(connectionString, sqlOptions =>
+            {
+                sqlOptions.EnableRetryOnFailure(maxRetryCount: 5, maxRetryDelay: TimeSpan.FromSeconds(10), errorNumbersToAdd: null);
+                sqlOptions.CommandTimeout(60);
+            });
             return new ApplicationDbContext(optionsBuilder.Options);
         }
 
@@ -133,33 +140,46 @@ namespace AntRunner.ToolCalling.AssistantDefinitions.Storage
         /// </summary>
         public static async Task<AssistantStorageMetadata?> GetAssistant(string assistantName)
         {
+            ApplicationDbContext context;
             try
             {
-                using var context = CreateContext();
-                
-                var assistant = await context.Assistants
-                    .AsNoTracking()
-                    .Include(a => a.Model)
-                    .Include(a => a.Tools).ThenInclude(t => t.Tool)
-                    .Include(a => a.OpenApiSchemas).ThenInclude(s => s.Operations)
-                    .Include(a => a.OpenApiSchemas).ThenInclude(s => s.AuthProvider)
-                    .Include(a => a.Files)
-                    .Include(a => a.SkillMetas)
-                    .Include(a => a.ContextOptions)
-                    .Include(a => a.ConversationStarters)
-                    .Include(a => a.CrewMembers).ThenInclude(m => m.Assistant)
-                    .Where(a => a.Name == assistantName && a.IsActive)
-                    .OrderBy(a => a.IsGlobal)
-                    .FirstOrDefaultAsync();
-
-                if (assistant == null) return null;
-
-                // Materialize to AssistantDefinition format
-                return MaterializeAssistant(assistant);
+                context = CreateContext();
             }
-            catch
+            catch (InvalidOperationException ex)
             {
+                Logger.LogError(ex, "Database context is not configured for assistant load");
                 return null;
+            }
+
+            try
+            {
+                await using (context)
+                {
+                    var assistant = await context.Assistants
+                        .AsNoTracking()
+                        .AsSplitQuery()
+                        .Include(a => a.Model)
+                        .Include(a => a.Tools).ThenInclude(t => t.Tool)
+                        .Include(a => a.OpenApiSchemas).ThenInclude(s => s.Operations)
+                        .Include(a => a.OpenApiSchemas).ThenInclude(s => s.AuthProvider)
+                        .Include(a => a.Files)
+                        .Include(a => a.SkillMetas)
+                        .Include(a => a.ContextOptions)
+                        .Include(a => a.ConversationStarters)
+                        .Include(a => a.CrewMembers).ThenInclude(m => m.Assistant)
+                        .Where(a => a.Name == assistantName && a.IsActive)
+                        .OrderBy(a => a.IsGlobal)
+                        .FirstOrDefaultAsync();
+
+                    if (assistant == null) return null;
+
+                    return MaterializeAssistant(assistant);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to load assistant {AssistantName} from database", assistantName);
+                throw;
             }
         }
 

--- a/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/DatabaseStorage.cs
+++ b/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/DatabaseStorage.cs
@@ -178,7 +178,7 @@ namespace AntRunner.ToolCalling.AssistantDefinitions.Storage
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "Failed to load assistant {AssistantName} from database", assistantName);
+                Logger.LogError(ex, "Failed to load assistant {AssistantName} from database", LogValueSanitizer.Sanitize(assistantName));
                 throw;
             }
         }

--- a/src/server/GuideAntsApi.DataModel/Migrations/20260715133750_AddProjectScheduledJobRunStatusIndex.Designer.cs
+++ b/src/server/GuideAntsApi.DataModel/Migrations/20260715133750_AddProjectScheduledJobRunStatusIndex.Designer.cs
@@ -4,6 +4,7 @@ using GuideAntsApi.DataModel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GuideAntsApi.DataModel.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715133750_AddProjectScheduledJobRunStatusIndex")]
+    partial class AddProjectScheduledJobRunStatusIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/server/GuideAntsApi.DataModel/Migrations/20260715133750_AddProjectScheduledJobRunStatusIndex.cs
+++ b/src/server/GuideAntsApi.DataModel/Migrations/20260715133750_AddProjectScheduledJobRunStatusIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GuideAntsApi.DataModel.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectScheduledJobRunStatusIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectScheduledJobRuns_ScheduledJobId_Status",
+                table: "ProjectScheduledJobRuns",
+                columns: new[] { "ScheduledJobId", "Status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ProjectScheduledJobRuns_ScheduledJobId_Status",
+                table: "ProjectScheduledJobRuns");
+        }
+    }
+}

--- a/src/server/GuideAntsApi.DataModel/Models/ProjectScheduledJobRun.cs
+++ b/src/server/GuideAntsApi.DataModel/Models/ProjectScheduledJobRun.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 namespace GuideAntsApi.DataModel.Models;
 
 [Index(nameof(ScheduledJobId), nameof(StartedUtc))]
+[Index(nameof(ScheduledJobId), nameof(Status))]
 public class ProjectScheduledJobRun
 {
     [Key]

--- a/src/server/GuideAntsApi.Tests/ChatLayer/AssistantUtilityCacheTests.cs
+++ b/src/server/GuideAntsApi.Tests/ChatLayer/AssistantUtilityCacheTests.cs
@@ -1,0 +1,67 @@
+using System.Collections;
+using System.Reflection;
+using AntRunner.Chat;
+using AntRunner.ToolCalling.AssistantDefinitions;
+using FluentAssertions;
+
+namespace GuideAntsApi.Tests.ChatLayer;
+
+[TestClass]
+public sealed class AssistantUtilityCacheTests
+{
+    [TestInitialize]
+    public void SetUp()
+    {
+        AssistantUtility.ClearAllCache();
+    }
+
+    [TestCleanup]
+    public void TearDown()
+    {
+        AssistantUtility.ClearAllCache();
+    }
+
+    [TestMethod]
+    public void ClearCache_RemovesEntrySoNextLoadWouldMissCache()
+    {
+        SeedCache("Creative Guide", new AssistantDefinition { Name = "Creative Guide", Model = "gpt-4o" });
+
+        AssistantUtility.ClearCache("Creative Guide");
+
+        GetCacheDictionary().Contains("Creative Guide").Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void ClearAllCache_RemovesAllEntries()
+    {
+        SeedCache("Creative Guide", new AssistantDefinition { Name = "Creative Guide" });
+        SeedCache("Search", new AssistantDefinition { Name = "Search" });
+
+        AssistantUtility.ClearAllCache();
+
+        GetCacheDictionary().Count.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void CachedAssistant_DoesNotUseTimeBasedExpiry()
+    {
+        var cacheType = typeof(AssistantUtility).GetNestedType("CachedAssistant", BindingFlags.NonPublic)!;
+        cacheType.GetProperties().Select(p => p.Name).Should().NotContain("CachedAt");
+        cacheType.GetProperties().Select(p => p.Name).Should().NotContain("Updated");
+    }
+
+    private static void SeedCache(string assistantName, AssistantDefinition definition)
+    {
+        var cacheType = typeof(AssistantUtility).GetNestedType("CachedAssistant", BindingFlags.NonPublic)!;
+        var entry = Activator.CreateInstance(cacheType, definition)!;
+        var cache = GetCacheDictionary();
+        cache[assistantName] = entry;
+    }
+
+    private static IDictionary GetCacheDictionary()
+    {
+        return (IDictionary)typeof(AssistantUtility)
+            .GetField("AssistantDefinitionCache", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetValue(null)!;
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Configuration/ComposeEnvironmentContractTests.cs
+++ b/src/server/GuideAntsApi.Tests/Configuration/ComposeEnvironmentContractTests.cs
@@ -401,6 +401,7 @@ public sealed class ComposeEnvironmentContractTests
 
         if (key.Equals("ACCEPT_EULA", StringComparison.OrdinalIgnoreCase)
             || key.Equals("MSSQL_DB_NAME", StringComparison.OrdinalIgnoreCase)
+            || key.Equals("MSSQL_PID", StringComparison.OrdinalIgnoreCase)
             || key.Equals("MSSQL_SA_PASSWORD", StringComparison.OrdinalIgnoreCase))
         {
             return true;

--- a/src/server/GuideAntsApi.Tests/Services/ConversationManagerTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/ConversationManagerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Moq;
 using FluentAssertions;
+using AntRunner.Chat;
 using GuideAntsApi.DataModel;
 using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Services.Conversations;
@@ -19,6 +20,7 @@ public class ConversationManagerTests
     private IMemoryCache _cache = null!;
     private Mock<ILogger<ConversationManager>> _loggerMock = null!;
     private ConversationManager _manager = null!;
+    private string? _originalConnectionString;
 
     private Guid _conversationId;
     private Guid _notebookId;
@@ -27,6 +29,11 @@ public class ConversationManagerTests
     [TestInitialize]
     public void Setup()
     {
+        const string connectionStringKey = "ConnectionStrings:DefaultConnection";
+        _originalConnectionString = Environment.GetEnvironmentVariable(connectionStringKey);
+        Environment.SetEnvironmentVariable(connectionStringKey, null);
+        AssistantUtility.ClearAllCache();
+
         // Generate unique IDs for each test
         _conversationId = Guid.NewGuid();
         _notebookId = Guid.NewGuid();
@@ -65,6 +72,8 @@ public class ConversationManagerTests
     [TestCleanup]
     public void Cleanup()
     {
+        Environment.SetEnvironmentVariable("ConnectionStrings:DefaultConnection", _originalConnectionString);
+        AssistantUtility.ClearAllCache();
         _context.Database.EnsureDeleted();
         _context.Dispose();
         _cache.Dispose();

--- a/src/server/GuideAntsApi.Tests/Services/NotebookHeaderToolbarServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/NotebookHeaderToolbarServiceTests.cs
@@ -45,6 +45,7 @@ public sealed class NotebookHeaderToolbarServiceTests
         await db.SaveChangesAsync();
 
         var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        SetupToolbarServiceModesDefaults(settings);
         settings
             .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(
@@ -176,6 +177,7 @@ public sealed class NotebookHeaderToolbarServiceTests
         await db.SaveChangesAsync();
 
         var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        SetupToolbarServiceModesDefaults(settings);
         settings
             .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(
@@ -284,6 +286,7 @@ public sealed class NotebookHeaderToolbarServiceTests
         await db.SaveChangesAsync();
 
         var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        SetupToolbarServiceModesDefaults(settings);
         settings
             .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(
@@ -425,6 +428,7 @@ public sealed class NotebookHeaderToolbarServiceTests
         await db.SaveChangesAsync();
 
         var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        SetupToolbarServiceModesDefaults(settings);
         settings
             .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(
@@ -531,6 +535,7 @@ public sealed class NotebookHeaderToolbarServiceTests
         var notebook = await SeedNotebookAsync(db);
 
         var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        SetupToolbarServiceModesDefaults(settings);
         settings
             .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SettingsModelDto>());
@@ -583,6 +588,7 @@ public sealed class NotebookHeaderToolbarServiceTests
         var notebook = await SeedNotebookAsync(db);
 
         var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        SetupToolbarServiceModesDefaults(settings);
         settings
             .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SettingsModelDto>());
@@ -634,6 +640,7 @@ public sealed class NotebookHeaderToolbarServiceTests
         var notebook = await SeedNotebookAsync(db);
 
         var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        SetupToolbarServiceModesDefaults(settings);
         settings
             .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SettingsModelDto>());
@@ -682,6 +689,88 @@ public sealed class NotebookHeaderToolbarServiceTests
             option.ModelRef == "chatterbox" && option.IsComplete);
         tts.LocalModelOptions.Should().Contain(option =>
             option.ModelRef == "OmniVoice" && !option.IsComplete);
+    }
+
+    [TestMethod]
+    public async Task GetToolbarAsync_MarksActiveImageBundle_FromPersistedServiceModes()
+    {
+        await using var db = CreateDb();
+        var notebook = await SeedNotebookAsync(db);
+        const string bundleId = "FLUX.2-dev-GGUF-Q5_K_M";
+
+        var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        SetupToolbarServiceModesDefaults(settings);
+        settings
+            .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SettingsModelDto>());
+        settings
+            .Setup(x => x.GetServiceEditorStateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string serviceId, CancellationToken _) =>
+                string.Equals(serviceId, RoutedServiceNames.ImageGeneration, StringComparison.Ordinal)
+                    ? CreateLocalServiceState(
+                        RoutedServiceNames.ImageGeneration,
+                        ServiceProviderIds.ImageGenerationLocalSdHttp,
+                        "LocalServiceHosts:ImageGenerationBaseUrl")
+                    : CreateReadyServiceState(serviceId));
+        settings
+            .Setup(x => x.GetServiceModesAsync(RoutedServiceNames.ImageGeneration, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new ServiceModeDto(
+                    RoutedServiceNames.ImageGeneration,
+                    "local",
+                    "LocalServiceHosts:ImageGenerationBaseUrl",
+                    bundleId,
+                    null,
+                    Enabled: true,
+                    IsDefault: true),
+            ]);
+
+        var sut = CreateSut(
+            db,
+            notebook.Id,
+            settings.Object,
+            httpClientFactory: CreateHttpClientFactory(request =>
+            {
+                if (request.RequestUri?.AbsolutePath.Contains("/health", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                        """{"status":"ok","engine":{"processAlive":true,"healthy":true}}""");
+                }
+
+                if (request.RequestUri?.AbsolutePath.Contains("/admin/bundles", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                        $$"""
+                        {
+                          "items": [
+                            {"bundleId":"{{bundleId}}","complete":true,"loaded":true},
+                            {"bundleId":"flux2-klein-4b-q4ks","complete":true,"loaded":false}
+                          ]
+                        }
+                        """);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }));
+
+        var toolbar = await sut.GetToolbarAsync(notebook.Id, conversationId: null);
+        var image = toolbar.Services.Single(service => service.Kind == "image");
+
+        image.LocalModelOptions.Should().Contain(option =>
+            option.ModelRef == bundleId && option.IsActive);
+        image.LocalModelOptions.Single(option => option.IsActive).DisplayLabel.Should().Be($"{bundleId} (active)");
+        image.Selection!.ResourceId.Should().Be(bundleId);
+        image.Summary.Should().Contain(bundleId);
+    }
+
+    private static void SetupToolbarServiceModesDefaults(Mock<IApplicationSettingsService> settings)
+    {
+        settings
+            .Setup(x => x.GetServiceModesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ServiceModeDto>());
     }
 
     private static async Task<Notebook> SeedNotebookAsync(ApplicationDbContext db)

--- a/src/server/GuideAntsApi.Tests/Skills/McpPublishedSkillResourceHandlersTests.cs
+++ b/src/server/GuideAntsApi.Tests/Skills/McpPublishedSkillResourceHandlersTests.cs
@@ -167,7 +167,7 @@ Skill body content
     {
         AssistantUtility.ClearCache(guideName);
         var cacheType = typeof(AssistantUtility).GetNestedType("CachedAssistant", BindingFlags.NonPublic)!;
-        var entry = Activator.CreateInstance(cacheType, definition, null, DateTime.UtcNow)!;
+        var entry = Activator.CreateInstance(cacheType, definition)!;
         var cache = typeof(AssistantUtility)
             .GetField("AssistantDefinitionCache", BindingFlags.Static | BindingFlags.NonPublic)!
             .GetValue(null)!;

--- a/src/server/GuideAntsApi.Tests/ToolCalling/DatabaseStorageDeepTests.cs
+++ b/src/server/GuideAntsApi.Tests/ToolCalling/DatabaseStorageDeepTests.cs
@@ -235,7 +235,7 @@ public sealed class DatabaseStorageDeepTests
     }
 
     [TestMethod]
-    public async Task GetAssistantMetadata_NoConnectionString_ReturnsNull()
+    public async Task GetAssistant_NoConnectionString_ReturnsNull()
     {
         const string key = "ConnectionStrings:DefaultConnection";
         var original = Environment.GetEnvironmentVariable(key);
@@ -243,8 +243,9 @@ public sealed class DatabaseStorageDeepTests
         {
             Environment.SetEnvironmentVariable(key, null);
 
-            (await DatabaseStorage.GetAssistantMetadata("anything")).Should().BeNull();
             (await DatabaseStorage.GetAssistant("anything")).Should().BeNull();
+
+            (await DatabaseStorage.GetAssistantMetadata("anything")).Should().BeNull();
             (await DatabaseStorage.GetAssistantAvatarAsync("anything")).Should().BeNull();
             (await DatabaseStorage.GetAssistantConversationStartersAsync("anything")).Should().BeNull();
         }

--- a/src/server/GuideAntsApi/Services/Bootstrap/ConfiguredLocalServiceSelectionSync.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/ConfiguredLocalServiceSelectionSync.cs
@@ -63,7 +63,7 @@ internal static class ConfiguredLocalServiceSelectionSync
         string? configuredBundleIdFromSd,
         CancellationToken cancellationToken)
     {
-        var persisted = await ReadPersistedLocalModelRefAsync(
+        var persisted = await TryReadPersistedLocalModelRefAsync(
                 settings,
                 RoutedServiceNames.ImageGeneration,
                 cancellationToken)
@@ -91,7 +91,7 @@ internal static class ConfiguredLocalServiceSelectionSync
         IHttpClientFactory httpClientFactory,
         CancellationToken cancellationToken)
     {
-        if (!string.IsNullOrWhiteSpace(await ReadPersistedLocalModelRefAsync(
+        if (!string.IsNullOrWhiteSpace(await TryReadPersistedLocalModelRefAsync(
                     settings,
                     RoutedServiceNames.ImageGeneration,
                     cancellationToken)
@@ -137,7 +137,7 @@ internal static class ConfiguredLocalServiceSelectionSync
         IHttpClientFactory httpClientFactory,
         CancellationToken cancellationToken)
     {
-        if (!string.IsNullOrWhiteSpace(await ReadPersistedLocalModelRefAsync(settings, serviceId, cancellationToken)
+        if (!string.IsNullOrWhiteSpace(await TryReadPersistedLocalModelRefAsync(settings, serviceId, cancellationToken)
                 .ConfigureAwait(false)))
         {
             return;
@@ -216,7 +216,7 @@ internal static class ConfiguredLocalServiceSelectionSync
         return null;
     }
 
-    private static async Task<string?> ReadPersistedLocalModelRefAsync(
+    public static async Task<string?> TryReadPersistedLocalModelRefAsync(
         IApplicationSettingsService settings,
         string serviceId,
         CancellationToken cancellationToken)

--- a/src/server/GuideAntsApi/Services/Guides/AssistantDefinitionCacheInvalidator.cs
+++ b/src/server/GuideAntsApi/Services/Guides/AssistantDefinitionCacheInvalidator.cs
@@ -1,0 +1,12 @@
+using AntRunner.Chat;
+
+namespace GuideAntsApi.Services.Guides;
+
+internal static class AssistantDefinitionCacheInvalidator
+{
+    public static void Invalidate(string assistantName)
+    {
+        AssistantUtility.ClearCache(assistantName);
+        ThreadRun.ClearRequestBuilderCache(assistantName);
+    }
+}

--- a/src/server/GuideAntsApi/Services/Guides/GuideExportImportService.cs
+++ b/src/server/GuideAntsApi/Services/Guides/GuideExportImportService.cs
@@ -1111,6 +1111,12 @@ public class GuideExportImportService : IGuideExportImportService
             await _assistantSkillMetaSync.SyncAssistantAsync(assistantId);
         }
 
+        AssistantDefinitionCacheInvalidator.Invalidate(guideName);
+        foreach (var assistantName in customAssistantIds.Keys)
+        {
+            AssistantDefinitionCacheInvalidator.Invalidate(assistantName);
+        }
+
         return new ImportGuideResultDto(
             true,
             guideId,
@@ -1201,6 +1207,8 @@ public class GuideExportImportService : IGuideExportImportService
         // Create markdown shadows and enqueue indexing jobs for imported files
         await CreateMarkdownShadowsForAssistantAsync(assistantId);
         await _assistantSkillMetaSync.SyncAssistantAsync(assistantId);
+
+        AssistantDefinitionCacheInvalidator.Invalidate(name);
 
         return new ImportGuideResultDto(
             true,

--- a/src/server/GuideAntsApi/Services/Guides/GuidesService.cs
+++ b/src/server/GuideAntsApi/Services/Guides/GuidesService.cs
@@ -636,6 +636,8 @@ public class GuidesService(
         await _context.SaveChangesAsync();
         await StageMcpSandboxSetupIfNeededAsync(dto.ProjectId, guide.Id, dto.CustomTools);
 
+        AssistantDefinitionCacheInvalidator.Invalidate(guide.Name);
+
         return new GuideDto(
             guide.Id,
             guide.Name,
@@ -665,8 +667,7 @@ public class GuidesService(
         await _context.SaveChangesAsync();
 
         // Invalidate caches to ensure deleted guide is no longer accessible
-        AssistantUtility.ClearCache(guideName);
-        ThreadRun.ClearRequestBuilderCache(guideName);
+        AssistantDefinitionCacheInvalidator.Invalidate(guideName);
 
         return true;
     }
@@ -1057,8 +1058,7 @@ public class GuidesService(
         await _context.SaveChangesAsync();
 
         // Invalidate caches to ensure deleted assistant is no longer accessible
-        AssistantUtility.ClearCache(assistantName);
-        ThreadRun.ClearRequestBuilderCache(assistantName);
+        AssistantDefinitionCacheInvalidator.Invalidate(assistantName);
 
         return true;
     }
@@ -2232,8 +2232,7 @@ public class GuidesService(
         await _context.SaveChangesAsync();
 
         // Invalidate caches to ensure updated assistant definition and OpenAPI schemas are reloaded
-        AssistantUtility.ClearCache(assistant.Name);
-        ThreadRun.ClearRequestBuilderCache(assistant.Name);
+        AssistantDefinitionCacheInvalidator.Invalidate(assistant.Name);
 
         return assistant;
     }

--- a/src/server/GuideAntsApi/Services/NotebookHeaderToolbar/NotebookHeaderToolbarService.cs
+++ b/src/server/GuideAntsApi/Services/NotebookHeaderToolbar/NotebookHeaderToolbarService.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Nodes;
 using Microsoft.EntityFrameworkCore;
 using GuideAntsApi.DataModel;
 using GuideAntsApi.Endpoints;
+using GuideAntsApi.Endpoints.Settings;
 using GuideAntsApi.Models;
 using GuideAntsApi.Models.Settings;
 using GuideAntsApi.Options;
@@ -59,6 +60,10 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
         public bool IsOperational =>
             Loaded && !Loading && !PostLoadWarming && !StartupWarmupRunning;
     }
+
+    private sealed record LocalModelInventoryLoadResult(
+        IReadOnlyList<NotebookToolbarLocalModelOptionDto> Models,
+        JsonNode? Root);
 
     public async Task<NotebookHeaderToolbarDto> GetToolbarAsync(
         Guid notebookId,
@@ -502,19 +507,37 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
             status = "degraded";
         }
 
-        var localModels = await TryLoadLocalModelInventoryAsync(
+        var inventory = await TryLoadLocalModelInventoryAsync(
             serviceId,
             localListPath,
             isImage,
             cancellationToken).ConfigureAwait(false);
+        var localModels = inventory.Models;
 
-        var selectedLocalRef = ResolveSelectedLocalModelRef(state, localProviderId);
+        string? selectedLocalRef;
         if (isImage)
         {
+            selectedLocalRef = await ConfiguredLocalServiceSelectionSync.ResolveOrSyncImageBundleAsync(
+                    _settings,
+                    inventory.Root is null
+                        ? null
+                        : ServiceLocalModelListEnricher.ReadConfiguredActiveBundleId(inventory.Root.ToJsonString()),
+                    cancellationToken)
+                .ConfigureAwait(false);
             localModels = MarkImageBundleSelection(localModels, selectedLocalRef);
         }
         else
         {
+            selectedLocalRef = await ConfiguredLocalServiceSelectionSync.TryReadPersistedLocalModelRefAsync(
+                    _settings,
+                    serviceId,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(selectedLocalRef))
+            {
+                selectedLocalRef = ResolveSelectedLocalModelRef(state, localProviderId);
+            }
+
             localModels = MarkVoiceModelSelection(localModels, selectedLocalRef);
         }
 
@@ -778,7 +801,7 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
         }
     }
 
-    private async Task<IReadOnlyList<NotebookToolbarLocalModelOptionDto>> TryLoadLocalModelInventoryAsync(
+    private async Task<LocalModelInventoryLoadResult> TryLoadLocalModelInventoryAsync(
         string serviceId,
         string listPath,
         bool isImage,
@@ -787,7 +810,9 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
         var json = await HttpGetLocalAdminJsonAsync(serviceId, listPath, cancellationToken).ConfigureAwait(false);
         if (string.IsNullOrWhiteSpace(json))
         {
-            return Array.Empty<NotebookToolbarLocalModelOptionDto>();
+            return new LocalModelInventoryLoadResult(
+                Array.Empty<NotebookToolbarLocalModelOptionDto>(),
+                null);
         }
 
         try
@@ -795,15 +820,17 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
             var node = JsonNode.Parse(json);
             if (isImage)
             {
-                return ParseImageBundles(node);
+                return new LocalModelInventoryLoadResult(ParseImageBundles(node), node);
             }
 
-            return ParseVoiceModels(node);
+            return new LocalModelInventoryLoadResult(ParseVoiceModels(node), node);
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Local inventory parse for {ServiceId}", serviceId);
-            return Array.Empty<NotebookToolbarLocalModelOptionDto>();
+            return new LocalModelInventoryLoadResult(
+                Array.Empty<NotebookToolbarLocalModelOptionDto>(),
+                null);
         }
     }
 

--- a/src/server/GuideAntsApi/Services/Scheduling/ProjectScheduledJobService.cs
+++ b/src/server/GuideAntsApi/Services/Scheduling/ProjectScheduledJobService.cs
@@ -251,9 +251,10 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
         pageSize = Math.Clamp(pageSize, 1, 100);
 
         await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        await EnsureJobBelongsToProjectAsync(db, projectId, jobId, cancellationToken);
 
         var query = db.ProjectScheduledJobRuns.AsNoTracking()
-            .Where(r => r.ScheduledJobId == jobId && r.ScheduledJob.ProjectId == projectId);
+            .Where(r => r.ScheduledJobId == jobId);
 
         var total = await query.CountAsync(cancellationToken);
         var items = await query
@@ -281,10 +282,11 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
         CancellationToken cancellationToken = default)
     {
         await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        await EnsureJobBelongsToProjectAsync(db, projectId, jobId, cancellationToken);
 
         var run = await db.ProjectScheduledJobRuns.AsNoTracking()
             .FirstOrDefaultAsync(
-                r => r.Id == runId && r.ScheduledJobId == jobId && r.ScheduledJob.ProjectId == projectId,
+                r => r.Id == runId && r.ScheduledJobId == jobId,
                 cancellationToken);
 
         return run == null
@@ -300,6 +302,19 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
                 run.StandardError,
                 run.CreatedConversationId,
                 run.ExitCode);
+    }
+
+    private static async Task EnsureJobBelongsToProjectAsync(
+        ApplicationDbContext db,
+        Guid projectId,
+        Guid jobId,
+        CancellationToken cancellationToken)
+    {
+        if (!await db.ProjectScheduledJobs.AsNoTracking()
+                .AnyAsync(j => j.Id == jobId && j.ProjectId == projectId, cancellationToken))
+        {
+            throw new KeyNotFoundException($"Scheduled job {jobId} was not found.");
+        }
     }
 
     private static async Task<ScheduledJobDetailRow?> LoadJobDetailRowAsync(

--- a/src/server/GuideAntsApi/Services/Scheduling/ProjectScheduledJobService.cs
+++ b/src/server/GuideAntsApi/Services/Scheduling/ProjectScheduledJobService.cs
@@ -67,13 +67,26 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
         CancellationToken cancellationToken = default)
     {
         await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
-        var jobs = await db.ProjectScheduledJobs.AsNoTracking()
-            .Include(j => j.Notebook)
+        var rows = await db.ProjectScheduledJobs.AsNoTracking()
             .Where(j => j.ProjectId == projectId)
             .OrderBy(j => j.Name)
+            .Select(j => new ScheduledJobSummaryRow(
+                j.Id,
+                j.Name,
+                j.JobType,
+                j.NotebookId,
+                j.Notebook.Title,
+                j.IsEnabled,
+                j.CronExpression,
+                j.TimeZoneId,
+                j.NextRunUtc,
+                j.LastRunUtc,
+                j.LastRunStatus,
+                j.CreatedUtc,
+                j.UpdatedUtc))
             .ToListAsync(cancellationToken);
 
-        return jobs.Select(MapSummary).ToList();
+        return rows.Select(MapSummary).ToList();
     }
 
     public async Task<ProjectScheduledJobDetailDto?> GetAsync(
@@ -82,8 +95,8 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
         CancellationToken cancellationToken = default)
     {
         await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
-        var job = await LoadJobDetailQuery(db, projectId, jobId, cancellationToken);
-        return job == null ? null : MapDetail(job);
+        var row = await LoadJobDetailRowAsync(db, projectId, jobId, cancellationToken);
+        return row == null ? null : MapDetail(row);
     }
 
     public async Task<ProjectScheduledJobDetailDto> CreateAsync(
@@ -133,7 +146,7 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
         db.ProjectScheduledJobs.Add(job);
         await db.SaveChangesAsync(cancellationToken);
 
-        var loaded = await LoadJobDetailQuery(db, projectId, job.Id, cancellationToken)
+        var loaded = await LoadJobDetailRowAsync(db, projectId, job.Id, cancellationToken)
             ?? throw new InvalidOperationException("Failed to load created scheduled job.");
         return MapDetail(loaded);
     }
@@ -179,7 +192,7 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
 
         await db.SaveChangesAsync(cancellationToken);
 
-        var loaded = await LoadJobDetailQuery(db, projectId, job.Id, cancellationToken)
+        var loaded = await LoadJobDetailRowAsync(db, projectId, job.Id, cancellationToken)
             ?? throw new InvalidOperationException("Failed to load updated scheduled job.");
         return MapDetail(loaded);
     }
@@ -198,16 +211,20 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
     public async Task EnqueueManualRunAsync(Guid projectId, Guid jobId, CancellationToken cancellationToken = default)
     {
         await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
-        var exists = await db.ProjectScheduledJobs.AsNoTracking()
-            .AnyAsync(j => j.Id == jobId && j.ProjectId == projectId, cancellationToken);
-        if (!exists)
+        var state = await db.ProjectScheduledJobs.AsNoTracking()
+            .Where(j => j.Id == jobId && j.ProjectId == projectId)
+            .Select(j => new
+            {
+                HasRunningRun = j.Runs.Any(r => r.Status == ProjectScheduledJobRunStatus.Running)
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (state == null)
         {
             throw new KeyNotFoundException($"Scheduled job {jobId} was not found.");
         }
 
-        var hasRunningRun = await db.ProjectScheduledJobRuns
-            .AnyAsync(r => r.ScheduledJobId == jobId && r.Status == ProjectScheduledJobRunStatus.Running, cancellationToken);
-        if (hasRunningRun)
+        if (state.HasRunningRun)
         {
             throw new InvalidOperationException("A run is already in progress for this scheduled job.");
         }
@@ -234,10 +251,9 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
         pageSize = Math.Clamp(pageSize, 1, 100);
 
         await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
-        await EnsureJobBelongsToProjectAsync(db, projectId, jobId, cancellationToken);
 
         var query = db.ProjectScheduledJobRuns.AsNoTracking()
-            .Where(r => r.ScheduledJobId == jobId);
+            .Where(r => r.ScheduledJobId == jobId && r.ScheduledJob.ProjectId == projectId);
 
         var total = await query.CountAsync(cancellationToken);
         var items = await query
@@ -247,8 +263,8 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
             .Select(r => new ProjectScheduledJobRunSummaryDto(
                 r.Id,
                 r.TriggeredBy.ToString(),
-                r.StartedUtc,
-                r.CompletedUtc,
+                AsUtc(r.StartedUtc),
+                AsUtc(r.CompletedUtc),
                 r.Status.ToString(),
                 r.ErrorMessage,
                 r.CreatedConversationId,
@@ -265,18 +281,19 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
         CancellationToken cancellationToken = default)
     {
         await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
-        await EnsureJobBelongsToProjectAsync(db, projectId, jobId, cancellationToken);
 
         var run = await db.ProjectScheduledJobRuns.AsNoTracking()
-            .FirstOrDefaultAsync(r => r.Id == runId && r.ScheduledJobId == jobId, cancellationToken);
+            .FirstOrDefaultAsync(
+                r => r.Id == runId && r.ScheduledJobId == jobId && r.ScheduledJob.ProjectId == projectId,
+                cancellationToken);
 
         return run == null
             ? null
             : new ProjectScheduledJobRunDetailDto(
                 run.Id,
                 run.TriggeredBy.ToString(),
-                run.StartedUtc,
-                run.CompletedUtc,
+                AsUtc(run.StartedUtc),
+                AsUtc(run.CompletedUtc),
                 run.Status.ToString(),
                 run.ErrorMessage,
                 run.StandardOutput,
@@ -285,68 +302,141 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
                 run.ExitCode);
     }
 
-    private static async Task<ProjectScheduledJob?> LoadJobDetailQuery(
+    private static async Task<ScheduledJobDetailRow?> LoadJobDetailRowAsync(
         ApplicationDbContext db,
         Guid projectId,
         Guid jobId,
         CancellationToken cancellationToken) =>
         await db.ProjectScheduledJobs.AsNoTracking()
-            .Include(j => j.Notebook)
-            .Include(j => j.ScriptNotebookFile)
-            .FirstOrDefaultAsync(j => j.Id == jobId && j.ProjectId == projectId, cancellationToken);
+            .Where(j => j.Id == jobId && j.ProjectId == projectId)
+            .Select(j => new ScheduledJobDetailRow(
+                j.Id,
+                j.Name,
+                j.JobType,
+                j.NotebookId,
+                j.Notebook.Title,
+                j.IsEnabled,
+                j.CronExpression,
+                j.TimeZoneId,
+                j.ConversationTitle,
+                j.Prompt,
+                j.AssistantName,
+                j.ScriptNotebookFileId,
+                j.ScriptNotebookFile != null ? j.ScriptNotebookFile.RelativePath : null,
+                j.ExposeSandboxWireApi,
+                j.WireTargetAssistantId,
+                j.WireAttributionConversationTitle,
+                j.WireCreateAttributionConversationPerRun,
+                j.WireDailyLimitUsd,
+                j.WireMonthlyLimitUsd,
+                j.NextRunUtc,
+                j.LastRunUtc,
+                j.LastRunStatus,
+                j.CreatedByUserId,
+                j.CreatedUtc,
+                j.UpdatedUtc))
+            .FirstOrDefaultAsync(cancellationToken);
 
-    private ProjectScheduledJobSummaryDto MapSummary(ProjectScheduledJob job)
+    private static DateTime AsUtc(DateTime value) =>
+        value.Kind == DateTimeKind.Utc ? value : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+
+    private static DateTime? AsUtc(DateTime? value) =>
+        value.HasValue ? AsUtc(value.Value) : null;
+
+    private sealed record ScheduledJobSummaryRow(
+        Guid Id,
+        string Name,
+        ProjectScheduledJobType JobType,
+        Guid NotebookId,
+        string NotebookTitle,
+        bool IsEnabled,
+        string CronExpression,
+        string TimeZoneId,
+        DateTime? NextRunUtc,
+        DateTime? LastRunUtc,
+        ProjectScheduledJobLastRunStatus? LastRunStatus,
+        DateTime CreatedUtc,
+        DateTime UpdatedUtc);
+
+    private sealed record ScheduledJobDetailRow(
+        Guid Id,
+        string Name,
+        ProjectScheduledJobType JobType,
+        Guid NotebookId,
+        string NotebookTitle,
+        bool IsEnabled,
+        string CronExpression,
+        string TimeZoneId,
+        string? ConversationTitle,
+        string? Prompt,
+        string? AssistantName,
+        Guid? ScriptNotebookFileId,
+        string? ScriptRelativePath,
+        bool ExposeSandboxWireApi,
+        Guid? WireTargetAssistantId,
+        string? WireAttributionConversationTitle,
+        bool WireCreateAttributionConversationPerRun,
+        decimal? WireDailyLimitUsd,
+        decimal? WireMonthlyLimitUsd,
+        DateTime? NextRunUtc,
+        DateTime? LastRunUtc,
+        ProjectScheduledJobLastRunStatus? LastRunStatus,
+        Guid CreatedByUserId,
+        DateTime CreatedUtc,
+        DateTime UpdatedUtc);
+
+    private ProjectScheduledJobSummaryDto MapSummary(ScheduledJobSummaryRow row)
     {
-        var friendly = _scheduleBuilder.ParseToFriendly(job.CronExpression);
+        var friendly = _scheduleBuilder.ParseToFriendly(row.CronExpression);
         return new ProjectScheduledJobSummaryDto(
-            job.Id,
-            job.Name,
-            job.JobType.ToString(),
-            job.NotebookId,
-            job.Notebook.Title,
-            job.IsEnabled,
-            job.CronExpression,
-            job.TimeZoneId,
-            _cronScheduleService.GetHumanReadableSummary(job.CronExpression, job.TimeZoneId, friendly),
+            row.Id,
+            row.Name,
+            row.JobType.ToString(),
+            row.NotebookId,
+            row.NotebookTitle,
+            row.IsEnabled,
+            row.CronExpression,
+            row.TimeZoneId,
+            _cronScheduleService.GetHumanReadableSummary(row.CronExpression, row.TimeZoneId, friendly),
             friendly,
-            job.NextRunUtc,
-            job.LastRunUtc,
-            job.LastRunStatus?.ToString(),
-            job.CreatedUtc,
-            job.UpdatedUtc);
+            AsUtc(row.NextRunUtc),
+            AsUtc(row.LastRunUtc),
+            row.LastRunStatus?.ToString(),
+            AsUtc(row.CreatedUtc),
+            AsUtc(row.UpdatedUtc));
     }
 
-    private ProjectScheduledJobDetailDto MapDetail(ProjectScheduledJob job)
+    private ProjectScheduledJobDetailDto MapDetail(ScheduledJobDetailRow row)
     {
-        var friendly = _scheduleBuilder.ParseToFriendly(job.CronExpression);
+        var friendly = _scheduleBuilder.ParseToFriendly(row.CronExpression);
         return new ProjectScheduledJobDetailDto(
-            job.Id,
-            job.Name,
-            job.JobType.ToString(),
-            job.NotebookId,
-            job.Notebook.Title,
-            job.IsEnabled,
-            job.CronExpression,
-            job.TimeZoneId,
-            _cronScheduleService.GetHumanReadableSummary(job.CronExpression, job.TimeZoneId, friendly),
+            row.Id,
+            row.Name,
+            row.JobType.ToString(),
+            row.NotebookId,
+            row.NotebookTitle,
+            row.IsEnabled,
+            row.CronExpression,
+            row.TimeZoneId,
+            _cronScheduleService.GetHumanReadableSummary(row.CronExpression, row.TimeZoneId, friendly),
             friendly,
-            job.ConversationTitle,
-            job.Prompt,
-            job.AssistantName,
-            job.ScriptNotebookFileId,
-            job.ScriptNotebookFile?.RelativePath,
-            job.ExposeSandboxWireApi,
-            job.WireTargetAssistantId,
-            job.WireAttributionConversationTitle,
-            job.WireCreateAttributionConversationPerRun,
-            job.WireDailyLimitUsd,
-            job.WireMonthlyLimitUsd,
-            job.NextRunUtc,
-            job.LastRunUtc,
-            job.LastRunStatus?.ToString(),
-            job.CreatedByUserId,
-            job.CreatedUtc,
-            job.UpdatedUtc);
+            row.ConversationTitle,
+            row.Prompt,
+            row.AssistantName,
+            row.ScriptNotebookFileId,
+            row.ScriptRelativePath,
+            row.ExposeSandboxWireApi,
+            row.WireTargetAssistantId,
+            row.WireAttributionConversationTitle,
+            row.WireCreateAttributionConversationPerRun,
+            row.WireDailyLimitUsd,
+            row.WireMonthlyLimitUsd,
+            AsUtc(row.NextRunUtc),
+            AsUtc(row.LastRunUtc),
+            row.LastRunStatus?.ToString(),
+            row.CreatedByUserId,
+            AsUtc(row.CreatedUtc),
+            AsUtc(row.UpdatedUtc));
     }
 
     private string BuildAndValidateSchedule(FriendlyScheduleDto schedule, string timeZoneId)
@@ -387,14 +477,6 @@ public sealed class ProjectScheduledJobService : IProjectScheduledJobService
         if (!await db.Projects.AsNoTracking().AnyAsync(p => p.Id == projectId, ct))
         {
             throw new KeyNotFoundException($"Project {projectId} was not found.");
-        }
-    }
-
-    private static async Task EnsureJobBelongsToProjectAsync(ApplicationDbContext db, Guid projectId, Guid jobId, CancellationToken ct)
-    {
-        if (!await db.ProjectScheduledJobs.AsNoTracking().AnyAsync(j => j.Id == jobId && j.ProjectId == projectId, ct))
-        {
-            throw new KeyNotFoundException($"Scheduled job {jobId} was not found.");
         }
     }
 


### PR DESCRIPTION
…app feedback.

Add shared scheduled-job polling with faster run-history queries and a run-status index, invalidate assistant definitions explicitly on guide mutations, sync persisted local-model toolbar selection, and replace alert()/confirm() with toasts, dialogs, and inline errors. Set MSSQL_PID=Developer in Docker compose files.