### PR TITLE
Let OpenRouter and Hugging Face rows own thinking control and extra request fields

### DIFF
--- a/docs/model-sampling-policy-regression-fix.md
+++ b/docs/model-sampling-policy-regression-fix.md
@@ -36,6 +36,24 @@ flowchart LR
 
 `BackfillNonLocalModelRowAuthority` copies missing non-local sampling/reasoning fields from linked runtime profiles once, then clears non-local `RuntimeConfigJson` profile pointers.
 
+## Row-Owned Request Shaping (`hf-inference-chat`, `openrouter-chat`)
+
+Both clients also honor the row's `ThinkingControlJson` and `RequestFieldsWhenToolsPresentJson`, projected onto
+`ProviderChatBehavior` by `RoutingChatCompletionClientFactory`:
+
+- **Thinking control** — when the row defines actions for the selected reasoning choice, they replace the client's
+  built-in reasoning mapping (OpenRouter's `reasoning` object, Hugging Face's `reasoning_effort`). This is how a model
+  reaches `chat_template_kwargs.enable_thinking`, which is what actually toggles thinking on Qwen/GLM-style models
+  behind the HF router. Choices the control does not cover keep the built-in mapping.
+- **Extra request fields** — merged into every completion body (`parallel_tool_calls`, `seed`, …). Sampling parameters
+  remain numeric-only, so this is the route for non-numeric body fields. `RuntimeProfileRequestFieldsValidator` accepts
+  **primitives only**; a field whose value is an object (OpenRouter `reasoning`, `provider`) has to go through a
+  `RequestField` thinking action instead. Note the sharp edge: an object value here throws during row parse, and the
+  non-local resolver treats a failed parse as "no behavior", silently dropping the row's thinking control as well.
+
+Both default to `{}` (unconfigured), which leaves request bodies byte-identical to before. Other non-local providers
+build typed request bodies and ignore these columns, so the catalog editor hides the fields for them.
+
 ## Adding a New Compatible Cloud Model
 
 1. Add the catalog row via Settings (or API) with the desired `SamplingParametersJson` / `ReasoningChoicesJson`.

--- a/docs/parameter-surface-test-plan.md
+++ b/docs/parameter-surface-test-plan.md
@@ -268,7 +268,7 @@ Shape names in this plan (`openai_chat_standard`, `anthropic_standard`, etc.) re
 
 | Flow | UI |
 |------|-----|
-| **Catalog edit** (pencil, non-llama) | **Sampling Parameters JSON** + **Reasoning Choices** |
+| **Catalog edit** (pencil, non-llama) | **Sampling Parameters JSON** + **Reasoning Choices**; OpenRouter and HF rows also show optional **Thinking Control JSON** + **Extra Request Fields JSON** |
 | **Catalog edit** (pencil, llama) | Full **Model chat behavior** editor (sampling, reasoning, thinking control, tools fields, combine/pattern) |
 | **Add Model** wizard (cloud) | Same sampling/reasoning fields; model id typeahead may pre-fill from `knownCloudModels.json` |
 | **Add Model** wizard (llama custom HF / attach) | Same model chat behavior editor — no runtime profile control |

--- a/src/client/src/pages/settings/__tests__/parameterSurface.test.ts
+++ b/src/client/src/pages/settings/__tests__/parameterSurface.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { resolveParameterSurfaceSeed } from '../parameterSurfaceSeeds';
-import { normalizeParameterSurface, parseReasoningChoicesJson } from '../parameterSurface';
+import {
+  normalizeParameterSurface,
+  parseReasoningChoicesJson,
+  providerSupportsRowOwnedRequestShaping,
+  validateOptionalJsonObject,
+} from '../parameterSurface';
 
 describe('parameter surface contract', () => {
   it('resolves known cloud model seed shapes without runtime profile pointers', () => {
@@ -25,5 +30,24 @@ describe('parameter surface contract', () => {
       reasoningChoicesJson: '[" high ", "low", "low"]',
     });
     expect(normalized.reasoningChoicesJson).toBe('["high","low"]');
+  });
+
+  it('offers row-owned request shaping only for providers whose clients apply it', () => {
+    expect(providerSupportsRowOwnedRequestShaping('openrouter-chat')).toBe(true);
+    expect(providerSupportsRowOwnedRequestShaping('hf-inference-chat')).toBe(true);
+    expect(providerSupportsRowOwnedRequestShaping('openai-chat')).toBe(false);
+    expect(providerSupportsRowOwnedRequestShaping('anthropic')).toBe(false);
+  });
+
+  it('treats blank behavior json as unconfigured and rejects non-objects', () => {
+    expect(validateOptionalJsonObject('', 'Thinking control JSON')).toBeNull();
+    expect(validateOptionalJsonObject('{}', 'Thinking control JSON')).toBeNull();
+    expect(validateOptionalJsonObject('{"defaultChoice":"none"}', 'Thinking control JSON')).toBeNull();
+    expect(validateOptionalJsonObject('[1,2]', 'Thinking control JSON')).toBe(
+      'Thinking control JSON must be a JSON object.',
+    );
+    expect(validateOptionalJsonObject('{oops', 'Thinking control JSON')).toBe(
+      'Thinking control JSON must be valid JSON.',
+    );
   });
 });

--- a/src/client/src/pages/settings/__tests__/utils.test.ts
+++ b/src/client/src/pages/settings/__tests__/utils.test.ts
@@ -48,6 +48,38 @@ describe('buildAddModelRequest', () => {
     expect(request.install).toBeUndefined();
   });
 
