### PR TITLE
Use the scheme of the  user agent request when fetching document server script, not 'http'

### DIFF
--- a/src/server/GuideAntsApi.Tests/Configuration/DocumentServerUrlResolverTests.cs
+++ b/src/server/GuideAntsApi.Tests/Configuration/DocumentServerUrlResolverTests.cs
@@ -8,26 +8,34 @@ namespace GuideAntsApi.Tests.Configuration;
 public sealed class DocumentServerUrlResolverTests
 {
     [TestMethod]
-    public void ResolvePublicUrl_UsesRequestOrigin_NotApiBaseUrl()
+    public void ResolvePublicUrl_UsesRequestHost_AndApiBaseUrlScheme_LocalDocker()
     {
+        var options = new DocumentServerOptions
+        {
+            ApiBaseUrl = "http://guideants-webapi-ui:8080"
+        };
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Scheme = "http";
         httpContext.Request.Host = new HostString("localhost:5107");
 
-        var publicUrl = DocumentServerUrlResolver.ResolvePublicUrl(httpContext);
+        var publicUrl = DocumentServerUrlResolver.ResolvePublicUrl(options, httpContext);
 
         publicUrl.Should().Be("http://localhost:5107/api/documentserver/ds");
     }
 
     [TestMethod]
-    public void ResolvePublicUrl_WhenXForwardedProtoHttps_UsesHttpsWithRequestHost()
+    public void ResolvePublicUrl_UsesRequestHost_AndApiBaseUrlHttpsScheme_Azure()
     {
+        var options = new DocumentServerOptions
+        {
+            ApiBaseUrl = "https://guideants-webapi-ui.example.azurecontainerapps.io"
+        };
         var httpContext = new DefaultHttpContext();
+        // ACA terminates TLS; the container still sees http.
         httpContext.Request.Scheme = "http";
         httpContext.Request.Host = new HostString("guideants-webapi-ui.example.azurecontainerapps.io");
-        httpContext.Request.Headers["X-Forwarded-Proto"] = "https";
 
-        var publicUrl = DocumentServerUrlResolver.ResolvePublicUrl(httpContext);
+        var publicUrl = DocumentServerUrlResolver.ResolvePublicUrl(options, httpContext);
 
         publicUrl.Should().Be("https://guideants-webapi-ui.example.azurecontainerapps.io/api/documentserver/ds");
     }

--- a/src/server/GuideAntsApi/Configuration/DocumentServerUrlResolver.cs
+++ b/src/server/GuideAntsApi/Configuration/DocumentServerUrlResolver.cs
@@ -22,14 +22,15 @@ public static class DocumentServerUrlResolver
     }
 
     /// <summary>
-    /// Browser-facing DocumentServer URL for the API proxy. Always the inbound request
-    /// origin + <see cref="ProxyPublicPrefix"/> so local Docker
-    /// (<c>localhost:5107</c>) and Azure public FQDNs both work. Do not use
-    /// <c>DocumentServer:ApiBaseUrl</c> here — that value is the DocumentServer→API
-    /// callback base (often an internal container hostname).
+    /// Browser-facing DocumentServer URL for the API proxy.
+    /// Host always comes from the inbound request (browser origin: localhost, ACA FQDN, etc.).
+    /// Scheme comes from <see cref="DocumentServerOptions.ApiBaseUrl"/> when configured —
+    /// that is the public API origin scheme (https on Azure, http in local Docker). Behind
+    /// TLS-terminating ingress <c>Request.Scheme</c> is http and is not used for the browser URL.
     /// </summary>
-    public static string ResolvePublicUrl(HttpContext httpContext)
+    public static string ResolvePublicUrl(DocumentServerOptions options, HttpContext httpContext)
     {
+        ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(httpContext);
 
         if (!httpContext.Request.Host.HasValue)
@@ -37,7 +38,7 @@ public static class DocumentServerUrlResolver
             return ProxyPublicPrefix;
         }
 
-        var scheme = ResolveRequestScheme(httpContext);
+        var scheme = ResolvePublicScheme(options, httpContext);
         if (string.IsNullOrWhiteSpace(scheme))
         {
             return ProxyPublicPrefix;
@@ -47,12 +48,23 @@ public static class DocumentServerUrlResolver
     }
 
     /// <summary>
