### PR TITLE
Keep cloud routing separate from local inventory

### DIFF
--- a/docs/native-ai-migration/STATE.md
+++ b/docs/native-ai-migration/STATE.md
@@ -4,7 +4,7 @@
 **Target:** [INVENTORY.md](./INVENTORY.md) — 2 ASR + 5 TTS (shipped) + 3 emb  
 **Next work:** operator runtime verification of the `pending-operator` rows below (needs container + GPU + HF token). All code-complete criteria for Tasks 5–8 pass.
 
-Last updated: 2026-07-03
+Last updated: 2026-08-03
 
 **Legend:** `pass` = verified with evidence. `pending-operator` = code is complete and unit/contract-tested, but the load+inference proof requires the operator's container/GPU/HF token and has not been run here. `fail` = known broken.
 
@@ -72,6 +72,7 @@ Last updated: 2026-07-03
 | I7 Voice-pack API | **pass** | `GET /admin/voice-pack` (tts_service.py) + `.../local-models/voice-pack` proxy + `api.settings.localModels.voicePackOutcome` |
 | I7 Voice-pack baked + attribution | pass | COPY in Dockerfile + `check-voice-pack-attribution.py` (54 voices, `kokoro_synthetic`/CC0-1.0) |
 | I7 NOTICE aligned | **pass** | NOTICE rewritten for Kokoro-82M synthetic provenance; `sourceDataset` corrected `common_voice`→`kokoro_synthetic` |
+| Cloud-active local inventory reporting | **pass (code)** | Saved local selections no longer overwrite cloud routing or runtime inventory. Tests: `ServiceLocalModelListEnricherTests.ProxyAndEnrichImageBundlesAsync_ExposesSavedSelectionWithoutRewritingRuntimeState`, `NotebookHeaderToolbarServiceTests.GetToolbarAsync_CloudProvidersDoNotPresentSavedLocalModelsAsActive`, `LocalAiStartupWarmupServiceTests.SyncDesiredAndApplyAsync_ProjectsImageBundlesWhenLocalModeIsConfiguredButCloudIsActive` |
 | I10 CI drift script | **pass** | `scripts/native-ai-migration/verify-catalog-contract.ps1` — ASR 2/2, TTS 5/5 shipped, Emb 3/3, no hardcoded lists |
 
 ---

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
@@ -79,7 +79,7 @@ public sealed class LocalAiStartupWarmupServiceTests
     }
 
     [TestMethod]
-    public async Task SyncDesiredAndApplyAsync_SkipsImageGenerationBundleProjectionWhenServiceIsNotWarmDesired()
+    public async Task SyncDesiredAndApplyAsync_ProjectsImageBundlesWhenLocalModeIsConfiguredButCloudIsActive()
     {
         string? capturedIni = null;
         var orchestration = new Mock<ILocalAiWarmupOrchestrationClient>(MockBehavior.Strict);
@@ -113,13 +113,33 @@ public sealed class LocalAiStartupWarmupServiceTests
             RequestPresetJson: null,
             Enabled: true,
             IsDefault: true);
+        var localImageGenerationMode = new ServiceMode(
+            ModeId: "local",
+            ProviderSection: "LocalServiceHosts:ImageGenerationBaseUrl",
+            ModelId: "saved-bundle",
+            RequestPresetJson: null,
+            Enabled: true,
+            IsDefault: false);
         var modeResolver = new FakeServiceModeResolver(
-            (RoutedServiceNames.ImageGeneration, cloudImageGenerationMode));
+            (RoutedServiceNames.ImageGeneration, cloudImageGenerationMode),
+            (RoutedServiceNames.ImageGeneration, localImageGenerationMode));
 
         var (settingsMock, _) = CreateSettingsMock(
             (RoutedServiceNames.ImageGeneration, cloudImageGenerationMode));
+        settingsMock
+            .Setup(s => s.GetServiceModesAsync(
+                RoutedServiceNames.ImageGeneration,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                ToServiceModeDto(RoutedServiceNames.ImageGeneration, cloudImageGenerationMode),
+                ToServiceModeDto(RoutedServiceNames.ImageGeneration, localImageGenerationMode),
+            ]);
 
         var bundleBootstrapper = new Mock<IImageGenerationBundleDefinitionBootstrapper>(MockBehavior.Strict);