+  it('sends row-owned request shaping for openrouter and omits it elsewhere', () => {
+    const openRouter = createEmptyAddModelWizardState('openrouter-chat');
+    openRouter.catalogModelId = 'qwen/qwen3-32b';
+    openRouter.catalogDisplayName = 'Qwen3 32B';
+    openRouter.thinkingControlJson =
+      '{"defaultChoice":"none","choiceActions":{"none":[{"target":"NestedRequestField","key":"chat_template_kwargs.enable_thinking","value":false}]}}';
+    openRouter.requestFieldsWhenToolsPresentJson = '{"parallel_tool_calls":false}';
+
+    const openRouterRequest = buildAddModelRequest(openRouter);
+    expect(openRouterRequest.providerConfig).toMatchObject({
+      thinkingControlJson: openRouter.thinkingControlJson,
+      requestFieldsWhenToolsPresentJson: '{"parallel_tool_calls":false}',
+    });
+
+    const openAi = createEmptyAddModelWizardState('openai-chat');
+    openAi.catalogModelId = 'gpt-4o-chat';
+    openAi.catalogDisplayName = 'GPT-4o Chat';
+    openAi.thinkingControlJson = '{"defaultChoice":"none","choiceActions":{}}';
+
+    const openAiRequest = buildAddModelRequest(openAi);
+    expect(openAiRequest.providerConfig).not.toHaveProperty('thinkingControlJson');
+  });
+
+  it('rejects malformed behavior json before sending an add-model request', () => {
+    const state = createEmptyAddModelWizardState('hf-inference-chat');
+    state.catalogModelId = 'Qwen/Qwen3-32B';
+    state.catalogDisplayName = 'Qwen3 32B';
+    state.requestFieldsWhenToolsPresentJson = '{not json';
+
+    expect(() => buildAddModelRequest(state)).toThrow('Extra request fields JSON must be valid JSON.');
+  });
+
   it('defaults anthropic add-model state with expected empty fields', () => {
     const state = createEmptyAddModelWizardState('anthropic');
 

--- a/src/client/src/pages/settings/components/catalog/AddModelWizard.tsx
+++ b/src/client/src/pages/settings/components/catalog/AddModelWizard.tsx
@@ -630,9 +630,12 @@ export function AddModelWizard({
           ) : (
             <>
               <NonLocalModelParameterSurfaceEditor
+                provider={value.provider}
                 value={{
                   samplingParametersJson: value.samplingParametersJson,
                   reasoningChoicesJson: value.reasoningChoicesJson,
+                  thinkingControlJson: value.thinkingControlJson,
+                  requestFieldsWhenToolsPresentJson: value.requestFieldsWhenToolsPresentJson,
                 }}
                 onChange={(updates) => setValue((previous) => ({ ...previous, ...updates }))}
               />

--- a/src/client/src/pages/settings/components/catalog/CatalogRowEditModal.tsx
+++ b/src/client/src/pages/settings/components/catalog/CatalogRowEditModal.tsx
@@ -238,9 +238,12 @@ export function CatalogRowEditModal({
             />
           ) : (
             <NonLocalModelParameterSurfaceEditor
+              provider={value.provider}
               value={{
                 samplingParametersJson: value.samplingParametersJson,
                 reasoningChoicesJson: value.reasoningChoicesJson,
+                thinkingControlJson: value.thinkingControlJson,
+                requestFieldsWhenToolsPresentJson: value.requestFieldsWhenToolsPresentJson,
               }}
               onChange={(updates) => setValue((previous) => (previous ? { ...previous, ...updates } : previous))}
             />

--- a/src/client/src/pages/settings/components/catalog/NonLocalModelParameterSurfaceEditor.tsx
+++ b/src/client/src/pages/settings/components/catalog/NonLocalModelParameterSurfaceEditor.tsx
@@ -1,22 +1,38 @@
 import type { NonLocalParameterSurface } from '../../parameterSurface';
 import {
   parseReasoningChoicesJson,
+  providerSupportsRowOwnedRequestShaping,
+  validateOptionalJsonObject,
   validateReasoningChoicesJson,
   validateSamplingParametersJson,
 } from '../../parameterSurface';
 
+export interface NonLocalModelParameterSurfaceValue extends NonLocalParameterSurface {
+  thinkingControlJson: string;
+  requestFieldsWhenToolsPresentJson: string;
+}
+
 interface NonLocalModelParameterSurfaceEditorProps {
-  value: NonLocalParameterSurface;
-  onChange: (updates: Partial<NonLocalParameterSurface>) => void;
+  provider: string;
+  value: NonLocalModelParameterSurfaceValue;
+  onChange: (updates: Partial<NonLocalModelParameterSurfaceValue>) => void;
 }
 
 export function NonLocalModelParameterSurfaceEditor({
+  provider,
   value,
   onChange,
 }: NonLocalModelParameterSurfaceEditorProps) {
   const samplingError = validateSamplingParametersJson(value.samplingParametersJson);
   const reasoningError = validateReasoningChoicesJson(value.reasoningChoicesJson);
   const reasoningChoicesText = parseReasoningChoicesJson(value.reasoningChoicesJson).join(', ');
+  const supportsRequestShaping = providerSupportsRowOwnedRequestShaping(provider);
+  const thinkingError = supportsRequestShaping
+    ? validateOptionalJsonObject(value.thinkingControlJson, 'Thinking control JSON')
+    : null;
+  const requestFieldsError = supportsRequestShaping
+    ? validateOptionalJsonObject(value.requestFieldsWhenToolsPresentJson, 'Extra request fields JSON')
+    : null;
 
   return (
     <div className="space-y-4">
@@ -64,6 +80,61 @@ export function NonLocalModelParameterSurfaceEditor({
         </p>
         {reasoningError ? <p className="text-xs text-red-700">{reasoningError}</p> : null}
       </div>
+
+      {supportsRequestShaping ? (
+        <>
+          <div className="space-y-2">
+            <label className="block text-xs font-medium uppercase tracking-wide text-gray-600">
+              Thinking Control JSON
+            </label>
+            <p className="text-xs text-gray-600">
+              Optional. Maps each reasoning choice to request fields for models this provider does not
+              normalize — for example{' '}
+              <code className="font-mono">chat_template_kwargs.enable_thinking</code> via a{' '}
+              <code className="font-mono">NestedRequestField</code> action. Leave <code className="font-mono">{'{}'}</code>{' '}
+              to use the provider default reasoning mapping.
+            </p>
+            <textarea
+              value={value.thinkingControlJson}
+              onChange={(event) => onChange({ thinkingControlJson: event.target.value })}
+              rows={6}
+              spellCheck={false}
+              className={`w-full rounded border px-3 py-2 font-mono text-xs text-gray-900 focus:outline-none focus:ring-1 ${
+                thinkingError
+                  ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                  : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500'
+              }`}
+            />
+            {thinkingError ? <p className="text-xs text-red-700">{thinkingError}</p> : null}
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-xs font-medium uppercase tracking-wide text-gray-600">
+              Extra Request Fields JSON
+            </label>
+            <p className="text-xs text-gray-600">
+              Optional. Additional request body fields merged into every completion for this model (for
+              example <code className="font-mono">{'{"parallel_tool_calls": false}'}</code>).{' '}
+              <strong>Primitive values only</strong> — booleans, numbers, strings, null. For a field
+              whose value is an object (such as OpenRouter{' '}
+              <code className="font-mono">reasoning</code>), use a{' '}
+              <code className="font-mono">RequestField</code> action in Thinking Control JSON instead.
+            </p>
+            <textarea
+              value={value.requestFieldsWhenToolsPresentJson}
+              onChange={(event) => onChange({ requestFieldsWhenToolsPresentJson: event.target.value })}
+              rows={3}
+              spellCheck={false}
+              className={`w-full rounded border px-3 py-2 font-mono text-xs text-gray-900 focus:outline-none focus:ring-1 ${
+                requestFieldsError
+                  ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                  : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500'
+              }`}
+            />
+            {requestFieldsError ? <p className="text-xs text-red-700">{requestFieldsError}</p> : null}
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/src/client/src/pages/settings/parameterSurface.ts
+++ b/src/client/src/pages/settings/parameterSurface.ts
@@ -85,6 +85,34 @@ export function validateReasoningChoicesJson(json: string): string | null {
   }
 }
 
+/**
+ * Providers whose chat clients honor row-owned request shaping (ThinkingControlJson and
+ * RequestFieldsWhenToolsPresentJson). The other non-local clients build their request bodies
+ * from typed shapes and ignore those columns, so the editor does not offer them there.
+ */
+const ROW_OWNED_REQUEST_SHAPING_PROVIDERS = new Set(['hf-inference-chat', 'openrouter-chat']);
+
+export function providerSupportsRowOwnedRequestShaping(provider: string): boolean {
+  return ROW_OWNED_REQUEST_SHAPING_PROVIDERS.has(provider.trim().toLowerCase());
+}
+
+/** Validates an optional JSON-object field: blank and `{}` both mean "not configured". */
+export function validateOptionalJsonObject(json: string, label: string): string | null {
+  const trimmed = json.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return `${label} must be a JSON object.`;
+    }
+    return null;
+  } catch {
+    return `${label} must be valid JSON.`;
+  }
+}
+
 export function normalizeParameterSurface(surface: NonLocalParameterSurface): NonLocalParameterSurface {
   const samplingError = validateSamplingParametersJson(surface.samplingParametersJson);
   if (samplingError) {

--- a/src/client/src/pages/settings/utils.ts
+++ b/src/client/src/pages/settings/utils.ts
@@ -18,7 +18,11 @@ import {
   CanonicalLocalRuntimeConfig,
   CatalogEditState,
 } from './types';
-import { normalizeParameterSurface } from './parameterSurface';
+import {
+  normalizeParameterSurface,
+  providerSupportsRowOwnedRequestShaping,
+  validateOptionalJsonObject,
+} from './parameterSurface';
 import { getServiceProviderDisplayName } from './constants/displayLabels';
 import {
   buildLocalModelAddModelRequest,
@@ -314,6 +318,16 @@ export function createCatalogEditStateFromModel(model: SettingsModelDto): Catalo
   };
 }
 
+/** Returns the trimmed JSON object, or undefined when the field is blank or an empty object. */
+function normalizeBehaviorJson(json: string, label: string): string | undefined {
+  const error = validateOptionalJsonObject(json, label);
+  if (error) {
+    throw new Error(error);
+  }
+  const trimmed = json.trim();
+  return trimmed.length === 0 || trimmed === '{}' ? undefined : trimmed;
+}
+
 export function buildAddModelRequest(state: AddModelWizardState): AddModelRequest {
   const provider = state.provider.trim();
   if (!provider) {
@@ -342,6 +356,19 @@ export function buildAddModelRequest(state: AddModelWizardState): AddModelReques
   };
   if (parameterSurface.reasoningChoicesJson) {
     providerConfig.reasoningChoicesJson = parameterSurface.reasoningChoicesJson;
+  }
+  if (providerSupportsRowOwnedRequestShaping(provider)) {
+    const thinkingControlJson = normalizeBehaviorJson(state.thinkingControlJson, 'Thinking control JSON');
+    if (thinkingControlJson) {
+      providerConfig.thinkingControlJson = thinkingControlJson;
+    }
+    const requestFieldsJson = normalizeBehaviorJson(
+      state.requestFieldsWhenToolsPresentJson,
+      'Extra request fields JSON',
+    );
+    if (requestFieldsJson) {
+      providerConfig.requestFieldsWhenToolsPresentJson = requestFieldsJson;
+    }
   }
   return {
     provider,
@@ -399,8 +426,9 @@ export function buildCatalogEditRequest(
     combineSystemAndDeveloperMessages: state.combineSystemAndDeveloperMessages,
     thoughtBlockPattern: normalizeOptionalString(state.thoughtBlockPattern),
     samplingParametersJson: parameterSurface.samplingParametersJson,
-    thinkingControlJson: state.thinkingControlJson.trim() || '{}',
-    requestFieldsWhenToolsPresentJson: state.requestFieldsWhenToolsPresentJson.trim() || '{}',
+    thinkingControlJson: normalizeBehaviorJson(state.thinkingControlJson, 'Thinking control JSON') ?? '{}',
+    requestFieldsWhenToolsPresentJson:
+      normalizeBehaviorJson(state.requestFieldsWhenToolsPresentJson, 'Extra request fields JSON') ?? '{}',
     isActive: state.isActive,
     displayOrder: normalizeDisplayOrder(state.displayOrder),
   };

--- a/src/server/AntRunner.Chat/AntRunner.Chat.Abstractions/ProviderChatBehavior.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.Abstractions/ProviderChatBehavior.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace AntRunner.Chat.Abstractions;
+
+/// <summary>
+/// Where a <see cref="ProviderChatBehaviorAction"/> writes its value.
+/// Mirrors the llama.cpp thinking-control targets so a catalog row means the same
+/// thing on every provider that honors model-owned chat behavior.
+/// </summary>
+public enum ProviderChatBehaviorActionTarget
+{
+    /// <summary>Top-level request body field, e.g. <c>reasoning_effort</c>.</summary>
+    RequestField,
+
+    /// <summary>Dotted path into a nested object, e.g. <c>chat_template_kwargs.enable_thinking</c>.</summary>
+    NestedRequestField,
+
+    /// <summary>Text prepended to the first system message (or a new one when absent).</summary>
+    SystemMessagePrefix
+}
+
+public sealed record ProviderChatBehaviorAction(
+    ProviderChatBehaviorActionTarget Target,
+    string Key,
+    object? Value);
+
+public sealed record ProviderThinkingControl(
+    string? DefaultChoice,
+    IReadOnlyDictionary<string, IReadOnlyList<ProviderChatBehaviorAction>> ChoiceActions);
+
+/// <summary>
+/// Model-row owned request shaping for OpenAI-compatible providers that do not
+/// normalize reasoning themselves (Hugging Face router) or expose vendor-specific
+/// body fields the typed request shape does not carry (OpenRouter <c>provider</c>,
+/// <c>parallel_tool_calls</c>, …).
+/// </summary>
+public sealed record ProviderChatBehavior(
+    ProviderThinkingControl? ThinkingControl = null,
+    IReadOnlyDictionary<string, JsonElement>? ExtraRequestFields = null)
+{
+    public bool HasExtraRequestFields => ExtraRequestFields is { Count: > 0 };
+
+    public bool HasThinkingControl => ThinkingControl?.ChoiceActions is { Count: > 0 };
+}
+
+/// <summary>
+/// Applies <see cref="ProviderChatBehavior"/> to an already-serialized request body.
+/// Provider clients keep their typed payload records and hand the serialized object
+/// here so row-owned fields can override or extend anything in the body.
+/// </summary>
+public static class ProviderChatBehaviorApplier
+{
+    /// <summary>
+    /// Merges extra request fields into <paramref name="body"/>. Row-owned keys win over
+    /// whatever the typed payload produced.
+    /// </summary>
+    public static void ApplyExtraRequestFields(JsonObject body, ProviderChatBehavior? behavior)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        if (behavior?.ExtraRequestFields is not { Count: > 0 } fields)
+        {
+            return;
+        }
+
+        foreach (var (key, value) in fields)
+        {
+            body[key] = JsonNode.Parse(value.GetRawText());
+        }
+    }
+
+    /// <summary>
+    /// Resolves the thinking-control actions for <paramref name="reasoningEffort"/>, falling back to
+    /// the configured default choice. Returns <c>null</c> when the row configures nothing for that
+    /// choice, which leaves the caller's built-in reasoning mapping in place — non-local rows list
+    /// their reasoning choices separately and may offer choices the control does not cover.
+    /// </summary>
+    public static IReadOnlyList<ProviderChatBehaviorAction>? ResolveThinkingActions(
+        ProviderChatBehavior? behavior,
+        string? reasoningEffort)
+    {
+        if (behavior?.ThinkingControl?.ChoiceActions is not { Count: > 0 } choiceActions)
+        {
+            return null;
+        }
+
+        var choice = string.IsNullOrWhiteSpace(reasoningEffort)
+            ? behavior.ThinkingControl.DefaultChoice
+            : reasoningEffort;
+        if (string.IsNullOrWhiteSpace(choice))
+        {
+            return null;
+        }
+
+        var matchingKey = choiceActions.Keys
+            .FirstOrDefault(key => string.Equals(key, choice, StringComparison.OrdinalIgnoreCase));
+        return matchingKey != null && choiceActions.TryGetValue(matchingKey, out var actions)
+            ? actions
+            : null;
+    }
+
+    /// <summary>
+    /// Writes resolved thinking-control actions into the request body. The caller is expected to
+    /// clear its own reasoning fields first so a configured row is the single authority.
+    /// </summary>
+    public static void ApplyThinkingActions(
+        JsonObject body,
+        JsonArray? messages,
+        IReadOnlyList<ProviderChatBehaviorAction> actions)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        ArgumentNullException.ThrowIfNull(actions);
+
+        foreach (var action in actions)
+        {
+            switch (action.Target)
+            {
+                case ProviderChatBehaviorActionTarget.RequestField:
+                    body[action.Key] = ToJsonNode(action.Value);
+                    break;
+                case ProviderChatBehaviorActionTarget.NestedRequestField:
+                    SetNestedField(body, action.Key, action.Value);
+                    break;
+                case ProviderChatBehaviorActionTarget.SystemMessagePrefix:
+                    PrependToSystemMessage(messages, ToText(action.Value));
+                    break;
+            }
+        }
+    }
+
+    private static void SetNestedField(JsonObject body, string dottedKey, object? value)
+    {
+        var segments = dottedKey.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            return;
+        }
+
+        var current = body;
+        for (var index = 0; index < segments.Length - 1; index++)
+        {
+            if (current[segments[index]] is not JsonObject child)
+            {
+                child = new JsonObject();
+                current[segments[index]] = child;
+            }
+
+            current = child;
+        }
+
+        current[segments[^1]] = ToJsonNode(value);
+    }
+
+    private static void PrependToSystemMessage(JsonArray? messages, string prefix)
+    {
+        if (messages == null || prefix.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var message in messages)
+        {
+            if (message is not JsonObject messageObject)
+            {
+                continue;
+            }
+
+            var role = messageObject["role"]?.GetValue<string>();
+            if (!string.Equals(role, "system", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(role, "developer", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (messageObject["content"] is JsonValue content && content.TryGetValue<string>(out var text))
+            {
+                messageObject["content"] = $"{prefix}\n\n{text}";
+                return;
+            }
+        }
+
+        messages.Insert(0, new JsonObject
+        {
+            ["role"] = "system",
+            ["content"] = prefix
+        });
+    }
+
+    private static string ToText(object? value) => value switch
+    {
+        null => string.Empty,
+        JsonElement { ValueKind: JsonValueKind.String } element => element.GetString() ?? string.Empty,
+        JsonElement element => element.GetRawText(),
+        _ => value.ToString() ?? string.Empty
+    };
+
+    private static JsonNode? ToJsonNode(object? value) => value switch
+    {
+        null => null,
+        JsonElement element => JsonNode.Parse(element.GetRawText()),
+        JsonNode node => node.DeepClone(),
+        bool boolean => JsonValue.Create(boolean),
+        string text => JsonValue.Create(text),
+        int integer => JsonValue.Create(integer),
+        long longValue => JsonValue.Create(longValue),
+        double doubleValue => JsonValue.Create(doubleValue),
+        decimal decimalValue => JsonValue.Create(decimalValue),
+        _ => JsonValue.Create(value.ToString())
+    };
+}

--- a/src/server/AntRunner.Chat/AntRunner.Chat.HuggingFace/HuggingFaceChatClient.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.HuggingFace/HuggingFaceChatClient.cs
@@ -21,6 +21,7 @@ public sealed class HuggingFaceChatClient : IChatCompletionClient
     private readonly HttpClient _httpClient;
     private readonly HuggingFaceChatConfig _config;
     private readonly string? _defaultModel;
+    private readonly ProviderChatBehavior? _behavior;
     private readonly ILogger<HuggingFaceChatClient> _logger;
 
     public bool SupportsToolChoiceNone => false;
@@ -29,11 +30,13 @@ public sealed class HuggingFaceChatClient : IChatCompletionClient
         HttpClient httpClient,
         HuggingFaceChatConfig config,
         string? defaultModel,
-        ILogger<HuggingFaceChatClient>? logger = null)
+        ILogger<HuggingFaceChatClient>? logger = null,
+        ProviderChatBehavior? behavior = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _defaultModel = defaultModel;
+        _behavior = behavior;
         _logger = logger ?? NullLogger<HuggingFaceChatClient>.Instance;
     }
 
@@ -41,8 +44,7 @@ public sealed class HuggingFaceChatClient : IChatCompletionClient
         ChatCompletionRequest request,
         CancellationToken cancellationToken = default)
     {
-        var payload = CreatePayloadOrThrow(request, stream: false);
-        using var message = CreateRequestMessage(payload);
+        using var message = CreateRequestMessage(CreateRequestBodyOrThrow(request, stream: false));
         using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
@@ -65,8 +67,7 @@ public sealed class HuggingFaceChatClient : IChatCompletionClient
         Action<ChatCompletionChunk> onChunk,
         CancellationToken cancellationToken = default)
     {
-        var payload = CreatePayloadOrThrow(request, stream: true);
-        using var message = CreateRequestMessage(payload);
+        using var message = CreateRequestMessage(CreateRequestBodyOrThrow(request, stream: true));
         using var response = await _httpClient.SendAsync(
             message,
             HttpCompletionOption.ResponseHeadersRead,
@@ -124,7 +125,7 @@ public sealed class HuggingFaceChatClient : IChatCompletionClient
         return accumulator.ToResponse();
     }
 
-    private HttpRequestMessage CreateRequestMessage(HuggingFaceChatRequest payload)
+    private HttpRequestMessage CreateRequestMessage(JsonObject body)
     {
         if (string.IsNullOrWhiteSpace(_config.Token))
         {
@@ -134,7 +135,7 @@ public sealed class HuggingFaceChatClient : IChatCompletionClient
         var endpoint = $"{(_config.RouterBaseUrl ?? "https://router.huggingface.co/v1").TrimEnd('/')}/chat/completions";
         var message = new HttpRequestMessage(HttpMethod.Post, endpoint)
         {
-            Content = new StringContent(JsonSerializer.Serialize(payload, SerializerOptions), Encoding.UTF8, "application/json")
+            Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json")
         };
         message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.Token);
         return message;
@@ -149,6 +150,31 @@ public sealed class HuggingFaceChatClient : IChatCompletionClient
         }
 
         return model;
+    }
+
+    /// <summary>
+    /// Maps the typed payload, then lets the model row's chat behavior override it. The router
+    /// forwards unknown body fields to the upstream provider, so this is how a model reaches
+    /// controls the OpenAI-compatible shape has no slot for — most importantly
+    /// <c>chat_template_kwargs.enable_thinking</c>, which is what actually toggles thinking on
+    /// Qwen/GLM-style models; <c>reasoning_effort</c> alone is silently ignored by most providers.
+    /// </summary>
+    private JsonObject CreateRequestBodyOrThrow(ChatCompletionRequest request, bool stream)
+    {
+        var payload = CreatePayloadOrThrow(request, stream);
+        var body = JsonSerializer.SerializeToNode(payload, SerializerOptions)?.AsObject()
+            ?? throw new InvalidOperationException("Hugging Face chat request payload could not be serialized.");
+
+        ProviderChatBehaviorApplier.ApplyExtraRequestFields(body, _behavior);
+
+        var thinkingActions = ProviderChatBehaviorApplier.ResolveThinkingActions(_behavior, request.ReasoningEffort);
+        if (thinkingActions != null)
+        {
+            body.Remove("reasoning_effort");
+            ProviderChatBehaviorApplier.ApplyThinkingActions(body, body["messages"] as JsonArray, thinkingActions);
+        }
+
+        return body;
     }
 
     private HuggingFaceChatRequest CreatePayloadOrThrow(ChatCompletionRequest request, bool stream)

--- a/src/server/AntRunner.Chat/AntRunner.Chat.HuggingFace/HuggingFaceChatClientFactory.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.HuggingFace/HuggingFaceChatClientFactory.cs
@@ -26,7 +26,17 @@ public sealed class HuggingFaceChatClientFactory : IChatCompletionClientFactory
 
     public string? DefaultDeploymentId => null;
 
-    public IChatCompletionClient CreateClient(string? deploymentId, HttpClient? httpClient = null)
+    public IChatCompletionClient CreateClient(string? deploymentId, HttpClient? httpClient = null) =>
+        CreateClientForBehavior(deploymentId, behavior: null, httpClient);
+
+    /// <summary>
+    /// Creates a client bound to the catalog row's model-owned chat behavior
+    /// (thinking control and extra request fields).
+    /// </summary>
+    public IChatCompletionClient CreateClientForBehavior(
+        string? deploymentId,
+        ProviderChatBehavior? behavior,
+        HttpClient? httpClient = null)
     {
         var resolvedConfig = _configAccessor?.Invoke()
             ?? _config
@@ -35,6 +45,7 @@ public sealed class HuggingFaceChatClientFactory : IChatCompletionClientFactory
             httpClient ?? _httpClientFactory.CreateClient(),
             resolvedConfig,
             deploymentId,
-            _logger);
+            _logger,
+            behavior);
     }
 }

--- a/src/server/AntRunner.Chat/AntRunner.Chat.OpenRouter/OpenRouterChatClient.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.OpenRouter/OpenRouterChatClient.cs
@@ -21,6 +21,7 @@ public sealed class OpenRouterChatClient : IChatCompletionClient
     private readonly HttpClient _httpClient;
     private readonly OpenRouterChatConfig _config;
     private readonly string? _defaultModel;
+    private readonly ProviderChatBehavior? _behavior;
     private readonly ILogger<OpenRouterChatClient> _logger;
 
     public bool SupportsToolChoiceNone => true;
@@ -29,11 +30,13 @@ public sealed class OpenRouterChatClient : IChatCompletionClient
         HttpClient httpClient,
         OpenRouterChatConfig config,
         string? defaultModel,
-        ILogger<OpenRouterChatClient>? logger = null)
+        ILogger<OpenRouterChatClient>? logger = null,
+        ProviderChatBehavior? behavior = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _defaultModel = defaultModel;
+        _behavior = behavior;
         _logger = logger ?? NullLogger<OpenRouterChatClient>.Instance;
     }
 
@@ -41,8 +44,7 @@ public sealed class OpenRouterChatClient : IChatCompletionClient
         ChatCompletionRequest request,
         CancellationToken cancellationToken = default)
     {
-        var payload = OpenRouterRequestMapper.ToRequest(request, ResolveModel(request), stream: false);
-        using var message = CreateRequestMessage(payload);
+        using var message = CreateRequestMessage(BuildRequestBody(request, stream: false));
         using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
@@ -61,8 +63,7 @@ public sealed class OpenRouterChatClient : IChatCompletionClient
         Action<ChatCompletionChunk> onChunk,
         CancellationToken cancellationToken = default)
     {
-        var payload = OpenRouterRequestMapper.ToRequest(request, ResolveModel(request), stream: true);
-        using var message = CreateRequestMessage(payload);
+        using var message = CreateRequestMessage(BuildRequestBody(request, stream: true));
         using var response = await _httpClient.SendAsync(
             message,
             HttpCompletionOption.ResponseHeadersRead,
@@ -116,7 +117,32 @@ public sealed class OpenRouterChatClient : IChatCompletionClient
         return accumulator.ToResponse();
     }
 
-    private HttpRequestMessage CreateRequestMessage(OpenRouterChatRequest payload)
+    /// <summary>
+    /// Serializes the typed payload, then lets the model row's chat behavior override it.
+    /// Row-owned thinking control replaces the built-in reasoning mapping entirely, so a model
+    /// that needs something other than OpenRouter's normalized <c>reasoning</c> object (nested
+    /// <c>chat_template_kwargs</c>, a bare <c>reasoning_effort</c>, a system prefix) can say so.
+    /// </summary>
+    private JsonObject BuildRequestBody(ChatCompletionRequest request, bool stream)
+    {
+        var payload = OpenRouterRequestMapper.ToRequest(request, ResolveModel(request), stream);
+        var body = JsonSerializer.SerializeToNode(payload, SerializerOptions)?.AsObject()
+            ?? throw new InvalidOperationException("OpenRouter chat request payload could not be serialized.");
+
+        ProviderChatBehaviorApplier.ApplyExtraRequestFields(body, _behavior);
+
+        var thinkingActions = ProviderChatBehaviorApplier.ResolveThinkingActions(_behavior, request.ReasoningEffort);
+        if (thinkingActions != null)
+        {
+            body.Remove("reasoning");
+            body.Remove("reasoning_effort");
+            ProviderChatBehaviorApplier.ApplyThinkingActions(body, body["messages"] as JsonArray, thinkingActions);
+        }
+
+        return body;
+    }
+
+    private HttpRequestMessage CreateRequestMessage(JsonObject body)
     {
         if (string.IsNullOrWhiteSpace(_config.ApiKey))
         {
@@ -126,7 +152,7 @@ public sealed class OpenRouterChatClient : IChatCompletionClient
         var endpoint = $"{(_config.BaseUrl ?? "https://openrouter.ai/api/v1").TrimEnd('/')}/chat/completions";
         var message = new HttpRequestMessage(HttpMethod.Post, endpoint)
         {
-            Content = new StringContent(JsonSerializer.Serialize(payload, SerializerOptions), Encoding.UTF8, "application/json")
+            Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json")
         };
         message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.ApiKey);
         OpenRouterAttribution.Apply(message);

--- a/src/server/AntRunner.Chat/AntRunner.Chat.OpenRouter/OpenRouterChatClientFactory.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.OpenRouter/OpenRouterChatClientFactory.cs
@@ -26,7 +26,17 @@ public sealed class OpenRouterChatClientFactory : IChatCompletionClientFactory
 
     public string? DefaultDeploymentId => null;
 
-    public IChatCompletionClient CreateClient(string? deploymentId, HttpClient? httpClient = null)
+    public IChatCompletionClient CreateClient(string? deploymentId, HttpClient? httpClient = null) =>
+        CreateClientForBehavior(deploymentId, behavior: null, httpClient);
+
+    /// <summary>
+    /// Creates a client bound to the catalog row's model-owned chat behavior
+    /// (thinking control and extra request fields).
+    /// </summary>
+    public IChatCompletionClient CreateClientForBehavior(
+        string? deploymentId,
+        ProviderChatBehavior? behavior,
+        HttpClient? httpClient = null)
     {
         var resolvedConfig = _configAccessor?.Invoke()
             ?? _config
@@ -35,6 +45,7 @@ public sealed class OpenRouterChatClientFactory : IChatCompletionClientFactory
             httpClient ?? _httpClientFactory.CreateClient(),
             resolvedConfig,
             deploymentId,
-            _logger);
+            _logger,
+            behavior);
     }
 }

--- a/src/server/AntRunner.Chat/AntRunner.Chat/ThreadRun.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat/ThreadRun.cs
@@ -388,6 +388,15 @@ namespace AntRunner.Chat
             var resolvedModelId = options.ExecutionPolicy.ModelId;
             var resolvedParameterBag = ResolveExecutionParameters(options.ExecutionPolicy);
             var requestedReasoningEffort = TryGetStringParameter(resolvedParameterBag, "reasoning_effort");
+            // A guide using its own model takes the Direct/EmptyParameters branch in ChatModelResolver,
+            // so the execution-policy bag carries no reasoning_effort. Fall back to the assistant/guide's
+            // own persisted ReasoningEffort so the per-guide setting is honored -- without this the
+            // request carries no effort and a model row's ThinkingControlJson defaultChoice wins every
+            // turn. A global override (ChatDefaults) still wins because it populates the bag above.
+            if (string.IsNullOrWhiteSpace(requestedReasoningEffort))
+            {
+                requestedReasoningEffort = assistantDef.ReasoningEffort;
+            }
             var reasoningEffortParam = await ResolveReasoningEffortAsync(
                 resolvedModelId,
                 requestedReasoningEffort,

--- a/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/DatabaseStorage.cs
+++ b/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/DatabaseStorage.cs
@@ -251,17 +251,52 @@ namespace AntRunner.ToolCalling.AssistantDefinitions.Storage
             }
         }
 
+        private static bool HasRuntimeProfile(string? runtimeConfigJson)
+        {
+            if (string.IsNullOrWhiteSpace(runtimeConfigJson))
+            {
+                return false;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(runtimeConfigJson);
+                return doc.RootElement.TryGetProperty("runtimeProfileId", out var value)
+                    && value.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(value.GetString());
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         /// <summary>
         /// Materializes a database Assistant entity to AssistantStorageMetadata format.
         /// </summary>
         private static AssistantStorageMetadata MaterializeAssistant(Assistant assistant)
         {
+            // Project the guide's persisted reasoning effort into the manifest so it reaches
+            // AssistantDefinition and, via ThreadRun's Direct/EmptyParameters fallback, the outgoing
+            // request. Without it a guide that references its own model sends no reasoning effort at
+            // all, and a model row whose ThinkingControlJson declares a defaultChoice would apply
+            // that default on every turn regardless of the guide's selection.
+            // Suppressed (left null, then omitted by WhenWritingNull) when an explicit
+            // SamplingParametersJson bag or a cloud runtime profile already governs this model's
+            // parameters -- those paths carry their own reasoning handling.
+            var hasSamplingBag = !string.IsNullOrWhiteSpace(assistant.SamplingParametersJson);
+            var hasCloudRuntimeProfile = HasRuntimeProfile(assistant.Model?.RuntimeConfigJson);
+            var projectedReasoningEffort = hasSamplingBag || hasCloudRuntimeProfile
+                ? null
+                : assistant.ReasoningEffort;
+
             // Build the manifest JSON
             var manifest = new
             {
                 name = assistant.Name,
                 description = assistant.Description,
                 model = assistant.ModelId ?? assistant.Model?.ModelId,
+                reasoning_effort = projectedReasoningEffort,
                 invocation_evaluator = assistant.InvocationEvaluator,
                 max_tool_calls_per_turn = assistant.MaxToolCallsPerTurn,
                 tools = BuildToolsArray(assistant),

--- a/src/server/GuideAntsApi.Tests/Services/LlamaCpp/ModelOwnedChatBehaviorTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/LlamaCpp/ModelOwnedChatBehaviorTests.cs
@@ -43,9 +43,9 @@ public sealed class ModelOwnedChatBehaviorTests
         var resolver = new ChatTargetResolver(new TestServiceScopeFactory(db));
         var target = resolver.Resolve("qwen-local");
 
-        target.LlamaChatBehavior.Should().NotBeNull();
-        target.LlamaChatBehavior!.ThinkingControl.ChoiceActions.Should().ContainKeys("none", "medium");
-        target.LlamaChatBehavior.ThoughtBlockPattern.Should().Be("<think>");
+        target.ChatBehavior.Should().NotBeNull();
+        target.ChatBehavior!.ThinkingControl.ChoiceActions.Should().ContainKeys("none", "medium");
+        target.ChatBehavior.ThoughtBlockPattern.Should().Be("<think>");
     }
 
     [TestMethod]

--- a/src/server/GuideAntsApi.Tests/Services/Providers/ProviderChatBehaviorTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Providers/ProviderChatBehaviorTests.cs
@@ -438,6 +438,65 @@ public sealed class ProviderChatBehaviorTests
     }
 
     /// <summary>
+    /// Same row-columns path for Hugging Face, where thinking control is the only mechanism that
+    /// exists: the built-in mapping is a bare <c>reasoning_effort</c> the router's providers ignore,
+    /// so <c>chat_template_kwargs.enable_thinking</c> is reachable only as a nested action.
+    /// </summary>
+    [TestMethod]
+    public async Task HuggingFaceRowConfig_TogglesEnableThinkingPerChoice()
+    {
+        const string thinkingControlJson = """
+            {
+              "defaultChoice": "none",
+              "choiceActions": {
+                "none":    [{ "target": "NestedRequestField", "key": "chat_template_kwargs.enable_thinking", "value": false }],
+                "enabled": [{ "target": "NestedRequestField", "key": "chat_template_kwargs.enable_thinking", "value": true }]
+              }
+            }
+            """;
+        var behavior = GuideAntsApi.Services.Conversations.RoutingChatCompletionClientFactory.ToProviderChatBehavior(
+            GuideAntsApi.Services.LlamaCpp.RuntimeProfileDataJson.FromJsonStrings(
+                "Qwen/Qwen3-32B",
+                combineSystemAndDeveloperMessages: true,
+                thoughtBlockPattern: null,
+                samplingParametersJson: "{}",
+                thinkingControlJson: thinkingControlJson,
+                requestFieldsWhenToolsPresentJson: "{}"));
+
+        var handler = new CapturingHandler(_ => JsonResponse(HuggingFaceTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new HuggingFaceChatClient(
+            httpClient,
+            new HuggingFaceChatConfig { Token = "t" },
+            "Qwen/Qwen3-32B",
+            logger: null,
+            behavior: behavior);
+
+        // No effort selected: the row's defaultChoice disables thinking.
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null));
+        using (var json = JsonDocument.Parse(handler.LastRequestBody))
+        {
+            json.RootElement.GetProperty("chat_template_kwargs").GetProperty("enable_thinking").GetBoolean()
+                .Should().BeFalse();
+            json.RootElement.TryGetProperty("reasoning_effort", out _).Should().BeFalse();
+        }
+
+        // A guide selecting "enabled" must reach the wire as the opposite kwarg.
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null,
+            reasoningEffort: "enabled"));
+        using (var json = JsonDocument.Parse(handler.LastRequestBody))
+        {
+            json.RootElement.GetProperty("chat_template_kwargs").GetProperty("enable_thinking").GetBoolean()
+                .Should().BeTrue();
+            json.RootElement.TryGetProperty("reasoning_effort", out _).Should().BeFalse();
+        }
+    }
+
+    /// <summary>
     /// The extra-request-fields column rejects object values (llama-era
     /// <see cref="GuideAntsApi.Services.LlamaCpp.RuntimeProfileRequestFieldsValidator"/> rule), and the
     /// non-local resolver treats a failed parse as "no behavior" — so an object there silently drops the

--- a/src/server/GuideAntsApi.Tests/Services/Providers/ProviderChatBehaviorTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Providers/ProviderChatBehaviorTests.cs
@@ -1,0 +1,508 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AntRunner.Chat.Abstractions;
+using AntRunner.Chat.HuggingFace;
+using AntRunner.Chat.OpenRouter;
+using FluentAssertions;
+
+namespace GuideAntsApi.Tests.Services.Providers;
+
+/// <summary>
+/// Row-owned chat behavior (ThinkingControlJson / RequestFieldsWhenToolsPresentJson) applied by the
+/// OpenAI-compatible providers. Without it, Hugging Face can only send <c>reasoning_effort</c> — which
+/// most routed providers ignore — and neither client can reach vendor body fields.
+/// </summary>
+[TestClass]
+public sealed class ProviderChatBehaviorTests
+{
+    private static ProviderChatBehavior EnableThinkingBehavior() => new(
+        new ProviderThinkingControl(
+            DefaultChoice: "enabled",
+            ChoiceActions: new Dictionary<string, IReadOnlyList<ProviderChatBehaviorAction>>(StringComparer.Ordinal)
+            {
+                ["none"] =
+                [
+                    new ProviderChatBehaviorAction(
+                        ProviderChatBehaviorActionTarget.NestedRequestField,
+                        "chat_template_kwargs.enable_thinking",
+                        false)
+                ],
+                ["high"] =
+                [
+                    new ProviderChatBehaviorAction(
+                        ProviderChatBehaviorActionTarget.NestedRequestField,
+                        "chat_template_kwargs.enable_thinking",
+                        true),
+                    new ProviderChatBehaviorAction(
+                        ProviderChatBehaviorActionTarget.RequestField,
+                        "reasoning_effort",
+                        "high")
+                ]
+            }));
+
+    private static ProviderChatBehavior ExtraFieldsBehavior(string json) => new(
+        ThinkingControl: null,
+        ExtraRequestFields: JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json)!);
+
+    [TestMethod]
+    public async Task HuggingFace_AppliesNestedThinkingControl_AndDropsReasoningEffort()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(HuggingFaceTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new HuggingFaceChatClient(
+            httpClient,
+            new HuggingFaceChatConfig { Token = "t" },
+            "Qwen/Qwen3-32B",
+            logger: null,
+            behavior: EnableThinkingBehavior());
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null,
+            reasoningEffort: "none"));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        json.RootElement.GetProperty("chat_template_kwargs").GetProperty("enable_thinking").GetBoolean()
+            .Should().BeFalse();
+        json.RootElement.TryGetProperty("reasoning_effort", out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task HuggingFace_ThinkingControlActions_CanSetReasoningEffortThemselves()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(HuggingFaceTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new HuggingFaceChatClient(
+            httpClient,
+            new HuggingFaceChatConfig { Token = "t" },
+            "Qwen/Qwen3-32B",
+            logger: null,
+            behavior: EnableThinkingBehavior());
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null,
+            reasoningEffort: "high"));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        json.RootElement.GetProperty("chat_template_kwargs").GetProperty("enable_thinking").GetBoolean()
+            .Should().BeTrue();
+        json.RootElement.GetProperty("reasoning_effort").GetString().Should().Be("high");
+    }
+
+    [TestMethod]
+    public async Task HuggingFace_UnconfiguredChoice_KeepsBuiltInReasoningEffort()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(HuggingFaceTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new HuggingFaceChatClient(
+            httpClient,
+            new HuggingFaceChatConfig { Token = "t" },
+            "Qwen/Qwen3-32B",
+            logger: null,
+            behavior: EnableThinkingBehavior());
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null,
+            reasoningEffort: "medium"));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        json.RootElement.GetProperty("reasoning_effort").GetString().Should().Be("medium");
+        json.RootElement.TryGetProperty("chat_template_kwargs", out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task HuggingFace_MergesExtraRequestFields()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(HuggingFaceTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new HuggingFaceChatClient(
+            httpClient,
+            new HuggingFaceChatConfig { Token = "t" },
+            "m",
+            logger: null,
+            behavior: ExtraFieldsBehavior("""{"parallel_tool_calls":false,"seed":7}"""));
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        json.RootElement.GetProperty("parallel_tool_calls").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("seed").GetInt32().Should().Be(7);
+        json.RootElement.GetProperty("model").GetString().Should().Be("m");
+    }
+
+    [TestMethod]
+    public async Task HuggingFace_WithoutBehavior_KeepsExistingPayloadShape()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(HuggingFaceTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new HuggingFaceChatClient(httpClient, new HuggingFaceChatConfig { Token = "t" }, "m");
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null,
+            reasoningEffort: "low",
+            samplingParameters: new Dictionary<string, double>(StringComparer.Ordinal) { ["temperature"] = 0.4 }));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        json.RootElement.GetProperty("reasoning_effort").GetString().Should().Be("low");
+        json.RootElement.GetProperty("temperature").GetDouble().Should().Be(0.4);
+        json.RootElement.GetProperty("messages")[0].GetProperty("content").GetString().Should().Be("hi");
+    }
+
+    [TestMethod]
+    public async Task OpenRouter_ThinkingControl_ReplacesBuiltInReasoningMapping()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(OpenRouterTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new OpenRouterChatClient(
+            httpClient,
+            new OpenRouterChatConfig { ApiKey = "k" },
+            "qwen/qwen3-32b",
+            logger: null,
+            behavior: EnableThinkingBehavior());
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null,
+            reasoningEffort: "none"));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        ReadBuiltInReasoning(json.RootElement).Should().BeNull();
+        json.RootElement.GetProperty("chat_template_kwargs").GetProperty("enable_thinking").GetBoolean()
+            .Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task OpenRouter_UnconfiguredChoice_KeepsBuiltInReasoningMapping()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(OpenRouterTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new OpenRouterChatClient(
+            httpClient,
+            new OpenRouterChatConfig { ApiKey = "k" },
+            "m",
+            logger: null,
+            behavior: EnableThinkingBehavior());
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null,
+            reasoningEffort: "medium"));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        ReadBuiltInReasoning(json.RootElement).Should().Be("medium");
+        json.RootElement.TryGetProperty("chat_template_kwargs", out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task OpenRouter_MergesExtraRequestFields()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(OpenRouterTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        // Primitives only — the row column rejects object values
+        // (see ExtraRequestFieldsColumn_RejectsObjectValues).
+        var client = new OpenRouterChatClient(
+            httpClient,
+            new OpenRouterChatConfig { ApiKey = "k" },
+            "m",
+            logger: null,
+            behavior: ExtraFieldsBehavior("""{"parallel_tool_calls":false,"seed":11}"""));
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        json.RootElement.GetProperty("parallel_tool_calls").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("seed").GetInt32().Should().Be(11);
+    }
+
+    [TestMethod]
+    public async Task OpenRouter_SystemMessagePrefixAction_PrependsToSystemMessage()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(OpenRouterTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var behavior = new ProviderChatBehavior(
+            new ProviderThinkingControl(
+                DefaultChoice: "none",
+                ChoiceActions: new Dictionary<string, IReadOnlyList<ProviderChatBehaviorAction>>(StringComparer.Ordinal)
+                {
+                    ["none"] =
+                    [
+                        new ProviderChatBehaviorAction(
+                            ProviderChatBehaviorActionTarget.SystemMessagePrefix,
+                            "thinking",
+                            "/no_think")
+                    ]
+                }));
+        var client = new OpenRouterChatClient(
+            httpClient,
+            new OpenRouterChatConfig { ApiKey = "k" },
+            "m",
+            logger: null,
+            behavior: behavior);
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages:
+            [
+                new ChatMessage(ChatRole.System, "You are helpful."),
+                new ChatMessage(ChatRole.User, "hi")
+            ],
+            model: null));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        json.RootElement.GetProperty("messages")[0].GetProperty("content").GetString()
+            .Should().Be("/no_think\n\nYou are helpful.");
+    }
+
+    [TestMethod]
+    public async Task OpenRouter_DefaultChoiceApplies_WhenRequestHasNoReasoningEffort()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(OpenRouterTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var behavior = new ProviderChatBehavior(
+            new ProviderThinkingControl(
+                DefaultChoice: "none",
+                ChoiceActions: new Dictionary<string, IReadOnlyList<ProviderChatBehaviorAction>>(StringComparer.Ordinal)
+                {
+                    ["none"] =
+                    [
+                        new ProviderChatBehaviorAction(
+                            ProviderChatBehaviorActionTarget.NestedRequestField,
+                            "chat_template_kwargs.enable_thinking",
+                            false)
+                    ]
+                }));
+        var client = new OpenRouterChatClient(
+            httpClient,
+            new OpenRouterChatConfig { ApiKey = "k" },
+            "m",
+            logger: null,
+            behavior: behavior);
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        json.RootElement.GetProperty("chat_template_kwargs").GetProperty("enable_thinking").GetBoolean()
+            .Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task OpenRouter_WithoutBehavior_KeepsExistingPayloadShape()
+    {
+        var handler = new CapturingHandler(_ => JsonResponse(OpenRouterTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new OpenRouterChatClient(httpClient, new OpenRouterChatConfig { ApiKey = "k" }, "m");
+
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null,
+            reasoningEffort: "high",
+            samplingParameters: new Dictionary<string, double>(StringComparer.Ordinal) { ["top_k"] = 30 }));
+
+        using var json = JsonDocument.Parse(handler.LastRequestBody);
+        ReadBuiltInReasoning(json.RootElement).Should().Be("high");
+        json.RootElement.GetProperty("top_k").GetDouble().Should().Be(30);
+        json.RootElement.TryGetProperty("chat_template_kwargs", out _).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// End to end from the catalog row's JSON columns: row strings -> RuntimeProfileData ->
+    /// ProviderChatBehavior -> request body, using the minimal operator config — override only the
+    /// no-effort case (where the built-in mapping sends nothing and the model thinks by default) and
+    /// let every explicit effort fall through to <c>ResolveReasoning</c>. Also covers an object-valued
+    /// <c>RequestField</c>, which the thinking-control column accepts though extra fields do not.
+    /// </summary>
+    [TestMethod]
+    public async Task RowDefaultChoiceOverridesNoEffort_ExplicitEffortsFallThroughToBuiltInMapping()
+    {
+        const string thinkingControlJson = """
+            {
+              "defaultChoice": "none",
+              "choiceActions": {
+                "none": [{ "target": "RequestField", "key": "reasoning", "value": { "enabled": false } }]
+              }
+            }
+            """;
+        var profile = GuideAntsApi.Services.LlamaCpp.RuntimeProfileDataJson.FromJsonStrings(
+            "deepseek/deepseek-v4-flash:nitro",
+            combineSystemAndDeveloperMessages: true,
+            thoughtBlockPattern: null,
+            samplingParametersJson: "{}",
+            thinkingControlJson: thinkingControlJson,
+            requestFieldsWhenToolsPresentJson: """{"parallel_tool_calls":false}""");
+        var behavior = GuideAntsApi.Services.Conversations.RoutingChatCompletionClientFactory
+            .ToProviderChatBehavior(profile);
+        behavior.Should().NotBeNull();
+
+        var handler = new CapturingHandler(_ => JsonResponse(OpenRouterTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new OpenRouterChatClient(
+            httpClient,
+            new OpenRouterChatConfig { ApiKey = "k" },
+            "deepseek/deepseek-v4-flash:nitro",
+            logger: null,
+            behavior: behavior);
+
+        // No reasoning effort on the request: the row's defaultChoice must still disable thinking.
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null));
+
+        using (var json = JsonDocument.Parse(handler.LastRequestBody))
+        {
+            json.RootElement.GetProperty("reasoning").GetProperty("enabled").GetBoolean().Should().BeFalse();
+            json.RootElement.GetProperty("parallel_tool_calls").GetBoolean().Should().BeFalse();
+            json.RootElement.TryGetProperty("reasoning_effort", out _).Should().BeFalse();
+        }
+
+        // An explicit effort the row does not configure keeps the client's built-in mapping, so the
+        // row never has to restate low/medium/high.
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null,
+            reasoningEffort: "high"));
+
+        using (var json = JsonDocument.Parse(handler.LastRequestBody))
+        {
+            ReadBuiltInReasoning(json.RootElement).Should().Be("high");
+            json.RootElement.GetProperty("parallel_tool_calls").GetBoolean().Should().BeFalse();
+        }
+    }
+
+    /// <summary>
+    /// Pins the documented operator config for a DeepSeek-style OpenRouter row: every choice mapped
+    /// explicitly, so the row is self-sufficient and produces the same wire bytes regardless of what
+    /// the client's own reasoning mapping would have done.
+    /// </summary>
+    [TestMethod]
+    public async Task DeepSeekRowConfig_MapsEveryChoiceWithoutRelyingOnFallback()
+    {
+        const string thinkingControlJson = """
+            {
+              "defaultChoice": "none",
+              "choiceActions": {
+                "none":   [{ "target": "RequestField", "key": "reasoning", "value": { "enabled": false } }],
+                "low":    [{ "target": "RequestField", "key": "reasoning", "value": { "effort": "low" } }],
+                "medium": [{ "target": "RequestField", "key": "reasoning", "value": { "effort": "medium" } }],
+                "high":   [{ "target": "RequestField", "key": "reasoning", "value": { "effort": "high" } }]
+              }
+            }
+            """;
+        var behavior = GuideAntsApi.Services.Conversations.RoutingChatCompletionClientFactory.ToProviderChatBehavior(
+            GuideAntsApi.Services.LlamaCpp.RuntimeProfileDataJson.FromJsonStrings(
+                "deepseek/deepseek-v4-flash:nitro",
+                combineSystemAndDeveloperMessages: true,
+                thoughtBlockPattern: null,
+                samplingParametersJson: "{}",
+                thinkingControlJson: thinkingControlJson,
+                requestFieldsWhenToolsPresentJson: """{"parallel_tool_calls":false}"""));
+
+        var handler = new CapturingHandler(_ => JsonResponse(OpenRouterTextResponse("hi")));
+        using var httpClient = new HttpClient(handler);
+        var client = new OpenRouterChatClient(
+            httpClient,
+            new OpenRouterChatConfig { ApiKey = "k" },
+            "deepseek/deepseek-v4-flash:nitro",
+            logger: null,
+            behavior: behavior);
+
+        // The phone-call case: no effort selected anywhere.
+        await client.GetCompletionAsync(new ChatCompletionRequest(
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            model: null));
+        using (var json = JsonDocument.Parse(handler.LastRequestBody))
+        {
+            json.RootElement.GetProperty("reasoning").GetProperty("enabled").GetBoolean().Should().BeFalse();
+            json.RootElement.GetProperty("parallel_tool_calls").GetBoolean().Should().BeFalse();
+            json.RootElement.TryGetProperty("reasoning_effort", out _).Should().BeFalse();
+        }
+
+        foreach (var effort in new[] { "low", "medium", "high" })
+        {
+            await client.GetCompletionAsync(new ChatCompletionRequest(
+                messages: [new ChatMessage(ChatRole.User, "hi")],
+                model: null,
+                reasoningEffort: effort));
+            using var json = JsonDocument.Parse(handler.LastRequestBody);
+            json.RootElement.GetProperty("reasoning").GetProperty("effort").GetString().Should().Be(effort);
+            json.RootElement.TryGetProperty("reasoning_effort", out _).Should().BeFalse();
+        }
+    }
+
+    /// <summary>
+    /// The extra-request-fields column rejects object values (llama-era
+    /// <see cref="GuideAntsApi.Services.LlamaCpp.RuntimeProfileRequestFieldsValidator"/> rule), and the
+    /// non-local resolver treats a failed parse as "no behavior" — so an object there silently drops the
+    /// row's thinking control too. Documents the trap; see the note in the catalog editor help text.
+    /// </summary>
+    [TestMethod]
+    public void ExtraRequestFieldsColumn_RejectsObjectValues()
+    {
+        var act = () => GuideAntsApi.Services.LlamaCpp.RuntimeProfileDataJson.FromJsonStrings(
+            "openrouter-row",
+            combineSystemAndDeveloperMessages: true,
+            thoughtBlockPattern: null,
+            samplingParametersJson: "{}",
+            thinkingControlJson: "{}",
+            requestFieldsWhenToolsPresentJson: """{"reasoning":{"enabled":false}}""");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*primitive*");
+    }
+
+    /// <summary>
+    /// Reads whichever shape the client's own reasoning mapping produced. OpenRouter's built-in
+    /// mapping is a bare <c>reasoning_effort</c> string on this base and the richer <c>reasoning</c>
+    /// object once "Make OpenRouter reasoning controllable from the guide" lands. These tests assert
+    /// only that row-owned behavior left that mapping untouched — its exact shape is that change's
+    /// contract, covered by <c>OpenRouterChatClientDeepTests</c>.
+    /// </summary>
+    private static string? ReadBuiltInReasoning(JsonElement root)
+    {
+        if (root.TryGetProperty("reasoning", out var reasoning) && reasoning.ValueKind == JsonValueKind.Object)
+        {
+            if (reasoning.TryGetProperty("effort", out var effort))
+            {
+                return effort.GetString();
+            }
+
+            if (reasoning.TryGetProperty("enabled", out var enabled))
+            {
+                return enabled.GetBoolean() ? "enabled" : "none";
+            }
+        }
+
+        return root.TryGetProperty("reasoning_effort", out var bare) ? bare.GetString() : null;
+    }
+
+    private static string OpenRouterTextResponse(string text) =>
+        $$"""{ "choices": [ { "message": { "content": "{{text}}" }, "finish_reason": "stop" } ] }""";
+
+    private static string HuggingFaceTextResponse(string text) =>
+        $$"""{ "choices": [ { "message": { "content": "{{text}}" }, "finish_reason": "stop" } ] }""";
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class CapturingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public string LastRequestBody { get; private set; } = string.Empty;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequestBody = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return responder(request);
+        }
+    }
+}