-    /// Public scheme for browser/editor URLs. Prefer the first
-    /// <c>X-Forwarded-Proto</c> value when present (TLS-terminating ingress such as ACA).
+    /// Scheme for browser-facing DocumentServer URLs and upstream X-Forwarded-Proto.
+    /// Prefer <see cref="DocumentServerOptions.ApiBaseUrl"/> scheme, then
+    /// <c>X-Forwarded-Proto</c>, then <c>Request.Scheme</c>.
     /// </summary>
-    public static string ResolveRequestScheme(HttpContext httpContext)
+    public static string ResolvePublicScheme(DocumentServerOptions options, HttpContext httpContext)
     {
+        ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(httpContext);
+
+        var configured = options.ApiBaseUrl?.Trim();
+        if (!string.IsNullOrWhiteSpace(configured)
+            && Uri.TryCreate(configured, UriKind.Absolute, out var apiBaseUri)
+            && (apiBaseUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase)
+                || apiBaseUri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase)))
+        {
+            return apiBaseUri.Scheme.ToLowerInvariant();
+        }
 
         var forwarded = httpContext.Request.Headers["X-Forwarded-Proto"].FirstOrDefault();
         if (!string.IsNullOrWhiteSpace(forwarded))

--- a/src/server/GuideAntsApi/Endpoints/DocumentServerEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/DocumentServerEndpoints.cs
@@ -98,7 +98,7 @@ public static class DocumentServerEndpoints
         {
             var logger = loggerFactory.CreateLogger("DocumentServerEndpoints");
             var documentServerOptions = options.Value;
-            var publicUrl = DocumentServerUrlResolver.ResolvePublicUrl(httpContext);
+            var publicUrl = DocumentServerUrlResolver.ResolvePublicUrl(documentServerOptions, httpContext);
             var sanitizedPublicUrl = LogValueSanitizer.Sanitize(publicUrl);
             logger.LogInformation(
                 "DocumentServer capabilities requested. enabled={Enabled} publicUrl={PublicUrl}",
@@ -312,7 +312,7 @@ public static class DocumentServerEndpoints
                 documentServer.Enabled,
                 documentServer.ApiBaseUrl,
                 documentServer.InternalUrl,
-                LogValueSanitizer.Sanitize(DocumentServerUrlResolver.ResolvePublicUrl(httpContext)),
+                LogValueSanitizer.Sanitize(DocumentServerUrlResolver.ResolvePublicUrl(documentServer, httpContext)),
                 "aspnet-data-protection",
                 documentServer.JwtEnabled,
                 documentServerReachable,
@@ -326,7 +326,7 @@ public static class DocumentServerEndpoints
                 enabled = documentServer.Enabled,
                 apiBaseUrl = documentServer.ApiBaseUrl,
                 internalUrl = documentServer.InternalUrl,
-                publicUrl = DocumentServerUrlResolver.ResolvePublicUrl(httpContext),
+                publicUrl = DocumentServerUrlResolver.ResolvePublicUrl(documentServer, httpContext),
                 tokenProtection = "aspnet-data-protection",
                 jwtEnabled = documentServer.JwtEnabled,
                 documentServer = new
@@ -485,7 +485,10 @@ public static class DocumentServerEndpoints
                 proxyRequest.Headers.TryAddWithoutValidation("X-Forwarded-Host", httpContext.Request.Host.Value);
             }
 
-            var forwardedProto = DocumentServerUrlResolver.ResolveRequestScheme(httpContext);
+            var options = httpContext.RequestServices.GetService(typeof(IOptions<DocumentServerOptions>)) as IOptions<DocumentServerOptions>;
+            var forwardedProto = options != null
+                ? DocumentServerUrlResolver.ResolvePublicScheme(options.Value, httpContext)
+                : httpContext.Request.Scheme;
             if (string.IsNullOrWhiteSpace(forwardedProto))
             {
                 forwardedProto = httpContext.Request.Scheme;

--- a/src/server/GuideAntsApi/Services/Components/DocumentServerService.cs
+++ b/src/server/GuideAntsApi/Services/Components/DocumentServerService.cs
@@ -204,7 +204,7 @@ public sealed class DocumentServerService : IDocumentServerService
             config["token"] = token;
         }
 
-        var documentServerUrl = DocumentServerUrlResolver.ResolvePublicUrl(httpContext);
+        var documentServerUrl = DocumentServerUrlResolver.ResolvePublicUrl(options, httpContext);
         if (string.Equals(documentServerUrl, DocumentServerUrlResolver.ProxyPublicPrefix, StringComparison.Ordinal)
             || documentServerUrl.StartsWith('/'))
         {


### PR DESCRIPTION
Fixed for document server proxy on https