+        bundleBootstrapper
+            .Setup(b => b.ProjectAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         var builder = new LocalAiDesiredStateBuilder(
             configuration,
@@ -144,12 +164,12 @@ public sealed class LocalAiStartupWarmupServiceTests
         capturedIni.Should().Contain("enabled = off");
         bundleBootstrapper.Verify(
             b => b.ProjectAsync(It.IsAny<CancellationToken>()),
-            Times.Never);
+            Times.Once);
         orchestration.VerifyAll();
     }
 
     [TestMethod]
-    public async Task SyncDesiredAndApplyAsync_ForceAuxiliaryIdle_SkipsImageGenerationBundleProjection()
+    public async Task SyncDesiredAndApplyAsync_ForceAuxiliaryIdle_ProjectsConfiguredImageBundlesWithoutLoadingThem()
     {
         string? capturedIni = null;
         var orchestration = new Mock<ILocalAiWarmupOrchestrationClient>(MockBehavior.Strict);
@@ -190,6 +210,9 @@ public sealed class LocalAiStartupWarmupServiceTests
             (RoutedServiceNames.ImageGeneration, imageGenerationMode));
 
         var bundleBootstrapper = new Mock<IImageGenerationBundleDefinitionBootstrapper>(MockBehavior.Strict);
+        bundleBootstrapper
+            .Setup(b => b.ProjectAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         var builder = new LocalAiDesiredStateBuilder(
             configuration,
@@ -214,7 +237,7 @@ public sealed class LocalAiStartupWarmupServiceTests
         capturedIni.Should().NotBeNullOrWhiteSpace();
         bundleBootstrapper.Verify(
             b => b.ProjectAsync(It.IsAny<CancellationToken>()),
-            Times.Never);
+            Times.Once);
         orchestration.VerifyAll();
     }
 

--- a/src/server/GuideAntsApi.Tests/Services/NotebookHeaderToolbarServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/NotebookHeaderToolbarServiceTests.cs
@@ -775,6 +775,73 @@ public sealed class NotebookHeaderToolbarServiceTests
     }
 
     [TestMethod]
+    public async Task GetToolbarAsync_CloudProvidersDoNotPresentSavedLocalModelsAsActive()
+    {
+        await using var db = CreateDb();
+        var notebook = await SeedNotebookAsync(db);
+
+        var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        SetupToolbarServiceModesDefaults(settings);
+        settings
+            .Setup(x => x.GetModelsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SettingsModelDto>());
+        settings
+            .Setup(x => x.GetServiceEditorStateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string serviceId, CancellationToken _) => serviceId switch
+            {
+                RoutedServiceNames.ImageGeneration => CreateCloudServiceStateWithLocalMode(
+                    serviceId,
+                    ServiceProviderIds.ImageGenerationLocalSdHttp,
+                    "LocalServiceHosts:ImageGenerationBaseUrl"),
+                RoutedServiceNames.SpeechSynthesis => CreateCloudServiceStateWithLocalMode(
+                    serviceId,
+                    ServiceProviderIds.SpeechSynthesisLocalTtsHttp,
+                    "LocalServiceHosts:SpeechSynthesisBaseUrl"),
+                RoutedServiceNames.SpeechTranscription => CreateCloudServiceStateWithLocalMode(
+                    serviceId,
+                    ServiceProviderIds.SpeechTranscriptionLocalAsrHttp,
+                    "LocalServiceHosts:SpeechTranscriptionBaseUrl"),
+                _ => CreateReadyServiceState(serviceId),
+            });
+
+        var sut = CreateSut(
+            db,
+            notebook.Id,
+            settings.Object,
+            httpClientFactory: CreateHttpClientFactory(request =>
+            {
+                if (request.RequestUri?.AbsolutePath.Contains("/admin/bundles", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                        """{"items":[{"bundleId":"saved-bundle","complete":true,"loaded":false}]}""");
+                }
+
+                if (request.RequestUri?.AbsolutePath.Contains("/admin/models", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                        """[{"modelRef":"saved-model","complete":true,"activeModel":false}]""");
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }));
+
+        var toolbar = await sut.GetToolbarAsync(notebook.Id, conversationId: null);
+
+        foreach (var service in toolbar.Services)
+        {
+            service.ActiveProviderId.Should().Be("google");
+            service.SupportsLocalRuntimePower.Should().BeFalse();
+            service.LocalRuntimeOn.Should().BeFalse();
+            service.Selection.Should().BeNull();
+            service.LocalModelOptions.Should().ContainSingle();
+            service.LocalModelOptions[0].IsActive.Should().BeFalse();
+            service.LocalModelOptions[0].DisplayLabel.Should().NotContain("(active)");
+        }
+    }
+
+    [TestMethod]
     public async Task GetToolbarAsync_CloudOnlyImage_DoesNotFailWhenSdReportsBundle()
     {
         await using var db = CreateDb();
@@ -820,8 +887,7 @@ public sealed class NotebookHeaderToolbarServiceTests
         var image = toolbar.Services.Single(service => service.Kind == "image");
 
         image.LocalModelOptions.Should().BeEmpty();
-        image.Selection.Should().NotBeNull();
-        image.Selection!.ResourceId.Should().BeNull();
+        image.Selection.Should().BeNull();
         settings.Verify(
             x => x.SetServiceModeModelIdAsync(
                 It.IsAny<string>(),
@@ -1025,6 +1091,32 @@ public sealed class NotebookHeaderToolbarServiceTests
                 Status: "ready",
                 Blockers: Array.Empty<string>(),
                 Warnings: Array.Empty<string>()));
+    }
+
+    private static ServiceEditorStateDto CreateCloudServiceStateWithLocalMode(
+        string serviceId,
+        string localProviderId,
+        string localProviderSection)
+    {
+        var cloud = CreateReadyServiceState(serviceId);
+        var local = new ProviderEditorStateDto(
+            ProviderId: localProviderId,
+            ProviderKind: "LocalHttp",
+            ProviderSection: localProviderSection,
+            ModeId: "local",
+            HasExplicitMode: true,
+            IsDefaultMode: false,
+            ConnectionConfigured: true,
+            ConnectionMissingFields: Array.Empty<string>(),
+            CanActivate: true,
+            ActivationBlockers: Array.Empty<string>(),
+            Fields: new Dictionary<string, ProviderFieldValueDto>(),
+            RuntimeDependencies: Array.Empty<RuntimeKeyDto>(),
+            OperativeFields: Array.Empty<string>(),
+            DiagnosticFields: Array.Empty<string>(),
+            FieldMetadata: Array.Empty<ProviderFieldMetadataDto>());
+
+        return cloud with { Providers = [.. cloud.Providers, local] };
     }
 
     private static ApplicationDbContext CreateDb()