--- a/src/server/GuideAntsApi/Endpoints/Settings/SettingsModelOnboardingSupport.cs
+++ b/src/server/GuideAntsApi/Endpoints/Settings/SettingsModelOnboardingSupport.cs
@@ -104,6 +104,9 @@ internal static class SettingsModelOnboardingSupport
     {
         var samplingParametersJson = GetProviderConfigString(request.ProviderConfig, "samplingParametersJson");
         var reasoningChoicesJson = GetProviderConfigString(request.ProviderConfig, "reasoningChoicesJson");
+        // Optional row-owned request shaping; only providers whose clients honor it send these.
+        var thinkingControlJson = GetProviderConfigString(request.ProviderConfig, "thinkingControlJson");
+        var requestFieldsJson = GetProviderConfigString(request.ProviderConfig, "requestFieldsWhenToolsPresentJson");
 
         return new CreateSettingsModelRequest(
             ModelId: request.Catalog.ModelId.Trim(),
@@ -115,8 +118,8 @@ internal static class SettingsModelOnboardingSupport
             CombineSystemAndDeveloperMessages: true,
             ThoughtBlockPattern: null,
             SamplingParametersJson: string.IsNullOrWhiteSpace(samplingParametersJson) ? "{}" : samplingParametersJson.Trim(),
-            ThinkingControlJson: "{}",
-            RequestFieldsWhenToolsPresentJson: "{}",
+            ThinkingControlJson: string.IsNullOrWhiteSpace(thinkingControlJson) ? "{}" : thinkingControlJson.Trim(),
+            RequestFieldsWhenToolsPresentJson: string.IsNullOrWhiteSpace(requestFieldsJson) ? "{}" : requestFieldsJson.Trim(),
             IsActive: request.Catalog.IsActive,
             DisplayOrder: request.Catalog.DisplayOrder);
     }

