### PR TITLE
Fix wire image_url handling and client chat/notebook polish.

### DIFF
--- a/src/client/src/components/chat-model/ChatModelConfigurator.tsx
+++ b/src/client/src/components/chat-model/ChatModelConfigurator.tsx
@@ -3,9 +3,9 @@ import { api } from '../../services/api';
 import { ModelDto } from '../../types/guides';
 import { ModelSelector } from '../guides/editor/ModelSelector';
 import { ConfigParams } from '../guides/editor/ConfigParams';
-import { normalizeReasoningEffortForModel, normalizeSamplingValueForModel } from './reasoning';
 import {
   ChatModelConfigValue,
+  buildChatModelConfigFromModelDefaults,
   normalizeChatModelConfigForModel,
 } from './chatDefaults';
 
@@ -100,21 +100,28 @@ export function ChatModelConfigurator({
       return;
     }
 
-    const normalizedReasoningEffort = normalizeReasoningEffortForModel(selectedModel, reasoningEffort);
-    const normalizedTemperature = normalizeSamplingValueForModel(selectedModel, 'temperature', temperature);
-    const normalizedTopP = normalizeSamplingValueForModel(selectedModel, 'top_p', topP);
+    const normalized = normalizeChatModelConfigForModel({
+      modelId: modelId ?? '',
+      temperature,
+      topP,
+      reasoningEffort,
+      samplingOverrides: overrides,
+    }, selectedModel);
+
+    const overridesChanged = Object.keys(normalized.samplingOverrides ?? {}).length !== Object.keys(overrides).length
+      || Object.entries(normalized.samplingOverrides ?? {}).some(
+        ([key, value]) => overrides[key] !== value
+      );
+
     if (
-      normalizedReasoningEffort !== reasoningEffort
-      || normalizedTemperature !== temperature
-      || normalizedTopP !== topP
+      normalized.reasoningEffort !== reasoningEffort
+      || normalized.temperature !== temperature
+      || normalized.topP !== topP
+      || overridesChanged
     ) {
-      pushChange({
-        temperature: normalizedTemperature,
-        topP: normalizedTopP,
-        reasoningEffort: normalizedReasoningEffort
-      });
+      onChange(normalized);
     }
-  }, [loading, selectedModel, temperature, topP, reasoningEffort]);
+  }, [loading, selectedModel, modelId, temperature, topP, reasoningEffort, overrides]);
 
   return (
     <div className="space-y-4">
@@ -126,10 +133,10 @@ export function ChatModelConfigurator({
         onChange={(id) => {
           const nextModelId = id ?? '';
           const nextModel = models.find((model) => model.modelId === nextModelId);
-          pushChange({
-            modelId: nextModelId,
-            reasoningEffort: normalizeReasoningEffortForModel(nextModel, reasoningEffort),
-          }, nextModel);
+          onChange(normalizeChatModelConfigForModel(
+            buildChatModelConfigFromModelDefaults(nextModelId, nextModel),
+            nextModel
+          ));
         }}
       />
 

--- a/src/client/src/components/chat-model/__tests__/chatDefaults.test.ts
+++ b/src/client/src/components/chat-model/__tests__/chatDefaults.test.ts
@@ -4,6 +4,7 @@ import type { ChatDefaultsDto } from '../../../types/settings';
 import {
   buildChatDefaultsModelChangeRequest,
   buildChatDefaultsUpdateRequest,
+  buildChatModelConfigFromModelDefaults,
   chatDefaultsToConfig,
   normalizeChatModelConfigForModel,
   parseSamplingOverrides,
@@ -36,10 +37,36 @@ describe('chatDefaults', () => {
     });
   });
 
+  it('builds config from model recommended defaults on model selection', () => {
+    const model: ModelDto = {
+      modelId: 'qwen',
+      displayName: 'Qwen',
+      samplingParameterPolicy: [
+        { key: 'temperature', label: 'Temperature', description: '', min: 0, max: 2, step: 0.1, recommendedDefault: 0.7, displayOrder: 0 },
+        { key: 'top_p', label: 'Top P', description: '', min: 0, max: 1, step: 0.05, recommendedDefault: 0.8, displayOrder: 1 },
+        { key: 'top_k', label: 'Top K', description: '', min: 1, max: 100, step: 1, recommendedDefault: 20, displayOrder: 2 },
+        { key: 'presence_penalty', label: 'Presence', description: '', min: 0, max: 2, step: 0.1, recommendedDefault: 1.5, displayOrder: 3 },
+      ],
+      reasoningChoices: ['none', 'medium'],
+      defaultReasoningChoice: 'medium',
+    } as ModelDto;
+
+    expect(buildChatModelConfigFromModelDefaults('qwen', model)).toEqual({
+      modelId: 'qwen',
+      temperature: 0.7,
+      topP: 0.8,
+      reasoningEffort: 'medium',
+      samplingOverrides: {
+        top_k: 20,
+        presence_penalty: 1.5,
+      },
+    });
+  });
+
   it('normalizes config against declared sampling policy keys', () => {
     const model: ModelDto = {
       id: 'gpt-4o',
-      samplingParameterPolicy: [{ key: 'frequency_penalty' }],
+      samplingParameterPolicy: [{ key: 'frequency_penalty', recommendedDefault: 0 }],
     } as ModelDto;
 
     const normalized = normalizeChatModelConfigForModel(
@@ -59,6 +86,36 @@ describe('chatDefaults', () => {
 
     expect(normalized.samplingOverrides).toEqual({ frequency_penalty: 0.3 });
     expect(normalized.samplingOverrides.ignored_key).toBeUndefined();
+  });
+
+  it('seeds missing sampling override keys from model recommended defaults', () => {
+    const model: ModelDto = {
+      modelId: 'qwen',
+      displayName: 'Qwen',
+      samplingParameterPolicy: [
+        { key: 'temperature', recommendedDefault: 0.7 },
+        { key: 'top_p', recommendedDefault: 0.8 },
+        { key: 'top_k', recommendedDefault: 20 },
+        { key: 'presence_penalty', recommendedDefault: 1.5 },
+      ],
+    } as ModelDto;
+
+    const normalized = normalizeChatModelConfigForModel(
+      {
+        modelId: 'qwen',
+        temperature: null,
+        topP: null,
+        samplingOverrides: {},
+      },
+      model
+    );
+
+    expect(normalized.temperature).toBe(0.7);
+    expect(normalized.topP).toBe(0.8);
+    expect(normalized.samplingOverrides).toEqual({
+      top_k: 20,
+      presence_penalty: 1.5,
+    });
   });
 
   it('builds update requests and model-change requests', () => {
@@ -84,14 +141,27 @@ describe('chatDefaults', () => {
       samplingParametersJson: '{"presence_penalty":0.1}',
     });
 
+    const qwenModel: ModelDto = {
+      modelId: 'qwen',
+      displayName: 'Qwen',
+      samplingParameterPolicy: [
+        { key: 'temperature', recommendedDefault: 0.7 },
+        { key: 'top_p', recommendedDefault: 0.8 },
+        { key: 'presence_penalty', recommendedDefault: 1.5 },
+      ],
+    } as ModelDto;
+
     const modelChange = buildChatDefaultsModelChangeRequest(
       baseDefaults,
-      'gpt-4o-mini',
-      undefined,
+      'qwen',
+      qwenModel,
       false
     );
-    expect(modelChange.defaultModelId).toBe('gpt-4o-mini');
+    expect(modelChange.defaultModelId).toBe('qwen');
     expect(modelChange.overrideAllChatModels).toBe(false);
+    expect(modelChange.temperature).toBe(0.7);
+    expect(modelChange.topP).toBe(0.8);
+    expect(modelChange.samplingParametersJson).toBe('{"presence_penalty":1.5}');
 
     const clearedModel = buildChatDefaultsUpdateRequest(
       baseDefaults,

--- a/src/client/src/components/chat-model/chatDefaults.ts
+++ b/src/client/src/components/chat-model/chatDefaults.ts
@@ -46,6 +46,43 @@ export function chatDefaultsToConfig(defaults: ChatDefaultsDto): ChatModelConfig
   };
 }
 
+/**
+ * Builds a config seeded entirely from the model's samplingParameterPolicy
+ * recommended defaults (and default reasoning choice). Used when the user
+ * selects a different model so prior model values are not carried over.
+ */
+export function buildChatModelConfigFromModelDefaults(
+  modelId: string,
+  model: ModelDto | undefined
+): ChatModelConfigValue {
+  const samplingOverrides: Record<string, number> = {};
+  let temperature: number | null = null;
+  let topP: number | null = null;
+
+  for (const param of model?.samplingParameterPolicy ?? []) {
+    const key = param.key.toLowerCase();
+    if (typeof param.recommendedDefault !== 'number' || Number.isNaN(param.recommendedDefault)) {
+      continue;
+    }
+
+    if (key === 'temperature') {
+      temperature = param.recommendedDefault;
+    } else if (key === 'top_p') {
+      topP = param.recommendedDefault;
+    } else {
+      samplingOverrides[param.key] = param.recommendedDefault;
+    }
+  }
+
+  return {
+    modelId,
+    temperature,
+    topP,
+    reasoningEffort: normalizeReasoningEffortForModel(model, undefined),
+    samplingOverrides,
+  };
+}
+
 export function normalizeChatModelConfigForModel(
   config: ChatModelConfigValue,
   model: ModelDto | undefined
@@ -72,6 +109,25 @@ export function normalizeChatModelConfigForModel(
       && !Number.isNaN(value)
     ) {
       normalizedOverrides[key] = value;
+    }
+  }
+
+  // Fill missing override keys from the model's recommended defaults so the UI
+  // and persisted chat defaults match the runtime profile JSON.
+  for (const param of model?.samplingParameterPolicy ?? []) {
+    const key = param.key.toLowerCase();
+    if (key === 'temperature' || key === 'top_p') {
+      continue;
+    }
+    const alreadySet = Object.keys(normalizedOverrides).some(
+      (overrideKey) => overrideKey.toLowerCase() === key
+    );
+    if (
+      !alreadySet
+      && typeof param.recommendedDefault === 'number'
+      && !Number.isNaN(param.recommendedDefault)
+    ) {
+      normalizedOverrides[param.key] = param.recommendedDefault;
     }
   }
 
@@ -112,10 +168,7 @@ export function buildChatDefaultsModelChangeRequest(
   overrideAllChatModels: boolean
 ): UpdateChatDefaultsRequest {
   const normalizedConfig = normalizeChatModelConfigForModel(
-    {
-      ...chatDefaultsToConfig(base),
-      modelId,
-    },
+    buildChatModelConfigFromModelDefaults(modelId, model),
     model
   );
 

--- a/src/client/src/components/guides/editor/ConfigParams.tsx
+++ b/src/client/src/components/guides/editor/ConfigParams.tsx
@@ -15,8 +15,8 @@ interface ConfigParamsProps {
 
 export function ConfigParams({
   model,
-  temperature = 1.0,
-  topP = 1.0,
+  temperature,
+  topP,
   reasoningEffort,
   samplingOverrides,
   onTemperatureChange,
@@ -39,10 +39,18 @@ export function ConfigParams({
   }
 
   const getParamValue = (key: string): number => {
-    const policyDefault = samplingPolicy.find(p => p.key === key)?.recommendedDefault ?? 0;
+    const policy = samplingPolicy.find(p => p.key.toLowerCase() === key.toLowerCase());
+    const policyDefault = policy?.recommendedDefault ?? 0;
     if (key === 'temperature') return temperature ?? policyDefault;
     if (key === 'top_p') return topP ?? policyDefault;
-    if (samplingOverrides && key in samplingOverrides) return samplingOverrides[key];
+    if (samplingOverrides) {
+      const overrideEntry = Object.entries(samplingOverrides).find(
+        ([overrideKey]) => overrideKey.toLowerCase() === key.toLowerCase()
+      );
+      if (overrideEntry) {
+        return overrideEntry[1];
+      }
+    }
     return policyDefault;
   };
 

--- a/src/client/src/components/guides/editor/__tests__/ConfigParams.test.tsx
+++ b/src/client/src/components/guides/editor/__tests__/ConfigParams.test.tsx
@@ -154,4 +154,44 @@ describe('ConfigParams', () => {
 
     expect((screen.getByLabelText('Reasoning Effort') as HTMLSelectElement).value).toBe('medium');
   });
+
+  it('falls back to model recommended defaults when temperature/topP are unset', () => {
+    render(
+      <ConfigParams
+        model={{
+          ...baseModel,
+          samplingParameterPolicy: [
+            {
+              key: 'temperature',
+              label: 'Temperature',
+              description: 'Controls randomness',
+              min: 0,
+              max: 2,
+              step: 0.1,
+              recommendedDefault: 0.7,
+              displayOrder: 1,
+            },
+            {
+              key: 'top_p',
+              label: 'Top P',
+              description: 'Nucleus sampling',
+              min: 0,
+              max: 1,
+              step: 0.05,
+              recommendedDefault: 0.8,
+              displayOrder: 2,
+            },
+          ],
+        }}
+        temperature={null}
+        topP={null}
+        onTemperatureChange={vi.fn()}
+        onTopPChange={vi.fn()}
+        onReasoningEffortChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Temperature')).toHaveValue('0.7');
+    expect(screen.getByLabelText('Top P')).toHaveValue('0.8');
+  });
 });

--- a/src/client/src/components/notebook/dialogs/NotebookUploadDialog.tsx
+++ b/src/client/src/components/notebook/dialogs/NotebookUploadDialog.tsx
@@ -248,9 +248,10 @@ export const NotebookUploadDialog: React.FC<NotebookUploadDialogProps> = ({
 
   const dialogMarkup = (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[80vh] flex flex-col">
+      {/* min-h-0 + overflow-hidden let flex children shrink so the file list can scroll inside max-h */}
+      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[80vh] flex flex-col min-h-0 overflow-hidden">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+        <div className="flex-shrink-0 flex items-center justify-between p-6 border-b border-gray-200">
           <h2 className="text-xl font-semibold text-gray-900 flex items-baseline gap-2">
             Add Files to Notebook
             <span className="text-sm font-normal text-gray-500">to {folderDisplayName}</span>
@@ -268,7 +269,7 @@ export const NotebookUploadDialog: React.FC<NotebookUploadDialogProps> = ({
 
         {/* Tabs */}
         {hasProjectFiles && (
-          <div className="flex border-b border-gray-200">
+          <div className="flex-shrink-0 flex border-b border-gray-200">
             <button
               onClick={() => setActiveTab('local')}
               className={`px-6 py-3 text-sm font-medium border-b-2 ${
@@ -293,16 +294,16 @@ export const NotebookUploadDialog: React.FC<NotebookUploadDialogProps> = ({
         )}
 
         {/* Content */}
-        <div className="p-6 flex-1 overflow-hidden flex flex-col">
+        <div className="p-6 flex-1 min-h-0 overflow-hidden flex flex-col">
           {activeTab === 'local' ? (
             <>
-              <h3 className="text-sm font-medium text-gray-700 mb-3">Select Files from Your Computer</h3>
+              <h3 className="flex-shrink-0 text-sm font-medium text-gray-700 mb-3">Select Files from Your Computer</h3>
               
               {/* Drop Zone */}
               <div
                 onDrop={handleDrop}
                 onDragOver={handleDragOver}
-                className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center cursor-pointer hover:border-blue-400 mb-4"
+                className="flex-shrink-0 border-2 border-dashed border-gray-300 rounded-lg p-6 text-center cursor-pointer hover:border-blue-400 mb-4"
                 onClick={() => fileInputRef.current?.click()}
               >
                 <svg className="w-12 h-12 mx-auto text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 48 48">
@@ -325,11 +326,11 @@ export const NotebookUploadDialog: React.FC<NotebookUploadDialogProps> = ({
 
               {/* Selected Files List */}
               {selectedFiles.length > 0 && (
-                <div className="flex-1 overflow-hidden flex flex-col">
-                  <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
+                  <h4 className="flex-shrink-0 text-sm font-medium text-gray-700 mb-2">
                     Selected Files ({selectedFiles.length})
                   </h4>
-                  <div className="flex-1 border border-gray-200 rounded-md overflow-y-auto">
+                  <div className="flex-1 min-h-0 border border-gray-200 rounded-md overflow-y-auto">
                     {selectedFiles.map((file, index) => (
                       <div key={index} className="flex items-center justify-between p-3 border-b border-gray-100 last:border-b-0">
                         <div className="flex items-center flex-1 min-w-0">
@@ -358,24 +359,24 @@ export const NotebookUploadDialog: React.FC<NotebookUploadDialogProps> = ({
             </>
           ) : (
             <>
-              <h3 className="text-sm font-medium text-gray-700 mb-3">Select Files from Current Project</h3>
+              <h3 className="flex-shrink-0 text-sm font-medium text-gray-700 mb-3">Select Files from Current Project</h3>
               
               {projectFolderTree ? (
-                <div className="flex-1 overflow-hidden flex flex-col">
+                <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
                   {selectedProjectFiles.length > 0 && (
-                    <div className="mb-3 p-2 bg-blue-50 border border-blue-200 rounded">
+                    <div className="flex-shrink-0 mb-3 p-2 bg-blue-50 border border-blue-200 rounded">
                       <span className="text-sm text-blue-800 font-medium">
                         {selectedProjectFiles.length} file{selectedProjectFiles.length > 1 ? 's' : ''} selected
                       </span>
                     </div>
                   )}
                   
-                  <div className="flex-1 border border-gray-200 rounded-md overflow-y-auto">
+                  <div className="flex-1 min-h-0 border border-gray-200 rounded-md overflow-y-auto">
                     {renderProjectFolderTree(projectFolderTree)}
                   </div>
                 </div>
               ) : (
-                <div className="flex-1 flex items-center justify-center text-gray-500">
+                <div className="flex-1 min-h-0 flex items-center justify-center text-gray-500">
                   <div className="text-center">
                     <svg className="w-12 h-12 mx-auto mb-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
@@ -389,7 +390,7 @@ export const NotebookUploadDialog: React.FC<NotebookUploadDialogProps> = ({
         </div>
 
         {/* Footer */}
-        <div className="p-6 border-t border-gray-200 flex items-center justify-between">
+        <div className="flex-shrink-0 p-6 border-t border-gray-200 flex items-center justify-between">
           <div />
           <div className="text-sm text-gray-600">
             {fileCount > 0 && (

--- a/src/client/src/components/notebook/dialogs/__tests__/NotebookUploadDialog.test.tsx
+++ b/src/client/src/components/notebook/dialogs/__tests__/NotebookUploadDialog.test.tsx
@@ -527,6 +527,42 @@ describe('NotebookUploadDialog', () => {
       expect(screen.getByText('Level 1')).toBeInTheDocument();
       expect(screen.getByText('Level 2')).toBeInTheDocument();
     });
+
+    it('renders every project file in a scrollable list container', () => {
+      const manyFiles: ProjectContentFile[] = Array.from({ length: 40 }, (_, i) => ({
+        ...mockProjectFile,
+        id: `bulk-${i}`,
+        fileName: `bulk-file-${i}.txt`,
+        relativePath: `bulk-file-${i}.txt`,
+        path: `/bulk-file-${i}.txt`,
+        documentId: `doc-bulk-${i}`,
+      }));
+      const tree: FolderTreeDto = {
+        ...mockProjectFolderTree,
+        files: manyFiles,
+        subFolders: [],
+      };
+
+      render(
+        <NotebookUploadDialog
+          isOpen
+          onClose={onClose}
+          onUpload={onUpload}
+          onCopyFromProject={onCopyFromProject}
+          projectFolderTree={tree}
+        />,
+      );
+
+      fireEvent.click(screen.getByText(/select project files/i));
+
+      expect(screen.getByText('bulk-file-0.txt')).toBeInTheDocument();
+      expect(screen.getByText('bulk-file-39.txt')).toBeInTheDocument();
+
+      const firstRow = screen.getByText('bulk-file-0.txt').closest('div');
+      const scrollContainer = firstRow?.parentElement?.parentElement;
+      expect(scrollContainer?.className).toMatch(/overflow-y-auto/);
+      expect(scrollContainer?.className).toMatch(/min-h-0/);
+    });
   });
 
   describe('Accessibility', () => {

--- a/src/client/src/pages/NotebookDetails.tsx
+++ b/src/client/src/pages/NotebookDetails.tsx
@@ -26,6 +26,7 @@ import { NotebookAuthInterstitial } from '../components/notebook/auth/NotebookAu
 import { checkNotebookAuthRequirements } from '../utils/notebookAuth';
 import { useRegisterTour } from '../tour/useRegisterTour';
 import { useNotebookFilesPolling } from '../hooks/useNotebookFilesPolling';
+import { useProjectFilesPolling } from '../hooks/useProjectFilesPolling';
 import { NotebookFolderTreeDto } from '../types/notebook';
 import { useToast } from '../components/common/Toast';
 import { useAuth } from '../contexts/AuthContext';
@@ -37,7 +38,7 @@ function NotebookDetailsContent() {
     const { projectId, notebookId } = useParams<{ projectId: string; notebookId: string }>();
     const navigate = useNavigate();
     const location = useLocation();
-    const { project, canEdit, isLoading: projectLoading, error: projectError, refreshProject, folderTree: projectFolderTree } = useProject();
+    const { project, canEdit, isLoading: projectLoading, error: projectError, refreshProject, folderTree: contextProjectFolderTree } = useProject();
     const { role, status } = useAuth();
     const isAdmin = role === 'Admin';
     const isAuthenticatedAdmin = status === 'authenticated' && isAdmin;
@@ -76,6 +77,13 @@ function NotebookDetailsContent() {
         notebookId: notebookId || '',
         enabled: Boolean(projectId && notebookId),
     });
+
+    // Keep project file picker current (ProjectContext tree is a one-shot load)
+    const { folderTree: polledProjectFolderTree } = useProjectFilesPolling({
+        projectId: projectId || '',
+        enabled: Boolean(projectId),
+    });
+    const projectFolderTree = polledProjectFolderTree ?? contextProjectFolderTree;
     
     // Initialize activeConversationId from URL query param 'c' to persist across iOS resume/page refresh
     const [activeConversationId, setActiveConversationIdState] = useState<string | null>(() => {

--- a/src/client/src/pages/__tests__/NotebookDetails.test.tsx
+++ b/src/client/src/pages/__tests__/NotebookDetails.test.tsx
@@ -86,6 +86,16 @@ vi.mock('../../hooks/useNotebookFilesPolling', () => ({
   }),
 }));
 
+vi.mock('../../hooks/useProjectFilesPolling', () => ({
+  useProjectFilesPolling: () => ({
+    folderTree: null,
+    isLoading: false,
+    error: null,
+    lastUpdated: null,
+    refresh: vi.fn(),
+  }),
+}));
+
 vi.mock('../../hooks/useNotebookWorkspaceControls', () => ({
   useNotebookWorkspaceControls: () => mockWorkspaceControls,
 }));

--- a/src/server/GuideAntsApi.Tests/Endpoints/PublishedOpenAiWireHandlersTests.cs
+++ b/src/server/GuideAntsApi.Tests/Endpoints/PublishedOpenAiWireHandlersTests.cs
@@ -110,6 +110,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -162,6 +164,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -217,6 +221,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -271,6 +277,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -337,6 +345,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -386,6 +396,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -442,6 +454,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -517,6 +531,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -590,6 +606,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -751,6 +769,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -844,6 +864,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -988,6 +1010,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1060,6 +1084,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1118,6 +1144,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1193,6 +1221,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1230,6 +1260,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1292,6 +1324,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1394,6 +1428,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1465,6 +1501,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1624,6 +1662,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1778,6 +1818,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -1969,6 +2011,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -2252,6 +2296,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -2442,6 +2488,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -2613,6 +2661,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -2736,6 +2786,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -2839,6 +2891,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -2966,6 +3020,8 @@ public sealed class PublishedOpenAiWireHandlersTests
             request,
             resolver,
             conversationService.Object,
+            CreateNotebookFileService().Object,
+            CreateHttpClientFactory().Object,
             db);
         var executed = await ExecuteResultAsync(result);
 
@@ -3020,7 +3076,7 @@ public sealed class PublishedOpenAiWireHandlersTests
                 """)
         };
 
-        var result = await PublishedAnthropicWireHandler.PostMessagesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedAnthropicWireHandler.PostMessagesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status200OK);
@@ -3072,7 +3128,7 @@ public sealed class PublishedOpenAiWireHandlersTests
                 """)
         };
 
-        var result = await PublishedAnthropicWireHandler.PostMessagesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedAnthropicWireHandler.PostMessagesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status200OK);
@@ -3119,7 +3175,7 @@ public sealed class PublishedOpenAiWireHandlersTests
                 """)
         };
 
-        var result = await PublishedAnthropicWireHandler.PostMessagesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedAnthropicWireHandler.PostMessagesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status200OK);
@@ -3169,7 +3225,7 @@ public sealed class PublishedOpenAiWireHandlersTests
                 """)
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostChatCompletionsAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostChatCompletionsAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status200OK);
@@ -3244,7 +3300,7 @@ public sealed class PublishedOpenAiWireHandlersTests
                 """)
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostChatCompletionsAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostChatCompletionsAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status200OK);
@@ -3284,7 +3340,7 @@ public sealed class PublishedOpenAiWireHandlersTests
             Conversation = ParseJsonElement($"\"conv_{conversationId:N}\"")
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status200OK);
@@ -3309,7 +3365,7 @@ public sealed class PublishedOpenAiWireHandlersTests
             Conversation = ParseJsonElement("\"not-a-conversation-id\"")
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
@@ -3340,7 +3396,7 @@ public sealed class PublishedOpenAiWireHandlersTests
             Conversation = ParseJsonElement($"\"conv_{conversationId:N}\"")
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
@@ -3373,7 +3429,7 @@ public sealed class PublishedOpenAiWireHandlersTests
             PreviousResponseId = $"resp_{assistantMessageId:N}"
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
@@ -3408,7 +3464,7 @@ public sealed class PublishedOpenAiWireHandlersTests
             Conversation = ParseJsonElement("\"conv_not_a_real_id\"")
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
@@ -3453,7 +3509,7 @@ public sealed class PublishedOpenAiWireHandlersTests
                 """)
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status200OK);
@@ -3487,7 +3543,7 @@ public sealed class PublishedOpenAiWireHandlersTests
             PreviousResponseId = "resp_not_a_real_id"
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostResponsesAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
@@ -3724,6 +3780,27 @@ public sealed class PublishedOpenAiWireHandlersTests
             });
 
         await db.SaveChangesAsync();
+    }
+
+    private static Mock<INotebookFileService> CreateNotebookFileService()
+    {
+        var mock = new Mock<INotebookFileService>(MockBehavior.Loose);
+        mock.Setup(s => s.UploadFilesAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid>(),
+                It.IsAny<IFormFileCollection>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(Array.Empty<GuideAntsApi.Models.NotebookFileDto>());
+        return mock;
+    }
+
+    private static Mock<IHttpClientFactory> CreateHttpClientFactory()
+    {
+        var mock = new Mock<IHttpClientFactory>(MockBehavior.Loose);
+        mock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient());
+        return mock;
     }
 
     private static PublishedApiExecutionContext CreateExecutionContext(
@@ -4058,7 +4135,7 @@ public sealed class PublishedOpenAiWireHandlersTests
                 """)
         };
 
-        var result = await PublishedOpenAiChatWireHandler.PostChatCompletionsAsync(http, pubId, request, resolver, conversationService.Object, db);
+        var result = await PublishedOpenAiChatWireHandler.PostChatCompletionsAsync(http, pubId, request, resolver, conversationService.Object, CreateNotebookFileService().Object, CreateHttpClientFactory().Object, db);
         var executed = await ExecuteResultAsync(result);
 
         executed.StatusCode.Should().Be(StatusCodes.Status200OK);

--- a/src/server/GuideAntsApi.Tests/Endpoints/PublishedWire/WireClientRequestParserTests.cs
+++ b/src/server/GuideAntsApi.Tests/Endpoints/PublishedWire/WireClientRequestParserTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using FluentAssertions;
+using GuideAntsApi.Endpoints.PublishedWire;
+
+namespace GuideAntsApi.Tests.Endpoints.PublishedWire;
+
+[TestClass]
+public sealed class WireClientRequestParserTests
+{
+    [TestMethod]
+    public void BuildOpenAiChatClientPrompt_Extracts_image_urls_from_user_turn()
+    {
+        using var doc = JsonDocument.Parse(
+            """
+            [
+              {
+                "role": "user",
+                "content": [
+                  { "type": "text", "text": "describe this plantuml" },
+                  { "type": "image_url", "image_url": { "url": "data:image/png;base64,AAAA" } }
+                ]
+              }
+            ]
+            """);
+
+        var prompt = WireClientRequestParser.BuildOpenAiChatClientPrompt(doc.RootElement);
+
+        prompt.UserPrompt.Should().Be("describe this plantuml");
+        prompt.UserImageUrls.Should().ContainSingle("data:image/png;base64,AAAA");
+        prompt.PrefixMessages.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void BuildOpenAiChatClientPrompt_Preserves_string_image_url_shape()
+    {
+        using var doc = JsonDocument.Parse(
+            """
+            [
+              {
+                "role": "user",
+                "content": [
+                  { "type": "text", "text": "what is this?" },
+                  { "type": "image_url", "image_url": "https://example.com/a.png" }
+                ]
+              }
+            ]
+            """);
+
+        var prompt = WireClientRequestParser.BuildOpenAiChatClientPrompt(doc.RootElement);
+
+        prompt.UserImageUrls.Should().ContainSingle("https://example.com/a.png");
+    }
+
+    [TestMethod]
+    public void BuildOpenAiChatClientPrompt_Keeps_prior_multimodal_messages_in_prefix()
+    {
+        using var doc = JsonDocument.Parse(
+            """
+            [
+              {
+                "role": "user",
+                "content": [
+                  { "type": "text", "text": "first" },
+                  { "type": "image_url", "image_url": { "url": "data:image/png;base64,BBBB" } }
+                ]
+              },
+              { "role": "assistant", "content": "ok" },
+              { "role": "user", "content": "follow up" }
+            ]
+            """);
+
+        var prompt = WireClientRequestParser.BuildOpenAiChatClientPrompt(doc.RootElement);
+
+        prompt.UserPrompt.Should().Be("follow up");
+        prompt.UserImageUrls.Should().BeEmpty();
+        prompt.PrefixMessages.Should().HaveCount(2);
+        prompt.PrefixMessages[0].Content.Should().Contain(c =>
+            c.IsImage && c.ImageUrl!.Url == "data:image/png;base64,BBBB");
+    }
+
+    [TestMethod]
+    public void BuildAnthropicClientPrompt_Extracts_base64_image_urls()
+    {
+        using var system = JsonDocument.Parse("\"\"");
+        using var messages = JsonDocument.Parse(
+            """
+            [
+              {
+                "role": "user",
+                "content": [
+                  { "type": "text", "text": "look" },
+                  {
+                    "type": "image",
+                    "source": {
+                      "type": "base64",
+                      "media_type": "image/jpeg",
+                      "data": "ZZZZ"
+                    }
+                  }
+                ]
+              }
+            ]
+            """);
+
+        var prompt = WireClientRequestParser.BuildAnthropicClientPrompt(system.RootElement, messages.RootElement);
+
+        prompt.UserPrompt.Should().Be("look");
+        prompt.UserImageUrls.Should().ContainSingle("data:image/jpeg;base64,ZZZZ");
+    }
+
+    [TestMethod]
+    public void BuildOpenAiResponsesClientPrompt_Extracts_input_image_urls()
+    {
+        using var doc = JsonDocument.Parse(
+            """
+            [
+              {
+                "role": "user",
+                "content": [
+                  { "type": "input_text", "text": "caption this" },
+                  { "type": "input_image", "image_url": "data:image/png;base64,CCCC" }
+                ]
+              }
+            ]
+            """);
+
+        var prompt = WireClientRequestParser.BuildOpenAiResponsesClientPrompt(doc.RootElement);
+
+        prompt.UserPrompt.Should().Be("caption this");
+        prompt.UserImageUrls.Should().ContainSingle("data:image/png;base64,CCCC");
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Endpoints/PublishedWire/WireImageAttachmentMaterializerTests.cs
+++ b/src/server/GuideAntsApi.Tests/Endpoints/PublishedWire/WireImageAttachmentMaterializerTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using GuideAntsApi.Endpoints.PublishedWire;
+using GuideAntsApi.Models;
+using GuideAntsApi.Models.Conversations;
+using GuideAntsApi.Services.Components;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace GuideAntsApi.Tests.Endpoints.PublishedWire;
+
+[TestClass]
+public sealed class WireImageAttachmentMaterializerTests
+{
+    [TestMethod]
+    public async Task MaterializeAsync_Uploads_data_uri_as_notebook_image_attachment()
+    {
+        var projectId = Guid.NewGuid();
+        var notebookId = Guid.NewGuid();
+        var fileId = Guid.NewGuid();
+        var notebookFileService = new Mock<INotebookFileService>(MockBehavior.Strict);
+        notebookFileService
+            .Setup(s => s.UploadFilesAsync(
+                projectId,
+                notebookId,
+                It.IsAny<IFormFileCollection>(),
+                "Output/.wire-attachments",
+                false,
+                false))
+            .ReturnsAsync(
+            [
+                new NotebookFileDto(
+                    fileId,
+                    "wire-image.png",
+                    "Output/.wire-attachments/wire-image.png",
+                    4,
+                    DateTime.UtcNow,
+                    "hash",
+                    null,
+                    false,
+                    false)
+            ]);
+
+        var attachments = await WireImageAttachmentMaterializer.MaterializeAsync(
+            notebookFileService.Object,
+            projectId,
+            notebookId,
+            ["data:image/png;base64,AAAA"]);
+
+        attachments.Should().ContainSingle();
+        attachments[0].NotebookFileId.Should().Be(fileId);
+        attachments[0].UploadType.Should().Be(ContentUploadType.ImageFile);
+        notebookFileService.VerifyAll();
+    }
+
+    [TestMethod]
+    public async Task MaterializeAsync_Skips_invalid_data_uri()
+    {
+        var notebookFileService = new Mock<INotebookFileService>(MockBehavior.Strict);
+
+        var attachments = await WireImageAttachmentMaterializer.MaterializeAsync(
+            notebookFileService.Object,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            ["data:image/png;base64,!!!not-base64!!!"]);
+
+        attachments.Should().BeEmpty();
+    }
+}

--- a/src/server/GuideAntsApi/Endpoints/PublishedWire/PublishedAnthropicWireHandler.cs
+++ b/src/server/GuideAntsApi/Endpoints/PublishedWire/PublishedAnthropicWireHandler.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using GuideAntsApi.DataModel;
+using GuideAntsApi.Services.Components;
 using GuideAntsApi.Services.Conversations;
 using GuideAntsApi.Services.PublishedWireApi;
 using GuideAntsApi.Services.Routing;
@@ -23,6 +24,8 @@ public static async Task<IResult> PostMessagesAsync(
     [FromBody] AnthropicMessagesRequest request,
     [FromServices] IPublishedApiExecutionContextResolver executionContextResolver,
     [FromServices] IPublishedConversationService publishedConversationService,
+    [FromServices] INotebookFileService notebookFileService,
+    [FromServices] IHttpClientFactory httpClientFactory,
     [FromServices] ApplicationDbContext db)
 {
     var loggerFactory = httpContext.RequestServices?.GetService<ILoggerFactory>() ?? Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance;
@@ -112,6 +115,14 @@ public static async Task<IResult> PostMessagesAsync(
                     httpContext.RequestAborted);
             }
 
+            var attachments = await WireImageAttachmentMaterializer.MaterializeAsync(
+                notebookFileService,
+                context.ProjectId,
+                context.NotebookId,
+                clientPrompt.UserImageUrls,
+                httpClientFactory.CreateClient(),
+                httpContext.RequestAborted);
+
             streamHandle = await WireConversationExecutor.StartConversationStreamAsync(
                 publishedConversationService,
                 context,
@@ -119,7 +130,8 @@ public static async Task<IResult> PostMessagesAsync(
                 httpContext.RequestAborted,
                 existingConversationId: existingConversationId,
                 clientMessages: existingConversationId.HasValue ? null : clientPrompt.PrefixMessages,
-                clientToolDefinitions: clientToolDefinitions);
+                clientToolDefinitions: clientToolDefinitions,
+                attachments: attachments.Count == 0 ? null : attachments);
         }
 
         var publicApiOrigin = WireResponseSerializer.ResolvePublicApiOrigin(httpContext);

--- a/src/server/GuideAntsApi/Endpoints/PublishedWire/PublishedOpenAiChatWireHandler.cs
+++ b/src/server/GuideAntsApi/Endpoints/PublishedWire/PublishedOpenAiChatWireHandler.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using GuideAntsApi.DataModel;
+using GuideAntsApi.Services.Components;
 using GuideAntsApi.Services.Conversations;
 using GuideAntsApi.Services.PublishedWireApi;
 using GuideAntsApi.Services.Routing;
@@ -30,6 +31,8 @@ public static async Task<IResult> PostChatCompletionsAsync(
     [FromBody] OpenAiChatCompletionsRequest request,
     [FromServices] IPublishedApiExecutionContextResolver executionContextResolver,
     [FromServices] IPublishedConversationService publishedConversationService,
+    [FromServices] INotebookFileService notebookFileService,
+    [FromServices] IHttpClientFactory httpClientFactory,
     [FromServices] ApplicationDbContext db)
 {
     var loggerFactory = httpContext.RequestServices?.GetService<ILoggerFactory>() ?? Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance;
@@ -104,6 +107,14 @@ public static async Task<IResult> PostChatCompletionsAsync(
                 db,
                 httpContext.RequestAborted);
 
+            var attachments = await WireImageAttachmentMaterializer.MaterializeAsync(
+                notebookFileService,
+                context.ProjectId,
+                context.NotebookId,
+                clientPrompt.UserImageUrls,
+                httpClientFactory.CreateClient(),
+                httpContext.RequestAborted);
+
             streamHandle = await WireConversationExecutor.StartConversationStreamAsync(
                 publishedConversationService,
                 context,
@@ -111,7 +122,8 @@ public static async Task<IResult> PostChatCompletionsAsync(
                 httpContext.RequestAborted,
                 existingConversationId: existingConversationId,
                 clientMessages: existingConversationId.HasValue ? null : clientPrompt.PrefixMessages,
-                clientToolDefinitions: clientToolDefinitions);
+                clientToolDefinitions: clientToolDefinitions,
+                attachments: attachments.Count == 0 ? null : attachments);
         }
 
         var publicApiOrigin = WireResponseSerializer.ResolvePublicApiOrigin(httpContext);
@@ -224,6 +236,8 @@ public static async Task<IResult> PostResponsesAsync(
     [FromBody] OpenAiResponsesRequest request,
     [FromServices] IPublishedApiExecutionContextResolver executionContextResolver,
     [FromServices] IPublishedConversationService publishedConversationService,
+    [FromServices] INotebookFileService notebookFileService,
+    [FromServices] IHttpClientFactory httpClientFactory,
     [FromServices] ApplicationDbContext db)
 {
     var loggerFactory = httpContext.RequestServices?.GetService<ILoggerFactory>() ?? Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance;
@@ -324,6 +338,14 @@ public static async Task<IResult> PostResponsesAsync(
                 return conversationResolution.ErrorResult;
             }
 
+            var attachments = await WireImageAttachmentMaterializer.MaterializeAsync(
+                notebookFileService,
+                context.ProjectId,
+                context.NotebookId,
+                clientPrompt.UserImageUrls,
+                httpClientFactory.CreateClient(),
+                httpContext.RequestAborted);
+
             streamHandle = await WireConversationExecutor.StartConversationStreamAsync(
                 publishedConversationService,
                 context,
@@ -331,7 +353,8 @@ public static async Task<IResult> PostResponsesAsync(
                 httpContext.RequestAborted,
                 existingConversationId: conversationResolution.ConversationId,
                 clientMessages: conversationResolution.ConversationId.HasValue ? null : clientPrompt.PrefixMessages,
-                clientToolDefinitions: clientToolDefinitions);
+                clientToolDefinitions: clientToolDefinitions,
+                attachments: attachments.Count == 0 ? null : attachments);
         }
 
         var publicApiOrigin = WireResponseSerializer.ResolvePublicApiOrigin(httpContext);

--- a/src/server/GuideAntsApi/Endpoints/PublishedWire/WireClientRequestParser.cs
+++ b/src/server/GuideAntsApi/Endpoints/PublishedWire/WireClientRequestParser.cs
@@ -9,7 +9,8 @@ internal static class WireClientRequestParser
 {
 internal sealed record ClientPromptParts(
         IReadOnlyList<ChatMessage> PrefixMessages,
-        string UserPrompt);
+        string UserPrompt,
+        IReadOnlyList<string> UserImageUrls);
 
 internal static List<ChatToolDefinition> ParseAnthropicClientToolDefinitions(JsonElement tools)
 {
@@ -182,6 +183,11 @@ internal static ClientPromptParts SplitClientPrompt(IReadOnlyList<ChatMessage> p
             continue;
         }
 
+        var imageUrls = message.Content
+            .Where(static c => c.IsImage && c.ImageUrl != null && !string.IsNullOrWhiteSpace(c.ImageUrl.Url))
+            .Select(static c => c.ImageUrl!.Url)
+            .ToList();
+
         var prefixMessages = new List<ChatMessage>(normalizedMessages.Count - 1);
         for (var index = 0; index < normalizedMessages.Count; index++)
         {
@@ -193,15 +199,21 @@ internal static ClientPromptParts SplitClientPrompt(IReadOnlyList<ChatMessage> p
             prefixMessages.Add(normalizedMessages[index]);
         }
 
-        return new ClientPromptParts(prefixMessages, text.Trim());
+        return new ClientPromptParts(prefixMessages, text.Trim(), imageUrls);
     }
 
-    return new ClientPromptParts(normalizedMessages, fallbackPrompt.Trim());
+    return new ClientPromptParts(normalizedMessages, fallbackPrompt.Trim(), []);
 }
 
 internal static bool IsMeaningfulClientMessage(ChatMessage message)
 {
     if (!string.IsNullOrWhiteSpace(message.GetText()))
+    {
+        return true;
+    }
+
+    if (message.Content.Any(static c =>
+            c.IsImage && c.ImageUrl != null && !string.IsNullOrWhiteSpace(c.ImageUrl.Url)))
     {
         return true;
     }
@@ -262,7 +274,7 @@ internal static List<ChatMessage> ParseOpenAiChatClientMessages(JsonElement mess
         }
 
         var contents = item.TryGetProperty("content", out var contentElement)
-            ? CreateTextContents(WireJson.ExtractTextContent(contentElement))
+            ? CreateOpenAiChatContents(contentElement)
             : Array.Empty<ChatContent>();
 
         var toolCalls = role == ChatRole.Assistant &&
@@ -356,6 +368,16 @@ internal static void TryAddOpenAiResponsesClientMessage(JsonElement item, IColle
         return;
     }
 
+    if (string.Equals(type, "input_image", StringComparison.OrdinalIgnoreCase))
+    {
+        var imageContents = CreateOpenAiChatContents(item);
+        if (imageContents.Count > 0)
+        {
+            destination.Add(new ChatMessage(ChatRole.User, imageContents));
+        }
+        return;
+    }
+
     if (string.Equals(type, "output_text", StringComparison.OrdinalIgnoreCase))
     {
         var text = item.TryGetProperty("text", out var textElement)
@@ -412,7 +434,7 @@ internal static void TryAddOpenAiResponsesClientMessage(JsonElement item, IColle
             : default;
     var contents = content.ValueKind == JsonValueKind.Undefined
         ? Array.Empty<ChatContent>()
-        : CreateTextContents(WireJson.ExtractTextContent(content));
+        : CreateOpenAiChatContents(content);
 
     var toolCalls = role == ChatRole.Assistant &&
                     messagePayload.TryGetProperty("tool_calls", out var toolCallsElement)
@@ -476,6 +498,7 @@ internal static List<ChatMessage> ParseAnthropicClientMessages(JsonElement syste
         }
 
         var textBlocks = new List<string>();
+        var imageContents = new List<ChatContent>();
         var toolCalls = new List<ChatToolCall>();
         var toolResults = new List<ChatMessage>();
 
@@ -497,6 +520,13 @@ internal static List<ChatMessage> ParseAnthropicClientMessages(JsonElement syste
                     textBlocks.Add(blockText.Trim());
                 }
 
+                continue;
+            }
+
+            if (string.Equals(blockType, "image", StringComparison.OrdinalIgnoreCase) &&
+                TryCreateAnthropicImageContent(block, out var imageContent))
+            {
+                imageContents.Add(imageContent!);
                 continue;
             }
 
@@ -554,8 +584,10 @@ internal static List<ChatMessage> ParseAnthropicClientMessages(JsonElement syste
             }
         }
 
+        var contents = new List<ChatContent>();
         var text = textBlocks.Count == 0 ? null : string.Join("\n", textBlocks);
-        var contents = CreateTextContents(text);
+        contents.AddRange(CreateTextContents(text));
+        contents.AddRange(imageContents);
 
         if (role == ChatRole.Assistant && toolCalls.Count > 0)
         {
@@ -643,6 +675,178 @@ internal static IReadOnlyList<ChatContent> CreateTextContents(string? text)
     }
 
     return [new ChatContent(text.Trim())];
+}
+
+internal static IReadOnlyList<ChatContent> CreateOpenAiChatContents(JsonElement content)
+{
+    if (content.ValueKind == JsonValueKind.String)
+    {
+        return CreateTextContents(content.GetString());
+    }
+
+    if (content.ValueKind == JsonValueKind.Array)
+    {
+        var items = new List<ChatContent>();
+        foreach (var part in content.EnumerateArray())
+        {
+            AddOpenAiChatContentPart(part, items);
+        }
+
+        return items;
+    }
+
+    if (content.ValueKind == JsonValueKind.Object)
+    {
+        var items = new List<ChatContent>();
+        AddOpenAiChatContentPart(content, items);
+        return items;
+    }
+
+    return Array.Empty<ChatContent>();
+}
+
+internal static void AddOpenAiChatContentPart(JsonElement part, List<ChatContent> items)
+{
+    if (part.ValueKind == JsonValueKind.String)
+    {
+        var text = part.GetString();
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            items.Add(new ChatContent(text.Trim()));
+        }
+
+        return;
+    }
+
+    if (part.ValueKind != JsonValueKind.Object)
+    {
+        return;
+    }
+
+    var type = part.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.String
+        ? typeElement.GetString()
+        : null;
+
+    if (string.Equals(type, "text", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(type, "input_text", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(type, "output_text", StringComparison.OrdinalIgnoreCase))
+    {
+        var text = WireJson.ExtractTextContent(part);
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            items.Add(new ChatContent(text.Trim()));
+        }
+
+        return;
+    }
+
+    if (string.Equals(type, "image_url", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(type, "input_image", StringComparison.OrdinalIgnoreCase) ||
+        part.TryGetProperty("image_url", out _))
+    {
+        if (TryReadOpenAiImageUrl(part, out var imageUrl))
+        {
+            items.Add(new ChatContent(new ChatImageUrl(imageUrl!)));
+        }
+
+        return;
+    }
+
+    if (part.TryGetProperty("text", out var textElement) && textElement.ValueKind == JsonValueKind.String)
+    {
+        var textValue = textElement.GetString();
+        if (!string.IsNullOrWhiteSpace(textValue))
+        {
+            items.Add(new ChatContent(textValue.Trim()));
+        }
+    }
+}
+
+internal static bool TryReadOpenAiImageUrl(JsonElement part, out string? imageUrl)
+{
+    imageUrl = null;
+
+    if (part.TryGetProperty("image_url", out var imageUrlElement))
+    {
+        if (imageUrlElement.ValueKind == JsonValueKind.String)
+        {
+            imageUrl = imageUrlElement.GetString();
+        }
+        else if (imageUrlElement.ValueKind == JsonValueKind.Object &&
+                 imageUrlElement.TryGetProperty("url", out var urlElement) &&
+                 urlElement.ValueKind == JsonValueKind.String)
+        {
+            imageUrl = urlElement.GetString();
+        }
+    }
+    else if (part.TryGetProperty("url", out var directUrlElement) &&
+             directUrlElement.ValueKind == JsonValueKind.String)
+    {
+        imageUrl = directUrlElement.GetString();
+    }
+
+    if (string.IsNullOrWhiteSpace(imageUrl))
+    {
+        imageUrl = null;
+        return false;
+    }
+
+    imageUrl = imageUrl.Trim();
+    return true;
+}
+
+internal static bool TryCreateAnthropicImageContent(JsonElement block, out ChatContent? content)
+{
+    content = null;
+    if (!block.TryGetProperty("source", out var source) || source.ValueKind != JsonValueKind.Object)
+    {
+        return false;
+    }
+
+    var sourceType = source.TryGetProperty("type", out var sourceTypeElement) &&
+                     sourceTypeElement.ValueKind == JsonValueKind.String
+        ? sourceTypeElement.GetString()
+        : null;
+
+    if (string.Equals(sourceType, "url", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(sourceType, "image_url", StringComparison.OrdinalIgnoreCase))
+    {
+        var url = source.TryGetProperty("url", out var urlElement) && urlElement.ValueKind == JsonValueKind.String
+            ? urlElement.GetString()
+            : null;
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        content = new ChatContent(new ChatImageUrl(url.Trim()));
+        return true;
+    }
+
+    if (string.Equals(sourceType, "base64", StringComparison.OrdinalIgnoreCase))
+    {
+        var data = source.TryGetProperty("data", out var dataElement) && dataElement.ValueKind == JsonValueKind.String
+            ? dataElement.GetString()
+            : null;
+        if (string.IsNullOrWhiteSpace(data))
+        {
+            return false;
+        }
+
+        var mediaType = source.TryGetProperty("media_type", out var mediaTypeElement) &&
+                        mediaTypeElement.ValueKind == JsonValueKind.String
+            ? mediaTypeElement.GetString()
+            : "image/png";
+        if (string.IsNullOrWhiteSpace(mediaType))
+        {
+            mediaType = "image/png";
+        }
+
+        content = new ChatContent(new ChatImageUrl($"data:{mediaType.Trim()};base64,{data.Trim()}"));
+        return true;
+    }
+
+    return false;
 }
 
 internal static bool TryMapClientRole(string? role, out ChatRole mappedRole)

--- a/src/server/GuideAntsApi/Endpoints/PublishedWire/WireConversationExecutor.cs
+++ b/src/server/GuideAntsApi/Endpoints/PublishedWire/WireConversationExecutor.cs
@@ -35,7 +35,8 @@ internal static async Task<WireConversationStreamHandle> StartConversationStream
     CancellationToken ct,
     Guid? existingConversationId = null,
     IReadOnlyList<ChatMessage>? clientMessages = null,
-    IReadOnlyList<ChatToolDefinition>? clientToolDefinitions = null)
+    IReadOnlyList<ChatToolDefinition>? clientToolDefinitions = null,
+    IReadOnlyList<AttachmentDto>? attachments = null)
 {
     var createdConversation = !existingConversationId.HasValue;
     var conversationId = existingConversationId ??
@@ -45,6 +46,7 @@ internal static async Task<WireConversationStreamHandle> StartConversationStream
     var request = new SendMessageRequest
     {
         Instructions = instructions,
+        Attachments = attachments == null ? null : [.. attachments],
         ClientMessages = clientMessages == null ? null : [.. clientMessages],
         ClientToolDefinitions = clientToolDefinitions == null ? null : [.. clientToolDefinitions]
     };
@@ -86,7 +88,8 @@ internal static async Task<WireConversationResult> ExecuteConversationAsync(
     CancellationToken ct,
     Guid? existingConversationId = null,
     IReadOnlyList<ChatMessage>? clientMessages = null,
-    IReadOnlyList<ChatToolDefinition>? clientToolDefinitions = null)
+    IReadOnlyList<ChatToolDefinition>? clientToolDefinitions = null,
+    IReadOnlyList<AttachmentDto>? attachments = null)
 {
     var streamHandle = await StartConversationStreamAsync(
         publishedConversationService,
@@ -95,7 +98,8 @@ internal static async Task<WireConversationResult> ExecuteConversationAsync(
         ct,
         existingConversationId,
         clientMessages,
-        clientToolDefinitions);
+        clientToolDefinitions,
+        attachments);
 
     var result = await CollectWireConversationResultAsync(streamHandle.Events, db, streamHandle.ConversationId, ct);
     if (streamHandle.CreatedConversation)

--- a/src/server/GuideAntsApi/Endpoints/PublishedWire/WireImageAttachmentMaterializer.cs
+++ b/src/server/GuideAntsApi/Endpoints/PublishedWire/WireImageAttachmentMaterializer.cs
@@ -1,0 +1,180 @@
+using GuideAntsApi.Models.Conversations;
+using GuideAntsApi.Services.Components;
+using Microsoft.AspNetCore.Http;
+
+namespace GuideAntsApi.Endpoints.PublishedWire;
+
+internal static class WireImageAttachmentMaterializer
+{
+    private const string WireAttachmentFolder = "Output/.wire-attachments";
+    private const int MaxRemoteImageBytes = 20 * 1024 * 1024;
+
+    internal static async Task<List<AttachmentDto>> MaterializeAsync(
+        INotebookFileService notebookFileService,
+        Guid projectId,
+        Guid notebookId,
+        IReadOnlyList<string> imageUrls,
+        HttpClient? httpClient = null,
+        CancellationToken cancellationToken = default)
+    {
+        var attachments = new List<AttachmentDto>();
+        if (imageUrls == null || imageUrls.Count == 0)
+        {
+            return attachments;
+        }
+
+        foreach (var rawUrl in imageUrls)
+        {
+            if (string.IsNullOrWhiteSpace(rawUrl))
+            {
+                continue;
+            }
+
+            var (bytes, contentType, extension) = await ResolveImageBytesAsync(
+                rawUrl.Trim(),
+                httpClient,
+                cancellationToken).ConfigureAwait(false);
+            if (bytes == null || bytes.Length == 0)
+            {
+                continue;
+            }
+
+            var fileName = $"wire-image-{Guid.NewGuid():N}.{extension}";
+            await using var memory = new MemoryStream(bytes, writable: false);
+            var formFile = new FormFile(memory, 0, memory.Length, "files", fileName)
+            {
+                Headers = new HeaderDictionary(),
+                ContentType = contentType
+            };
+            var files = new FormFileCollection { formFile };
+            var uploaded = await notebookFileService.UploadFilesAsync(
+                projectId,
+                notebookId,
+                files,
+                WireAttachmentFolder,
+                index: false,
+                forceMarkdownExtraction: false).ConfigureAwait(false);
+
+            foreach (var file in uploaded)
+            {
+                attachments.Add(new AttachmentDto(file.Id, ContentUploadType.ImageFile, file.RelativePath));
+            }
+        }
+
+        return attachments;
+    }
+
+    private static async Task<(byte[]? Bytes, string ContentType, string Extension)> ResolveImageBytesAsync(
+        string imageUrl,
+        HttpClient? httpClient,
+        CancellationToken cancellationToken)
+    {
+        if (imageUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        {
+            return ParseDataUri(imageUrl);
+        }
+
+        if (!Uri.TryCreate(imageUrl, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return (null, "application/octet-stream", "bin");
+        }
+
+        if (httpClient == null)
+        {
+            return (null, "application/octet-stream", "bin");
+        }
+
+        using var response = await httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            return (null, "application/octet-stream", "bin");
+        }
+
+        var contentLength = response.Content.Headers.ContentLength;
+        if (contentLength is > MaxRemoteImageBytes)
+        {
+            return (null, "application/octet-stream", "bin");
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using var buffer = new MemoryStream();
+        var copyBuffer = new byte[81920];
+        long total = 0;
+        int read;
+        while ((read = await stream.ReadAsync(copyBuffer.AsMemory(0, copyBuffer.Length), cancellationToken)
+                   .ConfigureAwait(false)) > 0)
+        {
+            total += read;
+            if (total > MaxRemoteImageBytes)
+            {
+                return (null, "application/octet-stream", "bin");
+            }
+
+            await buffer.WriteAsync(copyBuffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+        }
+
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        var contentType = string.IsNullOrWhiteSpace(mediaType) ? "application/octet-stream" : mediaType;
+        return (buffer.ToArray(), contentType, ExtensionFromContentType(contentType));
+    }
+
+    private static (byte[]? Bytes, string ContentType, string Extension) ParseDataUri(string dataUri)
+    {
+        var commaIndex = dataUri.IndexOf(',');
+        if (commaIndex <= 5)
+        {
+            return (null, "application/octet-stream", "bin");
+        }
+
+        var meta = dataUri[5..commaIndex];
+        var payload = dataUri[(commaIndex + 1)..];
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return (null, "application/octet-stream", "bin");
+        }
+
+        var contentType = "application/octet-stream";
+        var semiIndex = meta.IndexOf(';');
+        if (semiIndex > 0)
+        {
+            contentType = meta[..semiIndex];
+        }
+        else if (!string.IsNullOrWhiteSpace(meta) &&
+                 !meta.Equals("base64", StringComparison.OrdinalIgnoreCase))
+        {
+            contentType = meta;
+        }
+
+        if (!meta.Contains("base64", StringComparison.OrdinalIgnoreCase))
+        {
+            return (null, contentType, ExtensionFromContentType(contentType));
+        }
+
+        try
+        {
+            var bytes = Convert.FromBase64String(payload);
+            return (bytes, contentType, ExtensionFromContentType(contentType));
+        }
+        catch (FormatException)
+        {
+            return (null, contentType, ExtensionFromContentType(contentType));
+        }
+    }
+
+    private static string ExtensionFromContentType(string contentType)
+    {
+        var normalized = contentType.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "image/png" => "png",
+            "image/jpeg" or "image/jpg" => "jpg",
+            "image/gif" => "gif",
+            "image/webp" => "webp",
+            "image/bmp" => "bmp",
+            "image/tiff" => "tiff",
+            _ => "bin"
+        };
+    }
+}

--- a/src/server/GuideAntsApi/Endpoints/SandboxOpenAiWireHandlers.cs
+++ b/src/server/GuideAntsApi/Endpoints/SandboxOpenAiWireHandlers.cs
@@ -52,6 +52,8 @@ public static class SandboxOpenAiWireHandlers
         [FromBody] OpenAiChatCompletionsRequest request,
         [FromServices] ISandboxWireExecutionContextResolver executionContextResolver,
         [FromServices] ISandboxWireConversationService sandboxWireConversationService,
+        [FromServices] INotebookFileService notebookFileService,
+        [FromServices] IHttpClientFactory httpClientFactory,
         [FromServices] ApplicationDbContext db)
     {
         var resolution = await executionContextResolver.ResolveAsync(
@@ -125,12 +127,21 @@ public static class SandboxOpenAiWireHandlers
                     context.NotebookId,
                     httpContext.RequestAborted);
 
+                var attachments = await WireImageAttachmentMaterializer.MaterializeAsync(
+                    notebookFileService,
+                    context.ProjectId,
+                    context.NotebookId,
+                    clientPrompt.UserImageUrls,
+                    httpClientFactory.CreateClient(),
+                    httpContext.RequestAborted);
+
                 var stream = sandboxWireConversationService.SendMessageStreamAsync(
                     context,
                     ephemeralConversationId,
                     new Models.Conversations.SendMessageRequest
                     {
                         Instructions = instructions,
+                        Attachments = attachments.Count == 0 ? null : attachments,
                         ClientMessages = clientPrompt.PrefixMessages == null ? null : [.. clientPrompt.PrefixMessages],
                         ClientToolDefinitions = clientToolDefinitions
                     },
@@ -240,6 +251,8 @@ public static class SandboxOpenAiWireHandlers
         [FromBody] AnthropicMessagesRequest request,
         [FromServices] ISandboxWireExecutionContextResolver executionContextResolver,
         [FromServices] ISandboxWireConversationService sandboxWireConversationService,
+        [FromServices] INotebookFileService notebookFileService,
+        [FromServices] IHttpClientFactory httpClientFactory,
         [FromServices] ApplicationDbContext db)
     {
         var resolution = await executionContextResolver.ResolveAsync(
@@ -314,12 +327,21 @@ public static class SandboxOpenAiWireHandlers
                     context.NotebookId,
                     httpContext.RequestAborted);
 
+                var attachments = await WireImageAttachmentMaterializer.MaterializeAsync(
+                    notebookFileService,
+                    context.ProjectId,
+                    context.NotebookId,
+                    clientPrompt.UserImageUrls,
+                    httpClientFactory.CreateClient(),
+                    httpContext.RequestAborted);
+
                 var stream = sandboxWireConversationService.SendMessageStreamAsync(
                     context,
                     ephemeralConversationId,
                     new Models.Conversations.SendMessageRequest
                     {
                         Instructions = instructions,
+                        Attachments = attachments.Count == 0 ? null : attachments,
                         ClientMessages = clientPrompt.PrefixMessages == null ? null : [.. clientPrompt.PrefixMessages],
                         ClientToolDefinitions = clientToolDefinitions
                     },

--- a/src/server/GuideAntsApi/Services/SandboxWireApi/SandboxWireConversationService.cs
+++ b/src/server/GuideAntsApi/Services/SandboxWireApi/SandboxWireConversationService.cs
@@ -4,6 +4,7 @@ using GuideAntsApi.DataModel;
 using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Models.Conversations;
 using GuideAntsApi.Services.Conversations;
+using GuideAntsApi.Services.Conversations.Attachments;
 using GuideAntsApi.Services.Conversations.Mapping;
 using GuideAntsApi.Services.Conversations.Persistence;
 using GuideAntsApi.Services.Conversations.Streaming;
@@ -38,6 +39,7 @@ public sealed class SandboxWireConversationService : ISandboxWireConversationSer
     private readonly PublishedConversationStreamPolicy _streamPolicy;
     private readonly IConversationStreamEngine _streamEngine;
     private readonly IConversationPersistence _persistence;
+    private readonly IAttachmentContentService _attachmentContentService;
     private readonly IConfiguration? _configuration;
 
     public SandboxWireConversationService(
@@ -48,6 +50,7 @@ public sealed class SandboxWireConversationService : ISandboxWireConversationSer
         PublishedConversationStreamPolicy streamPolicy,
         IConversationStreamEngine streamEngine,
         IConversationPersistence persistence,
+        IAttachmentContentService attachmentContentService,
         IConfiguration? configuration = null)
     {
         _publishedConversationService = publishedConversationService;
@@ -57,6 +60,7 @@ public sealed class SandboxWireConversationService : ISandboxWireConversationSer
         _streamPolicy = streamPolicy;
         _streamEngine = streamEngine;
         _persistence = persistence;
+        _attachmentContentService = attachmentContentService;
         _configuration = configuration;
     }
 
@@ -151,6 +155,29 @@ public sealed class SandboxWireConversationService : ISandboxWireConversationSer
                     AssistantId: runningAssistantId),
                 ct);
             userMessageId = userResult.MessageId;
+
+            if (request.Attachments != null && request.Attachments.Count > 0)
+            {
+                await _attachmentContentService.AddAttachmentsToUserMessageAsync(
+                    db,
+                    userResult.MessageId,
+                    dbConversation.NotebookId,
+                    request.Attachments,
+                    ct);
+                foreach (var attachment in request.Attachments)
+                {
+                    if (!attachment.NotebookFileId.HasValue)
+                    {
+                        continue;
+                    }
+
+                    var messages = await _attachmentContentService.CreateOpenAiMessagesFromNotebookFileAsync(
+                        db,
+                        attachment.NotebookFileId.Value,
+                        ct);
+                    previousMessages.AddRange(messages);
+                }
+            }
         }
 
         var runContext = new ConversationStreamRunContext


### PR DESCRIPTION
Materialize inbound multimodal images on sandbox/published wire; reset sampling to model defaults on model change; keep notebook upload lists scrollable and project files current.