--- a/src/server/GuideAntsApi.Tests/Settings/ServiceLocalModelListEnricherTests.cs
+++ b/src/server/GuideAntsApi.Tests/Settings/ServiceLocalModelListEnricherTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using GuideAntsApi.Endpoints.Settings;
+using GuideAntsApi.Models.Settings;
+using GuideAntsApi.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace GuideAntsApi.Tests.Settings;
+
+[TestClass]
+public sealed class ServiceLocalModelListEnricherTests
+{
+    [TestMethod]
+    public async Task ProxyAndEnrichImageBundlesAsync_ExposesSavedSelectionWithoutRewritingRuntimeState()
+    {
+        var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        settings
+            .Setup(service => service.GetServiceModesAsync("ImageGeneration", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new ServiceModeDto(
+                    "ImageGeneration",
+                    "local",
+                    "LocalServiceHosts:ImageGenerationBaseUrl",
+                    "saved-bundle",
+                    null,
+                    Enabled: true,
+                    IsDefault: false),
+            ]);
+
+        using var client = new HttpClient(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {
+                  "activeBundleMarkerId":"engine-marker",
+                  "loadedBundleId":null,
+                  "items":[
+                    {"bundleId":"saved-bundle","active":false},
+                    {"bundleId":"engine-marker","active":true}
+                  ]
+                }
+                """,
+                Encoding.UTF8,
+                "application/json"),
+        }));
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://upstream/sd/admin/bundles");
+
+        var result = await ServiceLocalModelListEnricher.ProxyAndEnrichImageBundlesAsync(
+            client,
+            request,
+            settings.Object,
+            CancellationToken.None);
+
+        var (_, body) = await ExecuteResultAsync(result);
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+
+        root.GetProperty("selectedBundleId").GetString().Should().Be("saved-bundle");
+        root.GetProperty("activeBundleMarkerId").GetString().Should().Be("engine-marker");
+        root.TryGetProperty("activeBundleId", out _).Should().BeFalse();
+        root.GetProperty("items")[0].GetProperty("active").GetBoolean().Should().BeFalse();
+        root.GetProperty("items")[1].GetProperty("active").GetBoolean().Should().BeTrue();
+        settings.Verify(
+            service => service.SetServiceModeModelIdAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static async Task<(int StatusCode, string Body)> ExecuteResultAsync(IResult result)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+        };
+        using var responseBody = new MemoryStream();
+        context.Response.Body = responseBody;
+
+        await result.ExecuteAsync(context);
+
+        responseBody.Position = 0;
+        using var reader = new StreamReader(responseBody);
+        return (context.Response.StatusCode, await reader.ReadToEndAsync());
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(responder(request));
+    }
+}

--- a/src/server/GuideAntsApi/Endpoints/Settings/ServiceLocalModelListEnricher.cs
+++ b/src/server/GuideAntsApi/Endpoints/Settings/ServiceLocalModelListEnricher.cs
@@ -10,8 +10,8 @@ using Microsoft.AspNetCore.Http;
 namespace GuideAntsApi.Endpoints.Settings;
 
 /// <summary>
-/// Injects ServiceModes selection into proxied local inventory responses so UI
-/// and operators never treat engine disk markers as the selected model/bundle.
+/// Exposes the saved ServiceModes bundle selection without changing the local
+/// engine's marker, loaded state, or per-item runtime status.
 /// </summary>
 internal static class ServiceLocalModelListEnricher
 {
@@ -56,9 +56,9 @@ internal static class ServiceLocalModelListEnricher
                     statusCode: StatusCodes.Status502BadGateway);
             }
 
-            var selectedBundleId = await ConfiguredLocalServiceSelectionSync.ResolveOrSyncImageBundleAsync(
+            var selectedBundleId = await ConfiguredLocalServiceSelectionSync.TryReadPersistedLocalModelRefAsync(
                     settings,
-                    ServiceLocalModelListEnricher.ReadConfiguredActiveBundleId(body),
+                    RoutedServiceNames.ImageGeneration,
                     cancellationToken)
                 .ConfigureAwait(false);
             var enriched = ApplyImageBundleSelection(body, selectedBundleId);
@@ -86,24 +86,6 @@ internal static class ServiceLocalModelListEnricher
     {
         var root = JsonNode.Parse(upstreamBody) as JsonObject ?? new JsonObject();
         root["selectedBundleId"] = selectedBundleId;
-        root["activeBundleId"] = selectedBundleId;
-
-        if (root["items"] is JsonArray items)
-        {
-            foreach (var itemNode in items)
-            {
-                if (itemNode is not JsonObject item)
-                {
-                    continue;
-                }
-
-                var bundleId = item["bundleId"]?.GetValue<string>();
-                var isSelected = !string.IsNullOrWhiteSpace(selectedBundleId)
-                    && !string.IsNullOrWhiteSpace(bundleId)
-                    && string.Equals(bundleId, selectedBundleId, StringComparison.Ordinal);
-                item["active"] = isSelected;
-            }
-        }
 
         return root.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
     }

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStartupWarmupService.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStartupWarmupService.cs
@@ -143,7 +143,7 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
 
         try
         {
-            await ProjectImageGenerationBundlesIfConfiguredAsync(options, cancellationToken).ConfigureAwait(false);
+            await ProjectImageGenerationBundlesIfConfiguredAsync(cancellationToken).ConfigureAwait(false);
 
             await EnsureConfiguredLocalSelectionsSyncedAsync(cancellationToken).ConfigureAwait(false);
 
@@ -661,7 +661,6 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
     }
 
     private async Task ProjectImageGenerationBundlesIfConfiguredAsync(
-        WarmupDesiredBuildOptions? options,
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(LocalServiceAdminRouting.ResolveAdminBase("ImageGeneration", _configuration)))
@@ -669,14 +668,16 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
             return;
         }
 
-        if (!await IsImageGenerationWarmDesiredAsync(options, cancellationToken).ConfigureAwait(false))
+        using var projectionScope = _scopeFactory.CreateScope();
+        var settings = projectionScope.ServiceProvider.GetService<IApplicationSettingsService>();
+        if (settings is null
+            || !await ConfiguredLocalServiceSelectionSync
+                .HasLocalServiceModeAsync(settings, RoutedServiceNames.ImageGeneration, cancellationToken)
+                .ConfigureAwait(false))
         {
-            _logger.LogDebug(
-                "Skipping ImageGeneration bundle projection: service is not warm-desired for this warmup sync.");
             return;
         }
 
-        using var projectionScope = _scopeFactory.CreateScope();
         var bootstrapper = projectionScope.ServiceProvider.GetService<IImageGenerationBundleDefinitionBootstrapper>();
         if (bootstrapper is null)
         {
@@ -685,27 +686,5 @@ public sealed class LocalAiStartupWarmupService : ILocalAiStartupWarmupService, 
         }
 
         await bootstrapper.ProjectAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<bool> IsImageGenerationWarmDesiredAsync(
-        WarmupDesiredBuildOptions? options,
-        CancellationToken cancellationToken)
-    {
-        if (options?.ForceAuxiliaryIdle == true)
-        {
-            return false;
-        }
-
-        if (options?.ServiceDesiredOverrides is not null
-            && options.ServiceDesiredOverrides.TryGetValue(
-                RoutedServiceNames.ImageGeneration,
-                out var desiredOverride))
-        {
-            var normalized = desiredOverride.Trim().ToLowerInvariant();
-            return normalized is "warm" or "on";
-        }
-
-        return await IsLocalRoutingWarmAsync(RoutedServiceNames.ImageGeneration, cancellationToken)
-            .ConfigureAwait(false);
     }
 }

--- a/src/server/GuideAntsApi/Services/NotebookHeaderToolbar/NotebookHeaderToolbarService.cs
+++ b/src/server/GuideAntsApi/Services/NotebookHeaderToolbar/NotebookHeaderToolbarService.cs
@@ -560,7 +560,7 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
         var hasLocalServiceMode = localProviderState?.HasExplicitMode ?? false;
 
         IReadOnlyList<NotebookToolbarLocalModelOptionDto> localModels;
-        string? selectedLocalRef;
+        string? selectedLocalRef = null;
         if (hasLocalServiceMode)
         {
             var inventory = await TryLoadLocalModelInventoryAsync(
@@ -570,18 +570,10 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
                 cancellationToken).ConfigureAwait(false);
             localModels = inventory.Models;
 
-            if (isImage)
-            {
-                selectedLocalRef = await ConfiguredLocalServiceSelectionSync.ResolveOrSyncImageBundleAsync(
-                        _settings,
-                        inventory.Root is null
-                            ? null
-                            : ServiceLocalModelListEnricher.ReadConfiguredActiveBundleId(inventory.Root.ToJsonString()),
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                localModels = MarkImageBundleSelection(localModels, selectedLocalRef);
-            }
-            else
+            // A saved local selection is operational only while routing is local.
+            // When a cloud provider is active, retain raw inventory state but do
+            // not present the dormant ServiceModes value as an active model.
+            if (supportsPower)
             {
                 selectedLocalRef = await ConfiguredLocalServiceSelectionSync.TryReadPersistedLocalModelRefAsync(
                         _settings,
@@ -593,16 +585,19 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
                     selectedLocalRef = ResolveSelectedLocalModelRef(state, localProviderId);
                 }
 
-                localModels = MarkVoiceModelSelection(localModels, selectedLocalRef);
+                localModels = isImage
+                    ? MarkImageBundleSelection(localModels, selectedLocalRef)
+                    : MarkVoiceModelSelection(localModels, selectedLocalRef);
             }
         }
         else
         {
             localModels = Array.Empty<NotebookToolbarLocalModelOptionDto>();
-            selectedLocalRef = null;
         }
 
-        var selection = BuildSelectionForService(state, isImage, localModels, selectedLocalRef);
+        var selection = supportsPower
+            ? BuildSelectionForService(isImage, localModels, selectedLocalRef)
+            : null;
         var runtimeProbe = supportsPower
             ? await ProbeLocalRuntimeAsync(serviceId, isImage, cancellationToken).ConfigureAwait(false)
             : new LocalRuntimeProbe(false, false, false, false);
@@ -729,7 +724,6 @@ public sealed class NotebookHeaderToolbarService : INotebookHeaderToolbarService
         string.Equals(readinessStatus, "ready", StringComparison.OrdinalIgnoreCase) ? "ready" : "blocked";
 
     private static NotebookToolbarSelectionDto? BuildSelectionForService(
-        ServiceEditorStateDto state,
         bool isImage,
         IReadOnlyList<NotebookToolbarLocalModelOptionDto> localModels,
         string? selectedLocalRef)


### PR DESCRIPTION
Prevent dormant local selections from being reported as active, make image inventory reads non-mutating, and project configured SD definitions without warming the engine.