--- a/src/server/GuideAntsApi/Services/Conversations/RoutingChatCompletionClientFactory.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/RoutingChatCompletionClientFactory.cs
@@ -74,7 +74,7 @@ public sealed class RoutingChatCompletionClientFactory : IChatCompletionClientFa
         if (provider == Provider.LlamaCpp)
         {
             var localRuntime = LocalRuntimeConfigurationParser.ParseRequired(target.ModelId, target.RuntimeConfigJson);
-            if (target.LlamaChatBehavior?.ThinkingControl?.ChoiceActions is not { Count: > 0 })
+            if (target.ChatBehavior?.ThinkingControl?.ChoiceActions is not { Count: > 0 })
             {
                 throw new RoutingException(
                     RoutingErrorCodes.ModelNotReady,
@@ -85,7 +85,7 @@ public sealed class RoutingChatCompletionClientFactory : IChatCompletionClientFa
                     providerSection: "LlamaCpp");
             }
 
-            var llamaProfile = ToLlamaCppProfileData(target.LlamaChatBehavior);
+            var llamaProfile = ToLlamaCppProfileData(target.ChatBehavior);
 
             return _llamaCppFactory.CreateClientForProfile(
                 localRuntime.RouterModelId,
@@ -101,8 +101,14 @@ public sealed class RoutingChatCompletionClientFactory : IChatCompletionClientFa
             Provider.AzureOpenAiChat => _azureOpenAiChatFactory.CreateClient(target.ModelId, httpClient),
             Provider.AzureOpenAiResponses => _azureOpenAiResponsesFactory.CreateClient(target.ModelId, httpClient),
             Provider.GoogleGeminiChat => _googleGeminiFactory.CreateClient(target.ModelId, httpClient),
-            Provider.HuggingFaceInferenceChat => _huggingFaceFactory.CreateClient(target.ModelId, httpClient),
-            Provider.OpenRouterChat => _openRouterFactory.CreateClient(target.ModelId, httpClient),
+            Provider.HuggingFaceInferenceChat => _huggingFaceFactory.CreateClientForBehavior(
+                target.ModelId,
+                ToProviderChatBehavior(target.ChatBehavior),
+                httpClient),
+            Provider.OpenRouterChat => _openRouterFactory.CreateClientForBehavior(
+                target.ModelId,
+                ToProviderChatBehavior(target.ChatBehavior),
+                httpClient),
             _ => throw new RoutingException(
                 RoutingErrorCodes.ProviderNotReady,
                 $"Unsupported provider for model '{target.ModelId}'.",
@@ -144,6 +150,42 @@ public sealed class RoutingChatCompletionClientFactory : IChatCompletionClientFa
         GoogleGeminiChat,
         HuggingFaceInferenceChat,
         OpenRouterChat
+    }
+
+    /// <summary>
+    /// Projects the row-owned chat behavior onto the provider-agnostic shape used by the
+    /// OpenAI-compatible clients. Returns null when the row configures neither thinking control
+    /// nor extra request fields so those clients keep their built-in request mapping.
+    /// </summary>
+    internal static ProviderChatBehavior? ToProviderChatBehavior(RuntimeProfileData? data)
+    {
+        if (data == null)
+        {
+            return null;
+        }
+
+        var thinking = data.ThinkingControl?.ChoiceActions is { Count: > 0 } ? data.ThinkingControl : null;
+        var hasExtraFields = data.RequestFieldsWhenToolsPresent is { Count: > 0 };
+        if (thinking == null && !hasExtraFields)
+        {
+            return null;
+        }
+
+        var thinkingControl = thinking == null
+            ? null
+            : new ProviderThinkingControl(
+                thinking.DefaultChoice,
+                thinking.ChoiceActions.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => (IReadOnlyList<ProviderChatBehaviorAction>)kvp.Value.Select(action =>
+                        new ProviderChatBehaviorAction(
+                            (ProviderChatBehaviorActionTarget)(int)action.Target,
+                            action.Key,
+                            action.Value)).ToList()));
+
+        return new ProviderChatBehavior(
+            thinkingControl,
+            hasExtraFields ? data.RequestFieldsWhenToolsPresent : null);
     }
 
     private static LlamaCppRuntimeProfileData ToLlamaCppProfileData(RuntimeProfileData data)

--- a/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelOnboardingValidator.cs
+++ b/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelOnboardingValidator.cs
@@ -495,7 +495,7 @@ public sealed class LocalModelOnboardingValidator : ILocalModelOnboardingValidat
             ModelId: command.CatalogModelId,
             Provider: "llama-cpp",
             RuntimeConfigJson: LocalModelOnboardingOrchestrator.BuildLlamaLocalRuntimeJson(command),
-            LlamaChatBehavior: chatBehavior));
+            ChatBehavior: chatBehavior));
     }
 
     private static AddModelException MapRoutingException(RoutingException exception)

