### PR TITLE
Surgical scoped apply: apt-only global/startup, durable venv, fix pip reconcile

### DIFF
--- a/src/client/src/features/guideantsGuide/__tests__/sandboxAdminBridge.test.ts
+++ b/src/client/src/features/guideantsGuide/__tests__/sandboxAdminBridge.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sandboxAdminApply, sandboxAdminApplyApt } from '../sandboxAdminBridge';
+
+describe('sandboxAdminBridge apply targets', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sandboxAdminApply sends scoped pip and installScripts targets', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      text: async () => '{"jobId":"abc"}',
+      headers: new Headers({ 'content-type': 'application/json' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await sandboxAdminApply({
+      projectId: '11111111-1111-1111-1111-111111111111',
+      guideId: '22222222-2222-2222-2222-222222222222',
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ targets: ['pip', 'installScripts'] }));
+    expect(String(init.body)).not.toContain('apt');
+  });
+
+  it('sandboxAdminApplyApt sends global apt-only targets', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      text: async () => '{"jobId":"abc"}',
+      headers: new Headers({ 'content-type': 'application/json' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await sandboxAdminApplyApt();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ targets: ['apt'] }));
+  });
+});

--- a/src/client/src/features/guideantsGuide/guideantsAppBridge.ts
+++ b/src/client/src/features/guideantsGuide/guideantsAppBridge.ts
@@ -602,7 +602,10 @@ export function registerGuideAntsAppBridge(
       });
     }
 
-    const result = await callSandboxAdminEndpoint('POST', 'apply', { query });
+    const applyTargets = query
+      ? JSON.stringify({ targets: ['pip', 'installScripts'] })
+      : JSON.stringify({ targets: ['apt'] });
+    const result = await callSandboxAdminEndpoint('POST', 'apply', { query, body: applyTargets });
     return toolResult(call, 'SandboxAdminApply', result);
   });
 