--- a/src/server/GuideAntsApi/Services/Routing/IChatTargetResolver.cs
+++ b/src/server/GuideAntsApi/Services/Routing/IChatTargetResolver.cs
@@ -6,12 +6,15 @@ namespace GuideAntsApi.Services.Routing;
 /// <summary>
 /// A resolved chat dispatch target. Carries the raw catalog row so the validator
 /// and the routing factory can fan out without issuing another DB query.
+/// <paramref name="ChatBehavior"/> is the row-owned chat behavior. llama-cpp requires it;
+/// providers that accept row-owned request shaping (Hugging Face, OpenRouter) use it when
+/// configured and fall back to their built-in mapping when it is empty.
 /// </summary>
 public sealed record ChatTarget(
     string ModelId,
     string Provider,
     string? RuntimeConfigJson,
-    GuideAntsApi.Services.LlamaCpp.RuntimeProfileData? LlamaChatBehavior = null);
+    GuideAntsApi.Services.LlamaCpp.RuntimeProfileData? ChatBehavior = null);
 
 public interface IChatTargetResolver
 {
@@ -80,10 +83,12 @@ public sealed class ChatTargetResolver : IChatTargetResolver
                 serviceId: "Chat");
         }
 
-        GuideAntsApi.Services.LlamaCpp.RuntimeProfileData? llamaBehavior = null;
-        if (string.Equals(row.Provider.Trim(), "llama-cpp", StringComparison.OrdinalIgnoreCase))
+        var provider = row.Provider.Trim();
+        var isLlama = string.Equals(provider, "llama-cpp", StringComparison.OrdinalIgnoreCase);
+        GuideAntsApi.Services.LlamaCpp.RuntimeProfileData? chatBehavior;
+        try
         {
-            llamaBehavior = GuideAntsApi.Services.LlamaCpp.RuntimeProfileDataJson.FromJsonStrings(
+            chatBehavior = GuideAntsApi.Services.LlamaCpp.RuntimeProfileDataJson.FromJsonStrings(
                 row.ModelId,
                 row.CombineSystemAndDeveloperMessages,
                 row.ThoughtBlockPattern,
@@ -93,7 +98,13 @@ public sealed class ChatTargetResolver : IChatTargetResolver
                 row.DisplayName,
                 row.Description);
         }
+        catch (InvalidOperationException) when (!isLlama)
+        {
+            // Non-local rows only opt in to row-owned request shaping; a malformed surface must not
+            // take chat down, so fall back to the provider client's built-in request mapping.
+            chatBehavior = null;
+        }
 
-        return new ChatTarget(row.ModelId, row.Provider.Trim(), row.RuntimeConfigJson, llamaBehavior);
+        return new ChatTarget(row.ModelId, provider, row.RuntimeConfigJson, chatBehavior);
     }
 }

--- a/src/server/GuideAntsApi/Services/Routing/IChatTargetValidator.cs
+++ b/src/server/GuideAntsApi/Services/Routing/IChatTargetValidator.cs
@@ -200,7 +200,7 @@ public sealed class ChatTargetValidator : IChatTargetValidator
                 innerException: ex);
         }
 
-        if (target.LlamaChatBehavior?.ThinkingControl?.ChoiceActions is not { Count: > 0 })
+        if (target.ChatBehavior?.ThinkingControl?.ChoiceActions is not { Count: > 0 })
         {
             throw new RoutingException(
                 RoutingErrorCodes.ModelNotReady,

--- a/src/server/GuideAntsApi/Settings/ApplicationSettingsService.Models.cs
+++ b/src/server/GuideAntsApi/Settings/ApplicationSettingsService.Models.cs
@@ -46,8 +46,16 @@ public sealed partial class ApplicationSettingsService
             CombineSystemAndDeveloperMessages = request.CombineSystemAndDeveloperMessages,
             ThoughtBlockPattern = request.ThoughtBlockPattern,
             SamplingParametersJson = NormalizeJsonObject(request.SamplingParametersJson, "{}"),
-            ThinkingControlJson = NormalizeJsonObject(request.ThinkingControlJson, "{}"),
-            RequestFieldsWhenToolsPresentJson = NormalizeJsonObject(request.RequestFieldsWhenToolsPresentJson, "{}"),
+            ThinkingControlJson = NormalizeBehaviorJsonObject(
+                modelId,
+                nameof(Model.ThinkingControlJson),
+                request.ThinkingControlJson,
+                "{}"),
+            RequestFieldsWhenToolsPresentJson = NormalizeBehaviorJsonObject(
+                modelId,
+                nameof(Model.RequestFieldsWhenToolsPresentJson),
+                request.RequestFieldsWhenToolsPresentJson,
+                "{}"),
             IsActive = request.IsActive,
             DisplayOrder = request.DisplayOrder,
             Created = DateTime.UtcNow,
@@ -87,8 +95,14 @@ public sealed partial class ApplicationSettingsService
         model.CombineSystemAndDeveloperMessages = request.CombineSystemAndDeveloperMessages;
         model.ThoughtBlockPattern = request.ThoughtBlockPattern;
         model.SamplingParametersJson = NormalizeJsonObject(request.SamplingParametersJson, model.SamplingParametersJson);
-        model.ThinkingControlJson = NormalizeJsonObject(request.ThinkingControlJson, model.ThinkingControlJson);
-        model.RequestFieldsWhenToolsPresentJson = NormalizeJsonObject(
+        model.ThinkingControlJson = NormalizeBehaviorJsonObject(
+            routeModelId,
+            nameof(Model.ThinkingControlJson),
+            request.ThinkingControlJson,
+            model.ThinkingControlJson);
+        model.RequestFieldsWhenToolsPresentJson = NormalizeBehaviorJsonObject(
+            routeModelId,
+            nameof(Model.RequestFieldsWhenToolsPresentJson),
             request.RequestFieldsWhenToolsPresentJson,
             model.RequestFieldsWhenToolsPresentJson);
         model.IsActive = request.IsActive;
@@ -205,6 +219,37 @@ public sealed partial class ApplicationSettingsService
         }
 
         return json.Trim();
+    }
+
+    /// <summary>
+    /// Chat-behavior columns are replayed into request bodies at dispatch, where malformed JSON can
+    /// only be ignored. Reject it on write instead so a bad paste fails visibly in Settings.
+    /// </summary>
+    private static string NormalizeBehaviorJsonObject(string modelId, string field, string? json, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return fallback;
+        }
+
+        var trimmed = json.Trim();
+        JsonValueKind kind;
+        try
+        {
+            using var document = JsonDocument.Parse(trimmed);
+            kind = document.RootElement.ValueKind;
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Model '{modelId}' {field} must be valid JSON.", ex);
+        }
+
+        if (kind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException($"Model '{modelId}' {field} must be a JSON object.");
+        }
+
+        return trimmed;
     }
 
     private static string? NormalizeReasoningChoicesJson(string modelId, string? reasoningChoicesJson)


### PR DESCRIPTION
OpenRouter and Hugging Face model rows can now set ThinkingControlJson and RequestFieldsWhenToolsPresentJson, this is what lets a row disable/enable thinking (e.g. `chat_template_kwargs.enable_thinking` on Hugging Face) and merge extra body fields like `parallel_tool_calls`. Also fixes a guide's own reasoning effort not reaching the request at all, which let a row's default silently override whatever the guide had selected.