--- a/src/client/src/features/guideantsGuide/sandboxAdminBridge.ts
+++ b/src/client/src/features/guideantsGuide/sandboxAdminBridge.ts
@@ -153,7 +153,16 @@ export async function sandboxAdminGetAptPackages(): Promise<SandboxAdminCallResu
 }
 
 export async function sandboxAdminApply(scope: SandboxGuideScope): Promise<SandboxAdminCallResult> {
-  return callSandboxAdminEndpoint('POST', 'apply', { query: buildGuideScopeQuery(scope) });
+  return callSandboxAdminEndpoint('POST', 'apply', {
+    query: buildGuideScopeQuery(scope),
+    body: JSON.stringify({ targets: ['pip', 'installScripts'] }),
+  });
+}
+
+export async function sandboxAdminApplyApt(): Promise<SandboxAdminCallResult> {
+  return callSandboxAdminEndpoint('POST', 'apply', {
+    body: JSON.stringify({ targets: ['apt'] }),
+  });
 }
 
 export async function sandboxAdminGetApplyJob(jobId: string): Promise<SandboxAdminCallResult> {

--- a/src/server/GuideAntsApi.Tests/Models/SystemGuide/SandboxAdminApplyIntentTests.cs
+++ b/src/server/GuideAntsApi.Tests/Models/SystemGuide/SandboxAdminApplyIntentTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using FluentAssertions;
+using GuideAntsApi.Models.SystemGuide;
+
+namespace GuideAntsApi.Tests.Models.SystemGuide;
+
+[TestClass]
+public sealed class SandboxAdminApplyIntentTests
+{
+    [TestMethod]
+    public void ResolveTargets_global_returns_apt_only()
+    {
+        SandboxAdminApplyIntent.ResolveTargets(hasScope: false)
+            .Should().Equal("apt");
+    }
+
+    [TestMethod]
+    public void ResolveTargets_scoped_returns_pip_and_install_scripts()
+    {
+        SandboxAdminApplyIntent.ResolveTargets(hasScope: true)
+            .Should().Equal("pip", "installScripts");
+    }
+
+    [TestMethod]
+    public void ResolveForwardBody_without_body_synthesizes_global_apt_targets()
+    {
+        var body = SandboxAdminApplyIntent.ResolveForwardBody(rawBody: null, hasScope: false);
+        using var document = JsonDocument.Parse(body);
+
+        document.RootElement.GetProperty("targets").EnumerateArray()
+            .Select(element => element.GetString())
+            .Should().Equal("apt");
+    }
+
+    [TestMethod]
+    public void ResolveForwardBody_without_body_synthesizes_scoped_targets()
+    {
+        var body = SandboxAdminApplyIntent.ResolveForwardBody(rawBody: string.Empty, hasScope: true);
+        using var document = JsonDocument.Parse(body);
+
+        document.RootElement.GetProperty("targets").EnumerateArray()
+            .Select(element => element.GetString())
+            .Should().Equal("pip", "installScripts");
+    }
+
+    [TestMethod]
+    public void ResolveForwardBody_preserves_caller_supplied_json()
+    {
+        const string raw = """{"targets":["pip"]}""";
+
+        SandboxAdminApplyIntent.ResolveForwardBody(raw, hasScope: true).Should().Be(raw);
+    }
+
+    [TestMethod]
+    public void ResolveForwardBody_synthesized_targets_are_explicit_apply_intent_only()
+    {
+        foreach (var (hasScope, expected) in new (bool, string[])[]
+                 {
+                     (false, new[] { "apt" }),
+                     (true, new[] { "pip", "installScripts" })
+                 })
+        {
+            var body = SandboxAdminApplyIntent.ResolveForwardBody(rawBody: null, hasScope: hasScope);
+            using var document = JsonDocument.Parse(body);
+            document.RootElement.GetProperty("targets").EnumerateArray()
+                .Select(element => element.GetString())
+                .Should().Equal(expected);
+        }
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/SandboxWireApi/SandboxWireJwtServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/SandboxWireApi/SandboxWireJwtServiceTests.cs
@@ -48,9 +48,9 @@ public sealed class SandboxWireJwtServiceTests
     [TestMethod]
     public void ResolveAllowedEndpoints_respects_disabled_flags()
     {
-        var endpoints = SandboxWireEnvironmentProvisioner.ResolveAllowedEndpoints(new Models.Guides.SandboxWireApiConfigDto
+        var endpoints = SandboxWireEnvironmentProvisioner.ResolveAllowedEndpoints(new GuideAntsApi.Models.Guides.SandboxWireApiConfigDto
         {
-            EndpointFlags = new Models.Guides.PublishedWireApiEndpointFlagsDto
+            EndpointFlags = new GuideAntsApi.Models.Guides.PublishedWireApiEndpointFlagsDto
             {
                 Models = true,
                 ChatCompletions = false,

--- a/src/server/GuideAntsApi/Endpoints/SystemGuideEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/SystemGuideEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using GuideAntsApi.DataModel;
 using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Models.SystemGuide;
@@ -206,6 +207,7 @@ public static class SystemGuideEndpoints
             [FromQuery] Guid? projectId,
             [FromQuery] Guid? guideId,
             [FromQuery] Guid? notebookId,
+            HttpRequest request,
             ApplicationDbContext db,
             ISystemGuideSandboxAdminProxy proxy,
             CancellationToken cancellationToken) =>
@@ -221,12 +223,15 @@ public static class SystemGuideEndpoints
                 return scopeError;
             }
 
+            var rawBody = await ReadRawBodyAsync(request, cancellationToken);
+            var bodyToForward = SandboxAdminApplyIntent.ResolveForwardBody(rawBody, scopeQuery is not null);
+
             return await proxy.ForwardAsync(
                 HttpMethod.Post,
                 "apply",
                 query: scopeQuery,
-                body: null,
-                contentType: null,
+                body: bodyToForward,
+                contentType: "application/json",
                 cancellationToken);
         })
         .RequireAuthorization("RequireAdmin")

--- a/src/server/GuideAntsApi/Models/SystemGuide/SandboxAdminApplyRequest.cs
+++ b/src/server/GuideAntsApi/Models/SystemGuide/SandboxAdminApplyRequest.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+
+namespace GuideAntsApi.Models.SystemGuide;
+
+public sealed record SandboxAdminApplyRequest(string[]? Targets);
+
+public static class SandboxAdminApplyIntent
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static string[] ResolveTargets(bool hasScope) =>
+        hasScope
+            ? new[] { "pip", "installScripts" }
+            : new[] { "apt" };
+
+    public static string ResolveForwardBody(string? rawBody, bool hasScope)
+    {
+        if (!string.IsNullOrWhiteSpace(rawBody))
+        {
+            return rawBody;
+        }
+
+        return JsonSerializer.Serialize(
+            new SandboxAdminApplyRequest(ResolveTargets(hasScope)),
+            JsonOptions);
+    }
+}

--- a/src/server/GuideAntsApi/Resources/bootstrap/guides/guideants-guide-admin/OpenAPI/Web Connector.json
+++ b/src/server/GuideAntsApi/Resources/bootstrap/guides/guideants-guide-admin/OpenAPI/Web Connector.json
@@ -794,13 +794,13 @@
     "GuideAntsApp.SandboxAdminApply": {
       "post": {
         "operationId": "SandboxAdminApply",
-        "summary": "Start POST /api/system-guide/sandbox-admin/apply after staging requirements/apt. Runs preflight synchronously (fail fast on invalid packages). On success returns jobId with status running; poll SandboxAdminGetApplyJob until succeeded or failed.",
+        "summary": "Start POST /api/system-guide/sandbox-admin/apply after staging requirements/apt. Global apply uses targets [\"apt\"] only. Scoped apply uses targets [\"pip\",\"installScripts\"] for one guide venv. Runs preflight synchronously (fail fast on invalid packages). On success returns jobId with status running; poll SandboxAdminGetApplyJob until succeeded or failed.",
         "requestBody": {
           "required": false,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboxAdminScopedRequest"
+                "$ref": "#/components/schemas/SandboxAdminApplyRequest"
               }
             }
           }
@@ -1079,6 +1079,39 @@
           "status",
           "endpoint"
         ]
+      },
+      "SandboxAdminApplyRequest": {
+        "type": "object",
+        "properties": {
+          "projectId": {
+            "type": "string",
+            "description": "Project scope. Provide with either guideId or notebookId for scoped pip/installScripts apply.",
+            "format": "uuid"
+          },
+          "guideId": {
+            "type": "string",
+            "description": "Guide scope. Mutually exclusive with notebookId.",
+            "format": "uuid"
+          },
+          "notebookId": {
+            "type": "string",
+            "description": "Notebook scope. Mutually exclusive with guideId. API resolves guide for venv scope.",
+            "format": "uuid"
+          },
+          "targets": {
+            "type": "array",
+            "description": "Apply intent. Global (no scope): [\"apt\"] only. Scoped: [\"pip\", \"installScripts\"] or a subset. Omitted body defaults to apt (global) or pip+installScripts (scoped).",
+            "items": {
+              "type": "string",
+              "enum": [
+                "apt",
+                "pip",
+                "installScripts"
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
       },
       "SandboxAdminScopedRequest": {
         "type": "object",

--- a/src/server/GuideAntsApi/Resources/bootstrap/guides/guideants-guide-admin/instructions.md
+++ b/src/server/GuideAntsApi/Resources/bootstrap/guides/guideants-guide-admin/instructions.md
@@ -77,7 +77,7 @@ Recommended workflow:
 Apply is two-phase:
 
 - **Preflight (synchronous):** `SandboxAdminApply` validates requirements/apt/scripts (including pip/apt dry-run and Python/Bash syntax checks). Invalid packages or scripts return an immediate tool error (HTTP 400). Do not claim apply started when preflight fails.
-- **Background job:** When preflight passes, apply returns `jobId` with status `queued` or `running`. Apply order for scoped work: pip requirements, then install scripts in order. Global apply reconciles apt plus all known scoped venvs.
+- **Background job:** When preflight passes, apply returns `jobId` with status `queued` or `running`. Scoped apply order: pip requirements, then install scripts in order. Global apply reconciles apt only (`targets: ["apt"]`).
 - **Poll:** Call `SandboxAdminGetApplyJob` with `jobId` until status is `succeeded` or `failed`. Poll with backoff; do not block a single tool call for the full install duration.
 
 `SandboxAdminGetSetupStatus` returns `overallStatus` (`ready`, `pending`, `applying`, `failed`), staged/applied hashes, per install-script step status, active/last apply job, and an `errors` list. Use it before adjusting configuration.
@@ -91,9 +91,10 @@ Python scope policy:
 Apply scope policy:
 
 - `SandboxAdminApply` may run globally (no scope) or scoped.
-- Scoped apply runs pip and install scripts for the project+guide venv.
-- Global apply runs apt reconciliation plus all known scoped venvs.
+- Scoped apply runs pip and install scripts for the project+guide venv (`targets: ["pip", "installScripts"]`).
+- Global apply runs apt reconciliation only (`targets: ["apt"]`). It does not walk other guides' venvs.
 - Install scripts are scoped-only.
+- On container restart, scoped `python-venv/` folders on durable storage are trusted; startup reifies apt only.
 
 Do not retry the same invalid payload shape repeatedly. If validation fails after one corrected retry, report the exact tool error and stop.
 

--- a/src/server/ScriptExecutionAgent.Tests/AdminApplyTargetsTests.cs
+++ b/src/server/ScriptExecutionAgent.Tests/AdminApplyTargetsTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using ScriptExecutionAgent;
+
+namespace ScriptExecutionAgent.Tests;
+
+[TestClass]
+public sealed class AdminApplyTargetsTests
+{
+    [TestMethod]
+    public void Resolve_global_defaults_to_apt_only()
+    {
+        var targets = AdminApplyTargets.Resolve(hasScope: false, requestedTargets: null);
+
+        targets.Apt.Should().BeTrue();
+        targets.Pip.Should().BeFalse();
+        targets.InstallScripts.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Resolve_scoped_defaults_to_pip_and_install_scripts()
+    {
+        var targets = AdminApplyTargets.Resolve(hasScope: true, requestedTargets: null);
+
+        targets.Apt.Should().BeFalse();
+        targets.Pip.Should().BeTrue();
+        targets.InstallScripts.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Resolve_global_explicit_apt_is_allowed()
+    {
+        var targets = AdminApplyTargets.Resolve(hasScope: false, requestedTargets: new[] { "apt" });
+
+        targets.Apt.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Resolve_scoped_explicit_pip_only_is_allowed()
+    {
+        var targets = AdminApplyTargets.Resolve(hasScope: true, requestedTargets: new[] { "pip" });
+
+        targets.Pip.Should().BeTrue();
+        targets.InstallScripts.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Resolve_rejects_global_pip()
+    {
+        var act = () => AdminApplyTargets.Resolve(hasScope: false, requestedTargets: new[] { "pip" });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Global apply supports only apt*");
+    }
+
+    [TestMethod]
+    public void Resolve_rejects_scoped_apt()
+    {
+        var act = () => AdminApplyTargets.Resolve(hasScope: true, requestedTargets: new[] { "apt" });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Scoped apply cannot target apt*");
+    }
+
+    [TestMethod]
+    public void Resolve_rejects_unknown_target()
+    {
+        var act = () => AdminApplyTargets.Resolve(hasScope: false, requestedTargets: new[] { "npm" });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not supported*");
+    }
+
+    [TestMethod]
+    public void Resolve_rejects_scoped_empty_target_set()
+    {
+        var act = () => AdminApplyTargets.Resolve(hasScope: true, requestedTargets: Array.Empty<string>());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*cannot be empty*");
+    }
+}

--- a/src/server/ScriptExecutionAgent.Tests/InProcess/ScriptExecutionAgentAdminApiTests.cs
+++ b/src/server/ScriptExecutionAgent.Tests/InProcess/ScriptExecutionAgentAdminApiTests.cs
@@ -3,6 +3,8 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using ScriptExecutionAgent;
 using ScriptExecutionAgent.Tests.Infrastructure;
 
 namespace ScriptExecutionAgent.Tests.InProcess;
@@ -264,6 +266,147 @@ print("created")
     }
 
     [TestMethod]
+    public async Task Admin_apply_scoped_installs_missing_packages_when_requirements_hash_matches()
+    {
+        if (!PythonVenvTestHelper.CanCreateScopedPythonVenv())
+        {
+            Assert.Inconclusive("Scoped Python venv with pip is not available on this machine.");
+        }
+
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        using var adminClient = _factory.CreateAdminClient();
+        using var executionClient = _factory.CreateAuthenticatedClient();
+        var scopedAdminUrl = BuildScopedAdminUrl(_factory.Notebook);
+        using var setRequirementsContent = new StringContent("six", Encoding.UTF8, "text/plain");
+        var setRequirementsResponse = await adminClient.PutAsync($"/admin/requirements{scopedAdminUrl}", setRequirementsContent);
+        setRequirementsResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var firstApplyResponse = await adminClient.PostAsync(
+            $"/admin/apply{scopedAdminUrl}",
+            CreateApplyTargetsBody("pip", "installScripts"));
+        if (firstApplyResponse.StatusCode == HttpStatusCode.BadRequest)
+        {
+            var firstApplyBody = await firstApplyResponse.Content.ReadAsStringAsync();
+            if (firstApplyBody.Contains("Failed to create scoped Python virtual environment", StringComparison.OrdinalIgnoreCase))
+            {
+                Assert.Inconclusive("Scoped Python venv could not be provisioned on this host.");
+            }
+        }
+
+        firstApplyResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var firstApplyResult = await WaitForApplyJobResultAsync(
+            adminClient,
+            JsonDocument.Parse(await firstApplyResponse.Content.ReadAsStringAsync()).RootElement.GetProperty("jobId").GetString()!);
+        firstApplyResult.GetProperty("status").GetString().Should().Be("succeeded");
+        firstApplyResult.GetProperty("result").GetProperty("status").GetString().Should().BeOneOf("applied", "skipped");
+
+        var probeInstalledResponse = await executionClient.PostAsJsonAsync(
+            "/execute",
+            CreateExecuteBody(
+                _factory.Notebook,
+                "import importlib.util\nprint('present' if importlib.util.find_spec('six') else 'missing')",
+                scriptType: (int)ScriptType.Python));
+        probeInstalledResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (var installedDoc = JsonDocument.Parse(await probeInstalledResponse.Content.ReadAsStringAsync()))
+        {
+            ReadStandardOutput(installedDoc.RootElement).Should().Be("present");
+        }
+
+        var uninstallResponse = await executionClient.PostAsJsonAsync(
+            "/execute",
+            CreateExecuteBody(
+                _factory.Notebook,
+                """
+import subprocess
+import sys
+
+subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "-y", "six"])
+print("uninstalled")
+""",
+                scriptType: (int)ScriptType.Python));
+        uninstallResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var probeMissingResponse = await executionClient.PostAsJsonAsync(
+            "/execute",
+            CreateExecuteBody(
+                _factory.Notebook,
+                "import importlib.util\nprint('present' if importlib.util.find_spec('six') else 'missing')",
+                scriptType: (int)ScriptType.Python));
+        probeMissingResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (var missingDoc = JsonDocument.Parse(await probeMissingResponse.Content.ReadAsStringAsync()))
+        {
+            ReadStandardOutput(missingDoc.RootElement).Should().Be("missing");
+        }
+
+        var secondApplyResponse = await adminClient.PostAsync(
+            $"/admin/apply{scopedAdminUrl}",
+            CreateApplyTargetsBody("pip", "installScripts"));
+        secondApplyResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var secondApplyJob = await WaitForApplyJobResultAsync(
+            adminClient,
+            JsonDocument.Parse(await secondApplyResponse.Content.ReadAsStringAsync()).RootElement.GetProperty("jobId").GetString()!);
+        secondApplyJob.GetProperty("status").GetString().Should().Be("succeeded");
+        secondApplyJob.GetProperty("result").GetProperty("status").GetString().Should().Be("applied");
+
+        var probeRestoredResponse = await executionClient.PostAsJsonAsync(
+            "/execute",
+            CreateExecuteBody(
+                _factory.Notebook,
+                "import importlib.util\nprint('present' if importlib.util.find_spec('six') else 'missing')",
+                scriptType: (int)ScriptType.Python));
+        probeRestoredResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (var restoredDoc = JsonDocument.Parse(await probeRestoredResponse.Content.ReadAsStringAsync()))
+        {
+            ReadStandardOutput(restoredDoc.RootElement).Should().Be("present");
+        }
+    }
+
+    [TestMethod]
+    public async Task Admin_apply_scoped_is_skipped_when_requirements_already_satisfied()
+    {
+        if (!PythonVenvTestHelper.CanCreateScopedPythonVenv())
+        {
+            Assert.Inconclusive("Scoped Python venv with pip is not available on this machine.");
+        }
+
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        using var adminClient = _factory.CreateAdminClient();
+        var scopedAdminUrl = BuildScopedAdminUrl(_factory.Notebook);
+        using var setRequirementsContent = new StringContent("six", Encoding.UTF8, "text/plain");
+        var setRequirementsResponse = await adminClient.PutAsync($"/admin/requirements{scopedAdminUrl}", setRequirementsContent);
+        setRequirementsResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var firstApplyResponse = await adminClient.PostAsync(
+            $"/admin/apply{scopedAdminUrl}",
+            CreateApplyTargetsBody("pip", "installScripts"));
+        if (firstApplyResponse.StatusCode == HttpStatusCode.BadRequest)
+        {
+            var firstApplyBody = await firstApplyResponse.Content.ReadAsStringAsync();
+            if (firstApplyBody.Contains("Failed to create scoped Python virtual environment", StringComparison.OrdinalIgnoreCase))
+            {
+                Assert.Inconclusive("Scoped Python venv could not be provisioned on this host.");
+            }
+        }
+
+        firstApplyResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var firstApplyJob = await WaitForApplyJobResultAsync(
+            adminClient,
+            JsonDocument.Parse(await firstApplyResponse.Content.ReadAsStringAsync()).RootElement.GetProperty("jobId").GetString()!);
+        firstApplyJob.GetProperty("status").GetString().Should().Be("succeeded");
+
+        var secondApplyResponse = await adminClient.PostAsync(
+            $"/admin/apply{scopedAdminUrl}",
+            CreateApplyTargetsBody("pip", "installScripts"));
+        secondApplyResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var secondApplyJob = await WaitForApplyJobResultAsync(
+            adminClient,
+            JsonDocument.Parse(await secondApplyResponse.Content.ReadAsStringAsync()).RootElement.GetProperty("jobId").GetString()!);
+        secondApplyJob.GetProperty("status").GetString().Should().Be("succeeded");
+        secondApplyJob.GetProperty("result").GetProperty("status").GetString().Should().Be("skipped");
+        secondApplyJob.GetProperty("result").GetProperty("scopesSkipped").GetInt32().Should().Be(1);
+    }
+
+    [TestMethod]
     public async Task Admin_apply_scoped_preflight_rejects_missing_python_package()
     {
         if (!PythonVenvTestHelper.CanCreateScopedPythonVenv())
@@ -377,7 +520,7 @@ print("created")
         _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
         using var client = _factory.CreateAdminClient();
 
-        var startResponse = await client.PostAsync("/admin/apply", content: null);
+        var startResponse = await client.PostAsync("/admin/apply", CreateApplyTargetsBody("apt"));
         startResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
         using var acceptedDoc = JsonDocument.Parse(await startResponse.Content.ReadAsStringAsync());
         var jobId = acceptedDoc.RootElement.GetProperty("jobId").GetString();
@@ -388,12 +531,173 @@ print("created")
         result.TryGetProperty("result", out _).Should().BeTrue();
     }
 
+    [TestMethod]
+    public async Task Admin_apply_global_with_omitted_body_defaults_to_apt_only()
+    {
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        SeedPoisonedSiblingScope(_factory.StorageRoot);
+        using var client = _factory.CreateAdminClient();
+
+        var startResponse = await client.PostAsync("/admin/apply", content: null);
+
+        startResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        using var acceptedDoc = JsonDocument.Parse(await startResponse.Content.ReadAsStringAsync());
+        var jobId = acceptedDoc.RootElement.GetProperty("jobId").GetString();
+        var status = await WaitForApplyJobResultAsync(client, jobId!);
+        status.GetProperty("status").GetString().Should().Be("succeeded");
+        status.GetProperty("result").GetProperty("scopesApplied").GetInt32().Should().BeLessThanOrEqualTo(1);
+    }
+
+    [TestMethod]
+    public async Task Admin_apply_global_does_not_create_sibling_scope_venv_or_applied_state()
+    {
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        var poisonedScopeRoot = SeedPoisonedSiblingScope(_factory.StorageRoot);
+        using var client = _factory.CreateAdminClient();
+
+        var result = await StartApplyAndWaitForResultAsync(client);
+
+        result.TryGetProperty("apt", out _).Should().BeTrue();
+        result.GetProperty("scopesApplied").GetInt32().Should().BeLessThanOrEqualTo(1);
+        File.Exists(Path.Combine(poisonedScopeRoot, "applied-state.json")).Should().BeFalse();
+        Directory.Exists(Path.Combine(poisonedScopeRoot, "python-venv")).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task Admin_apply_scoped_with_omitted_body_defaults_to_pip_and_install_scripts()
+    {
+        if (!PythonVenvTestHelper.CanCreateScopedPythonVenv())
+        {
+            Assert.Inconclusive("Scoped Python venv with pip is not available on this machine.");
+        }
+
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        using var client = _factory.CreateAdminClient();
+        var scopedAdminUrl = BuildScopedAdminUrl(_factory.Notebook);
+        using var setRequirementsContent = new StringContent(string.Empty, Encoding.UTF8, "text/plain");
+        var setRequirementsResponse = await client.PutAsync($"/admin/requirements{scopedAdminUrl}", setRequirementsContent);
+        setRequirementsResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var applyResponse = await client.PostAsync($"/admin/apply{scopedAdminUrl}", content: null);
+        if (applyResponse.StatusCode == HttpStatusCode.BadRequest)
+        {
+            var body = await applyResponse.Content.ReadAsStringAsync();
+            if (body.Contains("Failed to create scoped Python virtual environment", StringComparison.OrdinalIgnoreCase))
+            {
+                Assert.Inconclusive("Scoped Python venv could not be provisioned on this host.");
+            }
+        }
+
+        applyResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+    }
+
+    [TestMethod]
+    public async Task Admin_apply_global_succeeds_when_poisoned_sibling_scope_exists()
+    {
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        SeedPoisonedSiblingScope(_factory.StorageRoot);
+        using var client = _factory.CreateAdminClient();
+
+        var startResponse = await client.PostAsync("/admin/apply", CreateApplyTargetsBody("apt"));
+
+        startResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        using var acceptedDoc = JsonDocument.Parse(await startResponse.Content.ReadAsStringAsync());
+        var jobId = acceptedDoc.RootElement.GetProperty("jobId").GetString();
+        var result = await WaitForApplyJobResultAsync(client, jobId!);
+        result.GetProperty("status").GetString().Should().Be("succeeded");
+        result.GetProperty("result").TryGetProperty("apt", out _).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task Admin_apply_global_preflight_does_not_fail_on_poisoned_sibling_scope()
+    {
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        SeedPoisonedSiblingScope(_factory.StorageRoot);
+        using var client = _factory.CreateAdminClient();
+
+        var applyResponse = await client.PostAsync("/admin/apply", CreateApplyTargetsBody("apt"));
+
+        applyResponse.StatusCode.Should().NotBe(HttpStatusCode.BadRequest);
+        applyResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+    }
+
+    [TestMethod]
+    public async Task Admin_apply_rejects_scoped_apt_target()
+    {
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        using var client = _factory.CreateAdminClient();
+        var scopedAdminUrl = BuildScopedAdminUrl(_factory.Notebook);
+
+        var applyResponse = await client.PostAsync(
+            $"/admin/apply{scopedAdminUrl}",
+            CreateApplyTargetsBody("apt"));
+
+        applyResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await applyResponse.Content.ReadAsStringAsync();
+        body.Should().Contain("Scoped apply cannot target apt");
+    }
+
+    [TestMethod]
+    public async Task Admin_apply_rejects_global_pip_target()
+    {
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        using var client = _factory.CreateAdminClient();
+
+        var applyResponse = await client.PostAsync("/admin/apply", CreateApplyTargetsBody("pip"));
+
+        applyResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await applyResponse.Content.ReadAsStringAsync();
+        body.Should().Contain("Global apply supports only apt");
+    }
+
+    [TestMethod]
+    public async Task Admin_startup_reconcile_is_apt_only_and_ignores_poisoned_scopes()
+    {
+        _factory = new ScriptExecutionAgentWebApplicationFactory(enableAdminApi: true);
+        var poisonedScopeRoot = SeedPoisonedSiblingScope(_factory.StorageRoot);
+        var adminStateDir = Path.Combine(_factory.StorageRoot, ".guideants", "script-agent-admin");
+        var scopeStateRoot = Path.Combine(_factory.StorageRoot, ".guideants", "script-execution");
+        var adminOptions = new AdminApiOptions(true, ScriptExecutionAgentWebApplicationFactory.AdminToken, adminStateDir, FailOpen: false);
+        var scopeOptions = new ScriptExecutionScopeOptions(scopeStateRoot, null, null, false, null);
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddSimpleConsole());
+        var logger = loggerFactory.CreateLogger<Program>();
+
+        var act = () => AdminStateRuntime.ReconcileStartupStateAsync(
+            adminOptions,
+            scopeOptions,
+            logger,
+            CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        File.Exists(Path.Combine(poisonedScopeRoot, "applied-state.json")).Should().BeFalse();
+    }
+
+    private static StringContent CreateApplyTargetsBody(params string[] targets) =>
+        new(JsonSerializer.Serialize(new { targets }), Encoding.UTF8, "application/json");
+
+    private static string SeedPoisonedSiblingScope(string storageRoot)
+    {
+        var scopeStateRoot = Path.Combine(storageRoot, ".guideants", "script-execution");
+        var poisonedProjectId = Guid.NewGuid();
+        var poisonedGuideId = Guid.NewGuid();
+        var scopeRoot = Path.Combine(scopeStateRoot, $"project-{poisonedProjectId:N}", $"guide-{poisonedGuideId:N}");
+        Directory.CreateDirectory(scopeRoot);
+        File.WriteAllText(
+            Path.Combine(scopeRoot, "requirements.txt"),
+            "--index-url https://example.invalid/simple");
+        return scopeRoot;
+    }
+
     private static async Task<JsonElement> StartApplyAndWaitForResultAsync(
         HttpClient client,
         string? scopedUrl = null,
         TimeSpan? timeout = null)
     {
-        var startResponse = await client.PostAsync("/admin/apply" + (scopedUrl ?? string.Empty), content: null);
+        var startResponse = await client.PostAsync(
+            "/admin/apply" + (scopedUrl ?? string.Empty),
+            string.IsNullOrEmpty(scopedUrl)
+                ? CreateApplyTargetsBody("apt")
+                : CreateApplyTargetsBody("pip", "installScripts"));
         startResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
         using var acceptedDoc = JsonDocument.Parse(await startResponse.Content.ReadAsStringAsync());
         var jobId = acceptedDoc.RootElement.GetProperty("jobId").GetString();

--- a/src/server/ScriptExecutionAgent/AdminApplyJobRuntime.cs
+++ b/src/server/ScriptExecutionAgent/AdminApplyJobRuntime.cs
@@ -36,6 +36,7 @@ internal static class AdminApplyJobRuntime
     internal static async Task<AdminApplyJobAccepted> StartApplyAsync(
         bool hasScope,
         ScriptExecutionScope? scope,
+        AdminApplyTargets targets,
         ScriptExecutionScopeOptions scopeOptions,
         AdminApiOptions adminOptions,
         ILogger logger,
@@ -55,18 +56,15 @@ internal static class AdminApplyJobRuntime
         {
             await ScriptExecutionScopeRuntime.PreflightScopeRequirementsAsync(
                 scope!,
+                targets,
                 scopeOptions,
                 adminOptions,
                 logger,
                 preflightCts.Token);
         }
-        else
+        else if (targets.Apt)
         {
-            await AdminStateRuntime.PreflightGlobalApplyAsync(
-                scopeOptions,
-                adminOptions,
-                logger,
-                preflightCts.Token);
+            await AdminStateRuntime.PreflightGlobalAptPackagesAsync(adminOptions, preflightCts.Token);
         }
 
         var job = new AdminApplyJobRecord(
@@ -79,7 +77,7 @@ internal static class AdminApplyJobRuntime
         ActiveJobByScopeKey[scopeKey] = job.JobId;
         await PersistJobAsync(job, adminOptions, cancellationToken);
 
-        _ = Task.Run(() => RunJobAsync(job, hasScope, scope, scopeOptions, adminOptions, logger));
+        _ = Task.Run(() => RunJobAsync(job, hasScope, scope, targets, scopeOptions, adminOptions, logger));
 
         return ToAccepted(job);
     }
@@ -183,6 +181,7 @@ internal static class AdminApplyJobRuntime
         AdminApplyJobRecord job,
         bool hasScope,
         ScriptExecutionScope? scope,
+        AdminApplyTargets targets,
         ScriptExecutionScopeOptions scopeOptions,
         AdminApiOptions adminOptions,
         ILogger logger)
@@ -198,6 +197,7 @@ internal static class AdminApplyJobRuntime
             {
                 result = await ScriptExecutionScopeRuntime.ApplyScopeRequirementsAsync(
                     scope!,
+                    targets,
                     scopeOptions,
                     adminOptions,
                     logger,
@@ -206,12 +206,7 @@ internal static class AdminApplyJobRuntime
             else
             {
                 var aptResult = await AdminStateRuntime.ApplyGlobalAptPackagesAsync(adminOptions, logger, cts.Token);
-                var scopeResult = await AdminStateRuntime.ApplyAllKnownScopesAsync(
-                    scopeOptions,
-                    adminOptions,
-                    logger,
-                    cts.Token);
-                result = scopeResult with
+                result = aptResult with
                 {
                     Apt = new AdminApplyResultDetails(
                         aptResult.Status,

--- a/src/server/ScriptExecutionAgent/AdminApplyTargets.cs
+++ b/src/server/ScriptExecutionAgent/AdminApplyTargets.cs
@@ -1,0 +1,81 @@
+namespace ScriptExecutionAgent;
+
+internal sealed record AdminApplyRequest(string[]? Targets);
+
+internal sealed class AdminApplyTargets
+{
+    private static readonly HashSet<string> Allowed = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "apt",
+        "pip",
+        "installScripts"
+    };
+
+    public bool Apt { get; private init; }
+
+    public bool Pip { get; private init; }
+
+    public bool InstallScripts { get; private init; }
+
+    public static AdminApplyTargets Resolve(bool hasScope, IReadOnlyList<string>? requestedTargets)
+    {
+        if (requestedTargets is not null && requestedTargets.Count == 0)
+        {
+            throw new InvalidOperationException("Apply targets cannot be empty.");
+        }
+
+        var targets = requestedTargets is { Count: > 0 }
+            ? requestedTargets
+            : hasScope
+                ? new[] { "pip", "installScripts" }
+                : new[] { "apt" };
+
+        var normalized = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var target in targets)
+        {
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                throw new InvalidOperationException("Apply targets cannot contain empty values.");
+            }
+
+            if (!Allowed.Contains(target))
+            {
+                throw new InvalidOperationException(
+                    $"Apply target '{target}' is not supported. Allowed targets: apt, pip, installScripts.");
+            }
+
+            normalized.Add(target);
+        }
+
+        if (!hasScope)
+        {
+            if (normalized.Contains("pip") || normalized.Contains("installScripts"))
+            {
+                throw new InvalidOperationException(
+                    "Global apply supports only apt. Use scoped apply for pip and installScripts.");
+            }
+
+            if (!normalized.Contains("apt"))
+            {
+                throw new InvalidOperationException("Global apply requires target apt.");
+            }
+        }
+        else if (normalized.Contains("apt"))
+        {
+            throw new InvalidOperationException(
+                "Scoped apply cannot target apt. Use global apply with targets [\"apt\"].");
+        }
+        else if (!normalized.Contains("pip") && !normalized.Contains("installScripts"))
+        {
+            throw new InvalidOperationException(
+                "Scoped apply requires at least one of pip or installScripts.");
+        }
+
+        return new AdminApplyTargets
+        {
+            Apt = normalized.Contains("apt"),
+            Pip = normalized.Contains("pip"),
+            InstallScripts = normalized.Contains("installScripts")
+        };
+    }
+}

--- a/src/server/ScriptExecutionAgent/Program.cs
+++ b/src/server/ScriptExecutionAgent/Program.cs
@@ -672,9 +672,18 @@ if (adminOptions.Enabled)
 
         try
         {
+            var body = await ReadRequestBodyAsync(context);
+            AdminApplyRequest? applyRequest = null;
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                applyRequest = JsonSerializer.Deserialize<AdminApplyRequest>(body, adminApiJsonOptions);
+            }
+
+            var targets = AdminApplyTargets.Resolve(hasScope, applyRequest?.Targets);
             var accepted = await AdminApplyJobRuntime.StartApplyAsync(
                 hasScope,
                 hasScope ? scope : null,
+                targets,
                 scopeOptions,
                 adminOptions,
                 logger,
@@ -1828,7 +1837,13 @@ internal static class ScriptExecutionScopeRuntime
             var desiredTopLevelPackages = ParseTopLevelRequirementPackageNames(requirementsText);
             var requirementsHash = ComputeSha256(requirementsText);
             var appliedState = AdminScopeAppliedStateRuntime.Read(scope);
-            if (requirementsHash == appliedState.RequirementsHash)
+            var scopedSitePackagesPath = ResolveScopedSitePackagesPath(scope.PythonVenvPath);
+            var missingTopLevelPackages = await GetMissingTopLevelPackagesAsync(
+                scope.PythonExecutablePath,
+                scopedSitePackagesPath,
+                desiredTopLevelPackages,
+                cancellationToken);
+            if (requirementsHash == appliedState.RequirementsHash && missingTopLevelPackages.Count == 0)
             {
                 return;
             }
@@ -1854,6 +1869,7 @@ internal static class ScriptExecutionScopeRuntime
 
             await PruneUnmanagedTopLevelPackagesAsync(
                 scope.PythonExecutablePath,
+                scopedSitePackagesPath,
                 desiredTopLevelPackages,
                 cancellationToken);
 
@@ -1878,6 +1894,7 @@ internal static class ScriptExecutionScopeRuntime
 
     public static async Task<AdminApplyResult> ApplyScopeRequirementsAsync(
         ScriptExecutionScope scope,
+        AdminApplyTargets targets,
         ScriptExecutionScopeOptions scopeOptions,
         AdminApiOptions adminOptions,
         ILogger logger,
@@ -1907,23 +1924,33 @@ internal static class ScriptExecutionScopeRuntime
             var desiredTopLevelPackages = ParseTopLevelRequirementPackageNames(requirementsText);
             var requirementsHash = ComputeSha256(requirementsText);
             var appliedState = AdminScopeAppliedStateRuntime.Read(scope);
+            var scopedSitePackagesPath = ResolveScopedSitePackagesPath(scope.PythonVenvPath);
+            var missingTopLevelPackages = await GetMissingTopLevelPackagesAsync(
+                scope.PythonExecutablePath,
+                scopedSitePackagesPath,
+                desiredTopLevelPackages,
+                cancellationToken);
             var unmanagedPackagesBeforeInstall = await GetUnmanagedTopLevelPackagesAsync(
                 scope.PythonExecutablePath,
+                scopedSitePackagesPath,
                 desiredTopLevelPackages,
                 cancellationToken);
             var installScriptsDocument = AdminInstallScriptsRuntime.ReadDocument(scope);
             var installScriptsHash = AdminInstallScriptsRuntime.ComputeDocumentHash(installScriptsDocument);
-            var requirementsNeedsApply = requirementsHash != appliedState.RequirementsHash || unmanagedPackagesBeforeInstall.Count > 0;
-            var scriptsNeedApply = AdminInstallScriptsRuntime.NeedsApply(
-                installScriptsHash,
-                appliedState.InstallScriptsHash,
-                installScriptsDocument.Scripts.Count);
+            var pipInstallNeeded = requirementsHash != appliedState.RequirementsHash || missingTopLevelPackages.Count > 0;
+            var requirementsNeedsApply = targets.Pip
+                && (pipInstallNeeded || unmanagedPackagesBeforeInstall.Count > 0);
+            var scriptsNeedApply = targets.InstallScripts
+                && AdminInstallScriptsRuntime.NeedsApply(
+                    installScriptsHash,
+                    appliedState.InstallScriptsHash,
+                    installScriptsDocument.Scripts.Count);
             if (!requirementsNeedsApply && !scriptsNeedApply)
             {
                 return new AdminApplyResult("skipped", 0, 1, Array.Empty<string>());
             }
 
-            if (requirementsNeedsApply && requirementsHash != appliedState.RequirementsHash && !string.IsNullOrWhiteSpace(requirementsText))
+            if (requirementsNeedsApply && pipInstallNeeded && !string.IsNullOrWhiteSpace(requirementsText))
             {
                 var result = await Cli.Wrap(scope.PythonExecutablePath)
                     .WithArguments(args => args
@@ -1946,6 +1973,7 @@ internal static class ScriptExecutionScopeRuntime
             {
                 await PruneUnmanagedTopLevelPackagesAsync(
                     scope.PythonExecutablePath,
+                    scopedSitePackagesPath,
                     desiredTopLevelPackages,
                     cancellationToken);
             }
@@ -1964,10 +1992,12 @@ internal static class ScriptExecutionScopeRuntime
 
             await AdminScopeAppliedStateRuntime.WriteAsync(
                 scope,
-                requirementsHash,
-                requirementsPath,
-                desiredTopLevelPackages,
-                installScriptsHash,
+                targets.Pip && requirementsNeedsApply ? requirementsHash : appliedState.RequirementsHash,
+                targets.Pip && requirementsNeedsApply ? requirementsPath : appliedState.RequirementsPath,
+                targets.Pip && requirementsNeedsApply
+                    ? desiredTopLevelPackages
+                    : appliedState.TopLevelPackages,
+                targets.InstallScripts && scriptsNeedApply ? installScriptsHash : appliedState.InstallScriptsHash,
                 installScriptStepResults,
                 cancellationToken);
             logger.LogInformation(
@@ -2120,6 +2150,7 @@ internal static class ScriptExecutionScopeRuntime
 
     public static async Task PreflightScopeRequirementsAsync(
         ScriptExecutionScope scope,
+        AdminApplyTargets targets,
         ScriptExecutionScopeOptions scopeOptions,
         AdminApiOptions adminOptions,
         ILogger logger,
@@ -2143,40 +2174,54 @@ internal static class ScriptExecutionScopeRuntime
         var desiredTopLevelPackages = ParseTopLevelRequirementPackageNames(requirementsText);
         var requirementsHash = ComputeSha256(requirementsText);
         var appliedState = AdminScopeAppliedStateRuntime.Read(scope);
-        var unmanagedPackagesBeforeInstall = await GetUnmanagedTopLevelPackagesAsync(
+        var scopedSitePackagesPath = ResolveScopedSitePackagesPath(scope.PythonVenvPath);
+        var missingTopLevelPackages = await GetMissingTopLevelPackagesAsync(
             scope.PythonExecutablePath,
+            scopedSitePackagesPath,
             desiredTopLevelPackages,
             cancellationToken);
-        if (requirementsHash != appliedState.RequirementsHash || unmanagedPackagesBeforeInstall.Count > 0)
+        var unmanagedPackagesBeforeInstall = await GetUnmanagedTopLevelPackagesAsync(
+            scope.PythonExecutablePath,
+            scopedSitePackagesPath,
+            desiredTopLevelPackages,
+            cancellationToken);
+        var pipInstallNeeded = requirementsHash != appliedState.RequirementsHash || missingTopLevelPackages.Count > 0;
+        if (targets.Pip)
         {
-            if (requirementsHash != appliedState.RequirementsHash && !string.IsNullOrWhiteSpace(requirementsText))
+            if (pipInstallNeeded || unmanagedPackagesBeforeInstall.Count > 0)
             {
-                var result = await Cli.Wrap(scope.PythonExecutablePath)
-                    .WithArguments(args => args
-                        .Add("-m")
-                        .Add("pip")
-                        .Add("--disable-pip-version-check")
-                        .Add("install")
-                        .Add("--dry-run")
-                        .Add("-r")
-                        .Add(requirementsPath))
-                    .WithValidation(CommandResultValidation.None)
-                    .ExecuteBufferedAsync(cancellationToken);
-
-                if (result.ExitCode != 0)
+                if (pipInstallNeeded && !string.IsNullOrWhiteSpace(requirementsText))
                 {
-                    throw new InvalidOperationException(FormatPipFailure(result));
+                    var result = await Cli.Wrap(scope.PythonExecutablePath)
+                        .WithArguments(args => args
+                            .Add("-m")
+                            .Add("pip")
+                            .Add("--disable-pip-version-check")
+                            .Add("install")
+                            .Add("--dry-run")
+                            .Add("-r")
+                            .Add(requirementsPath))
+                        .WithValidation(CommandResultValidation.None)
+                        .ExecuteBufferedAsync(cancellationToken);
+
+                    if (result.ExitCode != 0)
+                    {
+                        throw new InvalidOperationException(FormatPipFailure(result));
+                    }
                 }
             }
         }
 
-        var installScriptsDocument = AdminInstallScriptsRuntime.ReadDocument(scope);
-        await AdminInstallScriptsRuntime.PreflightSyntaxAsync(
-            scope,
-            scopeOptions,
-            installScriptsDocument,
-            logger,
-            cancellationToken);
+        if (targets.InstallScripts)
+        {
+            var installScriptsDocument = AdminInstallScriptsRuntime.ReadDocument(scope);
+            await AdminInstallScriptsRuntime.PreflightSyntaxAsync(
+                scope,
+                scopeOptions,
+                installScriptsDocument,
+                logger,
+                cancellationToken);
+        }
     }
 
     private static string FormatPipFailure(BufferedCommandResult result)
@@ -2430,12 +2475,40 @@ internal static class ScriptExecutionScopeRuntime
         return packageNames;
     }
 
-    private static async Task<IReadOnlyList<string>> GetUnmanagedTopLevelPackagesAsync(
+    private static string? ResolveScopedSitePackagesPath(string pythonVenvPath) =>
+        FindPythonSitePackages(pythonVenvPath).FirstOrDefault();
+
+    private static async Task<IReadOnlyList<string>> GetMissingTopLevelPackagesAsync(
         string pythonExecutablePath,
+        string? scopedSitePackagesPath,
         IReadOnlySet<string> desiredTopLevelPackages,
         CancellationToken cancellationToken)
     {
-        var installedTopLevelPackages = await GetInstalledTopLevelPackagesAsync(pythonExecutablePath, cancellationToken);
+        if (desiredTopLevelPackages.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var installedTopLevelPackages = await GetInstalledTopLevelPackagesAsync(
+            pythonExecutablePath,
+            scopedSitePackagesPath,
+            cancellationToken);
+        return desiredTopLevelPackages
+            .Where(packageName => !installedTopLevelPackages.Contains(packageName))
+            .OrderBy(static packageName => packageName, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static async Task<IReadOnlyList<string>> GetUnmanagedTopLevelPackagesAsync(
+        string pythonExecutablePath,
+        string? scopedSitePackagesPath,
+        IReadOnlySet<string> desiredTopLevelPackages,
+        CancellationToken cancellationToken)
+    {
+        var installedTopLevelPackages = await GetInstalledTopLevelPackagesAsync(
+            pythonExecutablePath,
+            scopedSitePackagesPath,
+            cancellationToken);
         return installedTopLevelPackages
             .Where(packageName =>
                 !ProtectedTopLevelPythonPackages.Contains(packageName)
@@ -2446,6 +2519,7 @@ internal static class ScriptExecutionScopeRuntime
 
     private static async Task<IReadOnlyList<string>> PruneUnmanagedTopLevelPackagesAsync(
         string pythonExecutablePath,
+        string? scopedSitePackagesPath,
         IReadOnlySet<string> desiredTopLevelPackages,
         CancellationToken cancellationToken)
     {
@@ -2455,6 +2529,7 @@ internal static class ScriptExecutionScopeRuntime
         {
             var toRemove = await GetUnmanagedTopLevelPackagesAsync(
                 pythonExecutablePath,
+                scopedSitePackagesPath,
                 desiredTopLevelPackages,
                 cancellationToken);
             if (toRemove.Count == 0)
@@ -2497,16 +2572,23 @@ internal static class ScriptExecutionScopeRuntime
 
     private static async Task<IReadOnlySet<string>> GetInstalledTopLevelPackagesAsync(
         string pythonExecutablePath,
+        string? scopedSitePackagesPath,
         CancellationToken cancellationToken)
     {
         var listResult = await Cli.Wrap(pythonExecutablePath)
-            .WithArguments(args => args
-                .Add("-m")
-                .Add("pip")
-                .Add("--disable-pip-version-check")
-                .Add("list")
-                .Add("--not-required")
-                .Add("--format=json"))
+            .WithArguments(args =>
+            {
+                args.Add("-m")
+                    .Add("pip")
+                    .Add("--disable-pip-version-check")
+                    .Add("list")
+                    .Add("--not-required")
+                    .Add("--format=json");
+                if (!string.IsNullOrWhiteSpace(scopedSitePackagesPath))
+                {
+                    args.Add("--path").Add(scopedSitePackagesPath);
+                }
+            })
             .WithValidation(CommandResultValidation.None)
             .ExecuteBufferedAsync(cancellationToken);
 
@@ -2684,10 +2766,9 @@ internal static class AdminStateRuntime
         }
     }
 
-    // Applies global apt packages and reconciles every known scope's Python requirements/install
-    // scripts. Intentionally NOT awaited during startup: it performs lengthy pip/apt work and must
-    // never gate the HTTP listener. /execute provisions whatever scope it needs on demand, so this
-    // is a warm-up reconcile rather than a prerequisite for serving requests.
+    // Applies global apt packages onto the container rootfs. Intentionally NOT awaited during
+    // startup: apt work must never gate the HTTP listener. Scoped pip venvs live on the durable
+    // admin volume and are provisioned on demand by EnsureScopeRequirementsForExecutionAsync.
     public static async Task ReconcileStartupStateAsync(
         AdminApiOptions adminOptions,
         ScriptExecutionScopeOptions scopeOptions,
@@ -2697,13 +2778,9 @@ internal static class AdminStateRuntime
         try
         {
             var aptResult = await ApplyGlobalAptPackagesAsync(adminOptions, logger, cancellationToken);
-            var result = await ApplyAllKnownScopesAsync(scopeOptions, adminOptions, logger, cancellationToken);
             logger.LogInformation(
-                "ScriptExecutionAgent admin startup reconcile complete. aptStatus={AptStatus} status={Status} scopesApplied={Applied} scopesSkipped={Skipped}",
-                aptResult.Status,
-                result.Status,
-                result.ScopesApplied,
-                result.ScopesSkipped);
+                "ScriptExecutionAgent admin startup reconcile complete. aptStatus={AptStatus}",
+                aptResult.Status);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -2746,25 +2823,6 @@ internal static class AdminStateRuntime
         }
 
         return ValidationResult.Success();
-    }
-
-    public static async Task PreflightGlobalApplyAsync(
-        ScriptExecutionScopeOptions scopeOptions,
-        AdminApiOptions adminOptions,
-        ILogger logger,
-        CancellationToken cancellationToken)
-    {
-        await PreflightGlobalAptPackagesAsync(adminOptions, cancellationToken);
-
-        foreach (var scope in ScriptExecutionScopeRuntime.EnumerateExistingScopes(scopeOptions))
-        {
-            await ScriptExecutionScopeRuntime.PreflightScopeRequirementsAsync(
-                scope,
-                scopeOptions,
-                adminOptions,
-                logger,
-                cancellationToken);
-        }
     }
 
     public static async Task PreflightGlobalAptPackagesAsync(
@@ -2941,41 +2999,6 @@ internal static class AdminStateRuntime
             packagesToRemove.Length,
             hash);
         return new AdminApplyResult("applied", 1, 0, Array.Empty<string>());
-    }
-
-    public static async Task<AdminApplyResult> ApplyAllKnownScopesAsync(
-        ScriptExecutionScopeOptions scopeOptions,
-        AdminApiOptions adminOptions,
-        ILogger logger,
-        CancellationToken cancellationToken)
-    {
-        var errors = new List<string>();
-        var applied = 0;
-        var skipped = 0;
-
-        foreach (var scope in ScriptExecutionScopeRuntime.EnumerateExistingScopes(scopeOptions))
-        {
-            try
-            {
-                var result = await ScriptExecutionScopeRuntime.ApplyScopeRequirementsAsync(scope, scopeOptions, adminOptions, logger, cancellationToken);
-                applied += result.ScopesApplied;
-                skipped += result.ScopesSkipped;
-            }
-            catch (Exception ex)
-            {
-                var message = $"project={scope.ProjectId:D} guide={scope.GuideScopeId:D}: {ex.Message}";
-                errors.Add(message);
-                logger.LogWarning(ex, "Failed to apply scoped requirements. {Scope}", message);
-            }
-        }
-
-        if (errors.Count > 0 && !adminOptions.FailOpen)
-        {
-            throw new InvalidOperationException($"One or more scoped requirement applies failed: {string.Join("; ", errors)}");
-        }
-
-        var status = errors.Count > 0 ? "partial" : applied > 0 ? "applied" : "skipped";
-        return new AdminApplyResult(status, applied, skipped, errors.ToArray());
     }
 
     private static string ComputeSha256(string value)

--- a/src/server/ScriptExecutionAgent/README.md
+++ b/src/server/ScriptExecutionAgent/README.md
@@ -72,7 +72,21 @@ All admin requests require `X-Script-Agent-Admin-Token`.
 
 Scoped `install-scripts.json` stores ordered setup scripts (`Python` or `Bash`) that run after pip requirements during apply and on replay. Each script's last status is recorded in `applied-state.json`.
 
-`POST /admin/apply` runs synchronous preflight (requirements/apt validation plus pip/apt dry-run when installs are needed) and returns `400` on preflight failure. When preflight passes it returns `202 Accepted` with a `jobId` and starts background apply work detached from the HTTP request (default timeout: 60 minutes via `SCRIPT_EXECUTION_ADMIN_APPLY_TIMEOUT_MINUTES`). Poll `GET /admin/apply/jobs/{jobId}` for `queued`, `running`, `succeeded`, or `failed` status. Preflight timeout defaults to 120 seconds (`SCRIPT_EXECUTION_ADMIN_APPLY_PREFLIGHT_TIMEOUT_SECONDS`).
+`POST /admin/apply` runs synchronous preflight for the requested **targets** only, then returns `400` on preflight failure. When preflight passes it returns `202 Accepted` with a `jobId` and starts background apply work detached from the HTTP request (default timeout: 60 minutes via `SCRIPT_EXECUTION_ADMIN_APPLY_TIMEOUT_MINUTES`). Poll `GET /admin/apply/jobs/{jobId}` for `queued`, `running`, `succeeded`, or `failed` status. Preflight timeout defaults to 120 seconds (`SCRIPT_EXECUTION_ADMIN_APPLY_PREFLIGHT_TIMEOUT_SECONDS`).
+
+Apply request body (JSON, optional — defaults apply when omitted):
+
+```json
+{ "targets": ["apt"] }
+```
+
+| Caller intent | Scope | Targets | Work performed |
+|---|---|---|---|
+| OS packages | Global (no `projectId`/`guideId`) | `["apt"]` | Reconcile `apt-packages.txt` onto container rootfs |
+| Python + scripts | Scoped (`projectId` + `guideId`) | `["pip", "installScripts"]` | Update **that** guide's durable `python-venv/` only |
+| Defaults | Omitted body | Global → `apt`; scoped → `pip` + `installScripts` | Same as above |
+
+Global apply never walks scoped venvs. Scoped apply never touches apt. Startup reconcile is **apt-only**; scoped pip venvs on the durable volume are source of truth and are ensured on demand at `/execute`.
 
 `GET`/`PUT /admin/requirements` and `POST /admin/apply` operate on global state unless both `projectId` and `guideId` query parameters are provided. Scoped requests affect the shared `project + guide` Python venv used by all matching notebooks.
 
@@ -98,6 +112,8 @@ Python runtime state is scoped by `project + guide`:
 All notebooks in the same project that use the same guide share that venv. Scoped requirements are applied into the scoped venv before Python execution. If a scoped `requirements.txt` does not exist, the agent uses the global admin `requirements.txt` as the fallback requirements source for that scope.
 
 Scoped venvs extend the image-provided Python runtime instead of replacing it. By default on Linux, the agent links the scoped venv to `/opt/venv` site-packages with a `.pth` file. Packages installed into the scoped venv remain first on `sys.path`, and baked image packages remain available as a fallback. Set `SCRIPT_EXECUTION_BASE_PYTHON_VENV` to override the base runtime venv path or leave it unset on non-AI images.
+
+Scoped pip apply and prune only inspect packages installed under the scoped venv's own `site-packages` directory. Inherited base-runtime packages are never treated as unmanaged guide requirements.
 
 The optional `environment` object on `/execute` is a per-run injection surface. Values are placed only into the launched script process environment; they are not persisted by the ScriptExecutionAgent and are not written to scope state.
 
@@ -150,8 +166,12 @@ That volume stores:
 - global `apt-packages.txt`
 - global `applied-state.json`
 - scoped state under `scopes/project-{projectId:N}/guide-{guideId:N}/`
+  - `requirements.txt`, `install-scripts.json`, `applied-state.json`
+  - `python-venv/` — **durable pip source of truth** (survives container restart/replace)
 
 The volume survives container restart and normal `docker compose down` / `up`. It is removed by `docker compose down -v` or manual volume deletion.
+
+**Durable vs ephemeral:** scoped `python-venv/` trees live on this volume and are not reinstalled on process start. Only apt packages (container rootfs) are re-materialized at startup and via global apply with `targets: ["apt"]`.
 
 ## Container Integration
 


### PR DESCRIPTION
## Summary

Scoped sandbox apply was walking every guide scope and re-running pip on startup, which was slow, noisy, and could touch unrelated venvs. This PR makes apply **intent-driven and scope-bounded**: global apply is **apt-only**, scoped apply updates **one guide venv**, and startup reconcile is **apt-only** with durable scoped venvs as the source of truth.

Also fixes two pip reconcile bugs found during holistic testing:
- Apply could report success without installing packages when `applied-state` hash matched but packages were missing.
- Repeat scoped apply took ~47s and returned `applied` because inherited `/opt/venv` packages (via `.pth`) were treated as unmanaged and pruned every run.

### SEA (`ScriptExecutionAgent`)
- Add `AdminApplyTargets` (`apt` | `pip` | `installScripts`) with validation and defaults: global → `["apt"]`, scoped → `["pip","installScripts"]`.
- Remove world-reconcile paths (`ApplyAllKnownScopesAsync`, global pip walk).
- `ReconcileStartupStateAsync` is **apt-only**.
- Pip missing-package detection: install when hash differs **or** desired top-level packages are absent from the venv.
- Pip prune/list scoped to the venv's own `site-packages` (`pip list --path …`) so base-runtime inheritance is not touched.

### API + client
- `SandboxAdminApplyRequest` / `SandboxAdminApplyIntent` synthesize and forward correct `targets` JSON.
- Client bridges send scoped `["pip","installScripts"]` and global `["apt"]`.
- OpenAPI + guide-admin instructions updated.

### Tests
- Unit/integration: illegal target combos, poisoned sibling scope, startup apt-only, omitted-body defaults, missing-package re-apply, idempotent scoped skip.
- Client vitest for bridge target forwarding.

## Holistic verification (local `guideants-ai`)

| Scenario | Result |
|---|---|
| Global apt apply | ~1.2s, `skipped`, `scopesApplied: 0` |
| Scoped apply (satisfied) | ~1.8s, `skipped` |
| Scoped apply (missing package, hash unchanged) | ~4.8s, `applied`, package restored |
| Container restart | Venv persisted; post-restart apply `skipped` |
| `/sandbox/execute` | Imports OK from durable scoped venv |
| Startup | `aptStatus=skipped`, no scoped pip walk |

## Test plan

- [x] `ScriptExecutionAgent.Tests` — Admin apply / targets suite (Linux CI for scoped venv tests)
- [x] `SandboxAdminApplyIntentTests`
- [x] `sandboxAdminBridge.test.ts`
- [x] Manual holistic: global apt, scoped apply skip/apply, restart, execute