### PR TITLE
Fix Microsoft Foundry Connections overwriting the stored API key on Resource edits

### DIFF
--- a/src/client/src/components/home/addAiServicesWizard/steps/CoreConnectionStep.tsx
+++ b/src/client/src/components/home/addAiServicesWizard/steps/CoreConnectionStep.tsx
@@ -52,7 +52,11 @@ export function CoreConnectionStep({
           type="password"
           value={apiKey}
           onChange={(event) => onChange({ apiKey: event.target.value })}
-          autoComplete="off"
+          // autoComplete="off" is ignored by browser password managers on password inputs; this
+          // field sits directly after a plain-text "Resource" input, which password managers
+          // treat as a login-form shape and will silently autofill into the field below,
+          // overwriting the SECRET_MASK sentinel this form relies on to detect "unchanged".
+          autoComplete="new-password"
           className={`w-full rounded border px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 ${
             errors.apiKey ? 'border-red-500' : 'border-gray-300'
           }`}

--- a/src/client/src/pages/settings/__tests__/utils.test.ts
+++ b/src/client/src/pages/settings/__tests__/utils.test.ts
@@ -28,6 +28,7 @@ import {
   parseFieldValue,
   parseRuntimeProfileId,
   payloadSignature,
+  stripStoredSecretPlaceholders,
   withSecretPreserved,
 } from '../utils';
 
@@ -348,13 +349,16 @@ describe('settings utility helpers', () => {
     expect(withSecretPreserved('', false)).toBe('');
   });
 
-  it('prepareSectionPayloadForSave preserves stored secrets omitted from draft', () => {
+  it('prepareSectionPayloadForSave omits a stored secret left blank in the draft', () => {
+    // Regression for the Microsoft Foundry Connections bug: an untouched secret field must be
+    // dropped from the save payload entirely (not sent as SECRET_MASK), so a value a password
+    // manager silently autofilled into the field is never sent unless the input is non-blank.
     const section: SettingsSectionDto = {
       sectionName: 'HuggingFace',
       schemaVersion: 1,
       rowVersion: 'rv',
       updatedUtc: '2026-01-01T00:00:00Z',
-      payload: { Token: SECRET_MASK, RouterBaseUrl: 'https://router.huggingface.co/v1' },
+      payload: { Token: '', RouterBaseUrl: 'https://router.huggingface.co/v1' },
       secretHasValue: { Token: true },
     };
     const schema: SettingsSectionSchemaDto = {
@@ -368,13 +372,107 @@ describe('settings utility helpers', () => {
     };
 
     const payload = prepareSectionPayloadForSave(
-      { RouterBaseUrl: 'https://example.com' },
+      { Token: '', RouterBaseUrl: 'https://example.com' },
       section,
       schema,
     );
 
-    expect(payload.Token).toBe(SECRET_MASK);
+    expect('Token' in payload).toBe(false);
     expect(payload.RouterBaseUrl).toBe('https://example.com');
+  });
+
+  it('prepareSectionPayloadForSave sends a non-blank secret as typed', () => {
+    const section: SettingsSectionDto = {
+      sectionName: 'HuggingFace',
+      schemaVersion: 1,
+      rowVersion: 'rv',
+      updatedUtc: '2026-01-01T00:00:00Z',
+      payload: { Token: '', RouterBaseUrl: 'https://router.huggingface.co/v1' },
+      secretHasValue: { Token: true },
+    };
+    const schema: SettingsSectionSchemaDto = {
+      sectionName: 'HuggingFace',
+      schemaVersion: 1,
+      hasSecrets: true,
+      properties: [
+        { name: 'Token', valueType: 'string', isSecret: true, isEditable: true, isRequired: true },
+        { name: 'RouterBaseUrl', valueType: 'string', isSecret: false, isEditable: true, isRequired: false },
+      ],
+    };
+
+    const payload = prepareSectionPayloadForSave(
+      { Token: 'hf_new_token', RouterBaseUrl: 'https://router.huggingface.co/v1' },
+      section,
+      schema,
+    );
+
+    expect(payload.Token).toBe('hf_new_token');
+  });
+
+  it('prepareSectionPayloadForSave keeps sending empty string when no secret is stored yet', () => {
+    const section: SettingsSectionDto = {
+      sectionName: 'HuggingFace',
+      schemaVersion: 1,
+      rowVersion: 'rv',
+      updatedUtc: '2026-01-01T00:00:00Z',
+      payload: { Token: '', RouterBaseUrl: '' },
+      secretHasValue: { Token: false },
+    };
+    const schema: SettingsSectionSchemaDto = {
+      sectionName: 'HuggingFace',
+      schemaVersion: 1,
+      hasSecrets: true,
+      properties: [
+        { name: 'Token', valueType: 'string', isSecret: true, isEditable: true, isRequired: true },
+        { name: 'RouterBaseUrl', valueType: 'string', isSecret: false, isEditable: true, isRequired: false },
+      ],
+    };
+
+    const payload = prepareSectionPayloadForSave({ Token: '', RouterBaseUrl: '' }, section, schema);
+
+    // No stored secret to preserve - sending '' still lets server-side required-field
+    // validation reject the save, same as before this change.
+    expect(payload.Token).toBe('');
+  });
+
+  it('prepareSectionPayloadForSave falls back to section.secretHasValue when schema failed to load', () => {
+    // Guards the hazard noted in the investigation: if getSchema() errored, schema is
+    // undefined - the guard must still find the secret fields instead of skipping the
+    // omit-on-blank normalization entirely.
+    const section: SettingsSectionDto = {
+      sectionName: 'AzureOpenAI',
+      schemaVersion: 1,
+      rowVersion: 'rv',
+      updatedUtc: '2026-01-01T00:00:00Z',
+      payload: { Resource: 'my-foundry', ApiKey: '' },
+      secretHasValue: { ApiKey: true },
+    };
+
+    const payload = prepareSectionPayloadForSave(
+      { Resource: 'new-foundry-resource', ApiKey: '' },
+      section,
+      undefined,
+    );
+
+    expect('ApiKey' in payload).toBe(false);
+    expect(payload.Resource).toBe('new-foundry-resource');
+  });
+
+  it('stripStoredSecretPlaceholders blanks stored secrets and leaves other fields untouched', () => {
+    const section: SettingsSectionDto = {
+      sectionName: 'AzureOpenAI',
+      schemaVersion: 1,
+      rowVersion: 'rv',
+      updatedUtc: '2026-01-01T00:00:00Z',
+      payload: { Resource: 'my-foundry', ApiKey: SECRET_MASK, ApiVersion: '2025-04-01-preview' },
+      secretHasValue: { ApiKey: true },
+    };
+
+    const draft = stripStoredSecretPlaceholders(section);
+
+    expect(draft.ApiKey).toBe('');
+    expect(draft.Resource).toBe('my-foundry');
+    expect(draft.ApiVersion).toBe('2025-04-01-preview');
   });
 
   it('formats valid ISO timestamps', () => {

--- a/src/client/src/pages/settings/components/ConnectionsTab.tsx
+++ b/src/client/src/pages/settings/components/ConnectionsTab.tsx
@@ -18,8 +18,6 @@ import {
 } from '../constants/connectionSections';
 import { getConnectionSectionDisplayName } from '../constants/displayLabels';
 import {
-  SECRET_MASK,
-  clonePayload,
   getErrorMessage,
   getInputTextValue,
   getSectionSchema,
@@ -28,8 +26,10 @@ import {
   parseFieldValue,
   payloadSignature,
   prepareSectionPayloadForSave,
+  stripStoredSecretPlaceholders,
 } from '../utils';
 import { TextActionButton } from './shared/ActionButtons';
+import { SecretInput } from './inputs/SecretInput';
 
 /**
  * Phase D (R-5.3 / R-5.5 / R-5.6 / R-8.1 / R-10.3): the Connections tab.
@@ -196,7 +196,7 @@ export function ConnectionsTab({
         } else {
           setSectionPreservedDraft(null);
         }
-        setSectionDraft(clonePayload(next.payload));
+        setSectionDraft(stripStoredSecretPlaceholders(next));
       } catch (error) {
         setSectionError(getErrorMessage(error, `Failed to load section ${sectionName}.`));
         setSectionData(null);
@@ -267,7 +267,7 @@ export function ConnectionsTab({
     if (!sectionData) {
       return;
     }
-    setSectionDraft(clonePayload(sectionData.payload));
+    setSectionDraft(stripStoredSecretPlaceholders(sectionData));
   }, [sectionData]);
 
   const handleDiscardPreservedDraft = useCallback(() => {
@@ -296,7 +296,7 @@ export function ConnectionsTab({
         payload: prepareSectionPayloadForSave(sectionDraft, sectionData, selectedSchema),
       });
       setSectionData(updated);
-      setSectionDraft(clonePayload(updated.payload));
+      setSectionDraft(stripStoredSecretPlaceholders(updated));
       setSectionPreservedDraft(null);
       onRefreshSectionSummaries();
       showToast({ type: 'success', title: `Saved ${getConnectionSectionDisplayName(updated.sectionName)}` });
@@ -334,7 +334,13 @@ export function ConnectionsTab({
     onRefreshSectionSummaries();
   }, [selectedSection, loadSection, loadUsage, loadOverview, onRefreshSectionSummaries]);
 
-  const isDirty = sectionData ? payloadSignature(sectionDraft) !== payloadSignature(sectionData.payload) : false;
+  // Compared against the same blanked-secret baseline the draft was seeded from (see
+  // stripStoredSecretPlaceholders), not the raw sectionData.payload - that still carries
+  // SECRET_MASK for stored secrets, which would make every section with a stored secret look
+  // dirty immediately after load even with no edits.
+  const isDirty = sectionData
+    ? payloadSignature(sectionDraft) !== payloadSignature(stripStoredSecretPlaceholders(sectionData))
+    : false;
 
   const { requiredProperties, optionalProperties } = useMemo(() => {
     if (!selectedSection || !selectedSchema) {
@@ -734,10 +740,25 @@ function FieldEditor({ section, property, value, disabled, onValueChange, tabInd
           />
           Enabled
         </label>
+      ) : property.isSecret ? (
+        // Left blank on load (see loadSection / handleResetDraft) rather than pre-filled with
+        // SECRET_MASK, and rendered with autoComplete="new-password" rather than "off" - browser
+        // password managers ignore autoComplete="off" on password inputs and will silently
+        // autofill a saved credential into this field when it sits next to a text input like
+        // Resource, overwriting the stored secret on save. See prepareSectionPayloadForSave,
+        // which omits this field entirely from the save payload while it stays blank.
+        <SecretInput
+          id={fieldInputId}
+          value={getInputTextValue(value)}
+          onChange={(next) => onValueChange(property.name, next)}
+          storedHasValue={Boolean(section.secretHasValue?.[property.name])}
+          disabled={disabled}
+          tabIndex={tabIndex}
+        />
       ) : (
         <input
           id={fieldInputId}
-          type={property.isSecret ? 'password' : property.valueType === 'int' ? 'number' : 'text'}
+          type={property.valueType === 'int' ? 'number' : 'text'}
           value={getInputTextValue(value)}
           onChange={(event) => onValueChange(property.name, parseFieldValue(event.target.value, property))}
           className="w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-100"
@@ -746,14 +767,6 @@ function FieldEditor({ section, property, value, disabled, onValueChange, tabInd
           disabled={disabled}
           tabIndex={tabIndex}
         />
-      )}
-
-      {property.isSecret && (
-        <p className="text-xs text-gray-500">
-          {section.secretHasValue?.[property.name]
-            ? `A secret is stored. Keep ${SECRET_MASK} to preserve it, or type a new value.`
-            : 'No secret stored yet. Enter a value to save one.'}
-        </p>
       )}
     </div>
   );

--- a/src/client/src/pages/settings/components/__tests__/ConnectionsTab.extended.test.tsx
+++ b/src/client/src/pages/settings/components/__tests__/ConnectionsTab.extended.test.tsx
@@ -110,6 +110,8 @@ describe('ConnectionsTab extended', () => {
   });
 
   it('preserves stored secrets when the api key field is left empty on save', async () => {
+    // The stored ApiKey is preserved by omitting it from the save payload entirely (not by
+    // resending SECRET_MASK) - see prepareSectionPayloadForSave / MergeForUpdate.
     const user = userEvent.setup();
     renderConnectionsTab();
 
@@ -124,11 +126,12 @@ describe('ConnectionsTab extended', () => {
         expect.objectContaining({
           payload: expect.objectContaining({
             Organization: 'org-updated',
-            ApiKey: '********',
           }),
         }),
       );
     });
+    const [, request] = vi.mocked(api.settings.updateSection).mock.calls[0];
+    expect('ApiKey' in (request.payload as Record<string, unknown>)).toBe(false);
   });
 
   it('resets unsaved draft edits back to the loaded section payload', async () => {

--- a/src/client/src/pages/settings/components/__tests__/ConnectionsTab.test.tsx
+++ b/src/client/src/pages/settings/components/__tests__/ConnectionsTab.test.tsx
@@ -63,7 +63,7 @@ const sectionData = {
   schemaVersion: 1,
   rowVersion: 'row-1',
   updatedUtc: '2026-01-01T00:00:00Z',
-  payload: { Organization: 'org-1' },
+  payload: { ApiKey: '********', Organization: 'org-1' },
   secretHasValue: { ApiKey: true },
 };
 
@@ -131,6 +131,58 @@ describe('ConnectionsTab', () => {
       );
     });
     expect(props.onRefreshSectionSummaries).toHaveBeenCalled();
+  });
+
+  it('renders a stored secret blank rather than the mask, and omits it from the save payload when untouched', async () => {
+    // Regression for the Microsoft Foundry Connections bug: editing a sibling field (here,
+    // Organization) must not resend the ApiKey at all, so nothing a password manager may have
+    // autofilled into the (now blank, not mask-prefilled) key field can leak into the request.
+    const user = userEvent.setup();
+    renderConnectionsTab();
+
+    const organizationInput = await screen.findByDisplayValue('org-1');
+
+    const apiKeyInput = document.getElementById('OpenAI-ApiKey') as HTMLInputElement;
+    expect(apiKeyInput).toBeInTheDocument();
+    expect(apiKeyInput.value).toBe('');
+    expect(apiKeyInput.type).toBe('password');
+    expect(apiKeyInput.autocomplete).toBe('new-password');
+
+    await user.clear(organizationInput);
+    await user.type(organizationInput, 'org-updated');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(api.settings.updateSection).toHaveBeenCalledWith(
+        'OpenAI',
+        expect.objectContaining({
+          rowVersion: 'row-1',
+          payload: expect.objectContaining({ Organization: 'org-updated' }),
+        }),
+      );
+    });
+    const [, request] = vi.mocked(api.settings.updateSection).mock.calls[0];
+    expect('ApiKey' in (request.payload as Record<string, unknown>)).toBe(false);
+  });
+
+  it('sends a newly typed secret value on save', async () => {
+    const user = userEvent.setup();
+    renderConnectionsTab();
+
+    await screen.findByDisplayValue('org-1');
+    const apiKeyInput = document.getElementById('OpenAI-ApiKey') as HTMLInputElement;
+
+    await user.type(apiKeyInput, 'sk-new-real-key');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(api.settings.updateSection).toHaveBeenCalledWith(
+        'OpenAI',
+        expect.objectContaining({
+          payload: expect.objectContaining({ ApiKey: 'sk-new-real-key' }),
+        }),
+      );
+    });
   });
 
   it('surfaces section load failures', async () => {

--- a/src/client/src/pages/settings/components/inputs/SecretInput.tsx
+++ b/src/client/src/pages/settings/components/inputs/SecretInput.tsx
@@ -4,23 +4,37 @@ interface SecretInputProps {
   /** When true, a secret is already stored server-side (value is not echoed). */
   storedHasValue?: boolean;
   placeholder?: string;
+  id?: string;
+  disabled?: boolean;
+  tabIndex?: number;
 }
 
 const STORED_PLACEHOLDER = 'Stored — leave blank to keep; type to replace';
 
-export function SecretInput({ value, onChange, storedHasValue = false, placeholder }: SecretInputProps) {
+export function SecretInput({
+  value,
+  onChange,
+  storedHasValue = false,
+  placeholder,
+  id,
+  disabled,
+  tabIndex,
+}: SecretInputProps) {
   const showStoredHint = storedHasValue && value === '';
   const effectivePlaceholder = showStoredHint ? STORED_PLACEHOLDER : placeholder;
 
   return (
     <div className="space-y-1">
       <input
+        id={id}
         type="password"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
         placeholder={effectivePlaceholder}
         autoComplete="new-password"
+        disabled={disabled}
+        tabIndex={tabIndex}
         aria-label={showStoredHint ? 'API key or secret credential' : undefined}
       />
       {showStoredHint ? (

--- a/src/client/src/pages/settings/components/inputs/__tests__/SecretInput.test.tsx
+++ b/src/client/src/pages/settings/components/inputs/__tests__/SecretInput.test.tsx
@@ -21,4 +21,20 @@ describe('SecretInput', () => {
     await userEvent.type(input, 'abc');
     expect(onChange).toHaveBeenCalled();
   });
+
+  it('uses autoComplete="new-password" so browser password managers do not autofill it', () => {
+    // autoComplete="off" is ignored by password managers on type="password" inputs; this is
+    // the attribute that actually suppresses the Foundry Connections autofill-overwrite bug.
+    render(<SecretInput value="" onChange={() => {}} />);
+    const input = document.querySelector('input[type="password"]') as HTMLInputElement;
+    expect(input.autocomplete).toBe('new-password');
+  });
+
+  it('forwards id, disabled, and tabIndex for use in a labelled form grid', () => {
+    render(<SecretInput value="" onChange={() => {}} id="Section-ApiKey" disabled tabIndex={3} />);
+    const input = document.getElementById('Section-ApiKey') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.disabled).toBe(true);
+    expect(input.tabIndex).toBe(3);
+  });
 });

--- a/src/client/src/pages/settings/utils.ts
+++ b/src/client/src/pages/settings/utils.ts
@@ -462,10 +462,28 @@ export function withSecretPreserved(value: string, hasStoredValue: boolean): str
   return hasStoredValue ? SECRET_MASK : '';
 }
 
+function getSecretPropertyNames(
+  section: SettingsSectionDto,
+  schema: SettingsSectionSchemaDto | undefined,
+): string[] {
+  if (schema) {
+    return schema.properties.filter((property) => property.isSecret).map((property) => property.name);
+  }
+  // Schema fetch can fail independently of the section fetch; secretHasValue always carries an
+  // entry for every secret property on the section itself (see MaskSecrets server-side), so it
+  // is a reliable fallback that keeps the omit-on-blank guard below active either way.
+  return section.secretHasValue ? Object.keys(section.secretHasValue) : [];
+}
+
 /**
  * Normalizes a Connections-tab draft immediately before
- * {@code PUT /api/settings/sections/{name}} so untouched or cleared secret
- * inputs do not overwrite stored secrets with an empty string.
+ * {@code PUT /api/settings/sections/{name}} so an untouched secret input is omitted from the
+ * save payload entirely, rather than sent as a value. {@code MergeForUpdate} server-side treats
+ * a missing property as "keep the existing stored secret" (see ApplicationSettingsJson.cs), so
+ * omission - not a mask placeholder - is what preserves it. This also means a field a password
+ * manager autofilled without the user noticing is only sent if it is non-blank, same as any
+ * other edit; the mask-placeholder approach previously here relied on the input always holding
+ * literal "********" until deliberately changed, which autofill silently defeats.
  */
 export function prepareSectionPayloadForSave(
   draft: Record<string, unknown>,
@@ -473,17 +491,40 @@ export function prepareSectionPayloadForSave(
   schema: SettingsSectionSchemaDto | undefined,
 ): Record<string, unknown> {
   const payload = clonePayload(draft);
-  const secretPropertyNames =
-    schema?.properties.filter((property) => property.isSecret).map((property) => property.name) ?? [];
+  const secretPropertyNames = getSecretPropertyNames(section, schema);
 
   for (const propertyName of secretPropertyNames) {
-    payload[propertyName] = withSecretPreserved(
-      getInputTextValue(payload[propertyName]),
-      Boolean(section.secretHasValue?.[propertyName]),
-    );
+    const raw = getInputTextValue(payload[propertyName]).trim();
+    if (raw.length > 0) {
+      payload[propertyName] = raw;
+      continue;
+    }
+
+    if (section.secretHasValue?.[propertyName]) {
+      delete payload[propertyName];
+    } else {
+      payload[propertyName] = '';
+    }
   }
 
   return payload;
+}
+
+/**
+ * Seeds a freshly-loaded section's draft with blank values for secrets that already have a
+ * stored value, instead of the literal {@code SECRET_MASK} placeholder the server echoes back.
+ * Used by ConnectionsTab so an untouched secret input renders empty - matching the "leave blank
+ * to keep" contract in {@link SecretInput} - rather than holding a fixed sentinel string that a
+ * browser password manager can match against and silently overwrite.
+ */
+export function stripStoredSecretPlaceholders(section: SettingsSectionDto): Record<string, unknown> {
+  const draft = clonePayload(section.payload);
+  for (const propertyName of Object.keys(section.secretHasValue ?? {})) {
+    if (section.secretHasValue?.[propertyName]) {
+      draft[propertyName] = '';
+    }
+  }
+  return draft;
 }
 
 export function getSectionSchema(schema: SettingsSchemaDto | null, sectionName: string) {

--- a/src/server/GuideAntsApi.Tests/Settings/ApplicationSettingsJsonDeep2Tests.cs
+++ b/src/server/GuideAntsApi.Tests/Settings/ApplicationSettingsJsonDeep2Tests.cs
@@ -190,6 +190,38 @@ public sealed class ApplicationSettingsJsonDeep2Tests
     }
 
     [TestMethod]
+    public void EncryptSecrets_SkipsEncV2PrefixedValues()
+    {
+        var definition = SecretDefinition();
+        var options = ValidOptions();
+
+        var result = ApplicationSettingsJson.EncryptSecrets(
+            definition,
+            new JsonObject { ["ApiKey"] = "encv2::already::encoded" },
+            options);
+
+        result["ApiKey"]!.GetValue<string>().Should().Be("encv2::already::encoded");
+    }
+
+    [TestMethod]
+    public void EncryptSecrets_SkipsLegacyEncPrefixedValues_ToAvoidDoubleWrapping()
+    {
+        // DecryptSecrets preserves an enc:: value verbatim when it fails to decrypt (no legacy
+        // protector supplied, or the cipher is corrupt). EncryptSecrets must not treat that
+        // leftover "enc::..." string as plaintext and encrypt it - that would permanently
+        // corrupt the secret into a double-wrapped, undecryptable value on the very next save.
+        var definition = SecretDefinition();
+        var options = ValidOptions();
+
+        var result = ApplicationSettingsJson.EncryptSecrets(
+            definition,
+            new JsonObject { ["ApiKey"] = "enc::CfDJ8undecryptable" },
+            options);
+
+        result["ApiKey"]!.GetValue<string>().Should().Be("enc::CfDJ8undecryptable");
+    }
+
+    [TestMethod]
     public void DecryptSecrets_LeavesValue_WhenEncV2EnvelopeMalformed()
     {
         var definition = SecretDefinition();
@@ -293,6 +325,53 @@ public sealed class ApplicationSettingsJsonDeep2Tests
             new JsonObject());
 
         merged["ApiKey"]!.GetValue<string>().Should().Be("existing-secret");
+    }
+
+    [TestMethod]
+    public void PreserveUnchangedSecretCiphertext_RestoresOriginalCiphertext_WhenPlaintextUnchanged()
+    {
+        var definition = SecretDefinition();
+        var rawCurrentPayload = new JsonObject { ["ApiKey"] = "encv2::k1::original-ciphertext" };
+        var decryptedCurrent = new JsonObject { ["ApiKey"] = "same-secret" };
+        // Simulates a save that only touched a sibling field: MergeForUpdate carried the
+        // decrypted plaintext through unchanged (e.g. because the client omitted ApiKey, or
+        // sent SECRET_MASK).
+        var merged = new JsonObject { ["ApiKey"] = "same-secret" };
+
+        var result = ApplicationSettingsJson.PreserveUnchangedSecretCiphertext(
+            definition, rawCurrentPayload, decryptedCurrent, merged);
+
+        result["ApiKey"]!.GetValue<string>().Should().Be("encv2::k1::original-ciphertext");
+    }
+
+    [TestMethod]
+    public void PreserveUnchangedSecretCiphertext_LeavesNewPlaintext_WhenSecretActuallyChanged()
+    {
+        var definition = SecretDefinition();
+        var rawCurrentPayload = new JsonObject { ["ApiKey"] = "encv2::k1::original-ciphertext" };
+        var decryptedCurrent = new JsonObject { ["ApiKey"] = "old-secret" };
+        var merged = new JsonObject { ["ApiKey"] = "brand-new-secret" };
+
+        var result = ApplicationSettingsJson.PreserveUnchangedSecretCiphertext(
+            definition, rawCurrentPayload, decryptedCurrent, merged);
+
+        result["ApiKey"]!.GetValue<string>().Should().Be("brand-new-secret");
+    }
+
+    [TestMethod]
+    public void PreserveUnchangedSecretCiphertext_DoesNotRestore_WhenOriginalWasLegacyEncoding()
+    {
+        // A legacy enc:: value should still be upgraded to encv2:: on an unrelated save rather
+        // than preserved verbatim, so legacy rows eventually migrate off DataProtection.
+        var definition = SecretDefinition();
+        var rawCurrentPayload = new JsonObject { ["ApiKey"] = "enc::legacy-cipher" };
+        var decryptedCurrent = new JsonObject { ["ApiKey"] = "same-secret" };
+        var merged = new JsonObject { ["ApiKey"] = "same-secret" };
+
+        var result = ApplicationSettingsJson.PreserveUnchangedSecretCiphertext(
+            definition, rawCurrentPayload, decryptedCurrent, merged);
+
+        result["ApiKey"]!.GetValue<string>().Should().Be("same-secret");
     }
 
     [TestMethod]

--- a/src/server/GuideAntsApi.Tests/Settings/ApplicationSettingsServiceDeepTests.cs
+++ b/src/server/GuideAntsApi.Tests/Settings/ApplicationSettingsServiceDeepTests.cs
@@ -199,6 +199,148 @@ public sealed class ApplicationSettingsServiceDeepTests
         reloaded!.Payload["Default"]!.GetValue<string>().Should().Be("Information");
     }
 
+    [TestMethod]
+    public async Task UpdateSectionAsync_ResourceOnlyEdit_LeavesApiKeyCiphertextByteIdentical()
+    {
+        // Regression for the Microsoft Foundry Connections bug: editing Resource alone must not
+        // touch the stored ApiKey - neither its plaintext, nor (as a secondary guarantee) its
+        // ciphertext bytes in the row, which would needlessly churn on every unrelated save.
+        const string foundrySection = "AzureOpenAI";
+        var configuration = BuildConfigurationWithFoundryConnection();
+
+        await using var db = CreateDbContext();
+        var service = CreateService(db, configuration);
+        await service.BootstrapAsync(configuration);
+
+        var section = await service.GetSectionAsync(foundrySection);
+        section.Should().NotBeNull();
+        section!.SecretHasValue["ApiKey"].Should().BeTrue();
+
+        var rawBefore = await db.ApplicationSettings.AsNoTracking()
+            .SingleAsync(x => x.SectionName == foundrySection);
+        var apiKeyCiphertextBefore = System.Text.Json.Nodes.JsonNode.Parse(rawBefore.JsonValue)!["ApiKey"]!.GetValue<string>();
+        apiKeyCiphertextBefore.Should().StartWith("encv2::");
+
+        // Only Resource is present in the incoming payload, mirroring what the fixed client now
+        // sends (the ApiKey field is omitted entirely rather than round-tripping a mask).
+        var result = await service.UpdateSectionAsync(
+            foundrySection,
+            new UpdateSettingsSectionRequest(section.RowVersion, new JsonObject
+            {
+                ["Resource"] = "new-foundry-resource"
+            }));
+
+        result.ConcurrencyConflict.Should().BeFalse();
+        result.ValidationErrors.Should().BeEmpty();
+        result.Section.Should().NotBeNull();
+        result.Section!.Payload["Resource"]!.GetValue<string>().Should().Be("new-foundry-resource");
+        result.Section.SecretHasValue["ApiKey"].Should().BeTrue();
+
+        var rawAfter = await db.ApplicationSettings.AsNoTracking()
+            .SingleAsync(x => x.SectionName == foundrySection);
+        var apiKeyCiphertextAfter = System.Text.Json.Nodes.JsonNode.Parse(rawAfter.JsonValue)!["ApiKey"]!.GetValue<string>();
+
+        apiKeyCiphertextAfter.Should().Be(apiKeyCiphertextBefore);
+    }
+
+    [TestMethod]
+    public async Task UpdateSectionAsync_ResourceOnlyEdit_KeepsApiKeyPlaintextRecoverable()
+    {
+        const string foundrySection = "AzureOpenAI";
+        var configuration = BuildConfigurationWithFoundryConnection();
+
+        await using var db = CreateDbContext();
+        var service = CreateService(db, configuration);
+        await service.BootstrapAsync(configuration);
+        var section = await service.GetSectionAsync(foundrySection);
+
+        await service.UpdateSectionAsync(
+            foundrySection,
+            new UpdateSettingsSectionRequest(section!.RowVersion, new JsonObject
+            {
+                ["Resource"] = "another-resource"
+            }));
+
+        // Route through GetSectionAsync (masked) plus a direct decrypt to confirm the real
+        // plaintext key used for authenticating to Foundry actually survived the save.
+        var protector = ApplicationSettingsJson.CreateLegacyProtector(AppContext.BaseDirectory);
+        var raw = await db.ApplicationSettings.AsNoTracking().SingleAsync(x => x.SectionName == foundrySection);
+        var decrypted = ApplicationSettingsJson.DecryptSecrets(
+            new SettingsSectionRegistry().All.Single(s => s.SectionName == foundrySection),
+            ApplicationSettingsJson.DeserializeObject(raw.JsonValue),
+            new SettingsSecretsOptions
+            {
+                ActiveKeyId = "tests",
+                Keys = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["tests"] = "MDEyMzQ1Njc4OUFCQ0RFRjAxMjM0NTY3ODlBQkNERUY="
+                }
+            },
+            protector);
+
+        decrypted["ApiKey"]!.GetValue<string>().Should().Be("original-foundry-key");
+    }
+
+    [TestMethod]
+    public async Task UpdateSectionAsync_ResourceEditWithMaskedApiKey_LeavesApiKeyCiphertextByteIdentical()
+    {
+        // The Add-AI-Services wizard still sends SECRET_MASK explicitly (rather than omitting
+        // the field) for an untouched key - that path must get the same ciphertext stability.
+        const string foundrySection = "AzureOpenAI";
+        var configuration = BuildConfigurationWithFoundryConnection();
+
+        await using var db = CreateDbContext();
+        var service = CreateService(db, configuration);
+        await service.BootstrapAsync(configuration);
+        var section = await service.GetSectionAsync(foundrySection);
+
+        var rawBefore = await db.ApplicationSettings.AsNoTracking()
+            .SingleAsync(x => x.SectionName == foundrySection);
+        var apiKeyCiphertextBefore = System.Text.Json.Nodes.JsonNode.Parse(rawBefore.JsonValue)!["ApiKey"]!.GetValue<string>();
+
+        var result = await service.UpdateSectionAsync(
+            foundrySection,
+            new UpdateSettingsSectionRequest(section!.RowVersion, new JsonObject
+            {
+                ["Resource"] = "wizard-updated-resource",
+                ["ApiKey"] = ApplicationSettingsJson.SecretMask
+            }));
+
+        result.ValidationErrors.Should().BeEmpty();
+        result.Section!.Payload["Resource"]!.GetValue<string>().Should().Be("wizard-updated-resource");
+
+        var rawAfter = await db.ApplicationSettings.AsNoTracking()
+            .SingleAsync(x => x.SectionName == foundrySection);
+        var apiKeyCiphertextAfter = System.Text.Json.Nodes.JsonNode.Parse(rawAfter.JsonValue)!["ApiKey"]!.GetValue<string>();
+
+        apiKeyCiphertextAfter.Should().Be(apiKeyCiphertextBefore);
+    }
+
+    private static IConfiguration BuildConfigurationWithFoundryConnection()
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["SettingsSecrets:ActiveKeyId"] = "tests",
+            ["SettingsSecrets:Keys:tests"] = "MDEyMzQ1Njc4OUFCQ0RFRjAxMjM0NTY3ODlBQkNERUY=",
+            ["Ui:RootPath"] = "./ui",
+            ["LlamaCpp:BaseUrl"] = "http://localhost:8110/llama-cpp",
+            ["ServiceRouting:Containers:guideants-ai:BaseUrl"] = "http://localhost:8110/sandbox",
+            ["LocalServiceHosts:SpeechTranscriptionBaseUrl"] = "http://localhost:8110",
+            ["LocalServiceHosts:SpeechSynthesisBaseUrl"] = "http://localhost:8110",
+            ["LocalServiceHosts:ImageGenerationBaseUrl"] = "http://localhost:8110",
+            ["LocalServiceHosts:EmbeddingsBaseUrl"] = "http://localhost:8110",
+            ["LocalServiceHosts:MediaBaseUrl"] = "http://localhost:8110",
+            ["LocalServiceHosts:DocumentIntelligenceBaseUrl"] = "http://localhost:5001",
+            ["GoogleGeminiApi:ApiKey"] = "test-gemini-key",
+            ["AzureOpenAI:Resource"] = "original-foundry-resource",
+            ["AzureOpenAI:ApiKey"] = "original-foundry-key"
+        };
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
     private static ApplicationDbContext CreateDbContext()
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()

--- a/src/server/GuideAntsApi/Settings/ApplicationSettingsJson.cs
+++ b/src/server/GuideAntsApi/Settings/ApplicationSettingsJson.cs
@@ -109,6 +109,14 @@ public static class ApplicationSettingsJson
                 continue;
             }
 
+            if (raw.StartsWith(LegacySecretCipherPrefix, StringComparison.Ordinal))
+            {
+                // A legacy enc:: value that failed to decrypt (DecryptSecrets preserves the
+                // original string on failure) must not be re-encrypted as if it were plaintext -
+                // doing so would permanently corrupt the secret into a double-wrapped value.
+                continue;
+            }
+
             var encrypted = EncryptEncV2(raw, activeKeyId, activeKeyBytes);
             copy[secret.Name] = encrypted;
         }
@@ -220,6 +228,57 @@ public static class ApplicationSettingsJson
         }
 
         return merged;
+    }
+
+    /// <summary>
+    /// Rewrites any secret in <paramref name="merged"/> whose plaintext is unchanged from
+    /// <paramref name="decryptedCurrent"/> back to its original ciphertext from
+    /// <paramref name="rawCurrentPayload"/>, when that ciphertext is already <c>encv2::</c>-encoded.
+    /// <see cref="EncryptSecrets"/> skips values already in that form, so callers who apply this
+    /// before encrypting get a byte-stable secret ciphertext for saves that did not actually
+    /// change the secret (e.g. editing a sibling field like Resource) instead of a fresh
+    /// re-encryption with a new nonce on every save.
+    /// </summary>
+    public static JsonObject PreserveUnchangedSecretCiphertext(
+        SettingsSectionDefinition definition,
+        JsonObject rawCurrentPayload,
+        JsonObject decryptedCurrent,
+        JsonObject merged)
+    {
+        var result = CloneObject(merged);
+
+        foreach (var secret in definition.Properties.Where(p => p.IsSecret))
+        {
+            if (!result.TryGetPropertyValue(secret.Name, out var mergedNode))
+            {
+                continue;
+            }
+
+            var mergedPlaintext = NodeToString(mergedNode);
+            var currentPlaintext = decryptedCurrent.TryGetPropertyValue(secret.Name, out var currentNode)
+                ? NodeToString(currentNode)
+                : string.Empty;
+
+            if (!string.Equals(mergedPlaintext, currentPlaintext, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!rawCurrentPayload.TryGetPropertyValue(secret.Name, out var rawNode))
+            {
+                continue;
+            }
+
+            var rawValue = NodeToString(rawNode);
+            if (!rawValue.StartsWith(SecretCipherPrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            result[secret.Name] = rawValue;
+        }
+
+        return result;
     }
 
     public static JsonObject CanonicalizeToDefinition(SettingsSectionDefinition definition, JsonObject payload)

--- a/src/server/GuideAntsApi/Settings/ApplicationSettingsService.Sections.cs
+++ b/src/server/GuideAntsApi/Settings/ApplicationSettingsService.Sections.cs
@@ -94,9 +94,10 @@ public sealed partial class ApplicationSettingsService
         }
 
         var protector = GetProtector();
+        var rawCurrentPayload = ApplicationSettingsJson.DeserializeObject(row.JsonValue);
         var decryptedCurrent = ApplicationSettingsJson.DecryptSecrets(
             definition,
-            ApplicationSettingsJson.DeserializeObject(row.JsonValue),
+            rawCurrentPayload,
             _settingsSecretsOptionsMonitor.CurrentValue,
             protector.Protect);
 
@@ -118,9 +119,18 @@ public sealed partial class ApplicationSettingsService
             return (null, validationErrors, false);
         }
 
+        // Secrets whose plaintext is unchanged keep their original ciphertext instead of being
+        // re-encrypted with a fresh nonce, so saves that only touch a sibling field (e.g. Resource)
+        // don't churn the stored ApiKey bytes.
+        var preservedForEncryption = ApplicationSettingsJson.PreserveUnchangedSecretCiphertext(
+            definition,
+            rawCurrentPayload,
+            decryptedCurrent,
+            merged);
+
         var encrypted = ApplicationSettingsJson.EncryptSecrets(
             definition,
-            merged,
+            preservedForEncryption,
             _settingsSecretsOptionsMonitor.CurrentValue);
         row.JsonValue = ApplicationSettingsJson.Serialize(encrypted);
         row.SchemaVersion = definition.SchemaVersion;


### PR DESCRIPTION
### Problem
Editing only the **Resource** field under Settings → Connections → Microsoft Foundry replaced the API key

### Fixes
- `ConnectionsTab` now renders secret fields with `SecretInput` (`autoComplete="new-password"`), seeded blank instead of the mask.
- `prepareSectionPayloadForSave` omits an untouched secret from the save payload entirely instead of resending `SECRET_MASK`, with a fallback to `secretHasValue` when the schema fails to load.
- `UpdateSectionAsync` now restores the original ciphertext for any secret whose plaintext is unchanged (`PreserveUnchangedSecretCiphertext`), so unrelated saves no longer churn the stored API key bytes.
- `EncryptSecrets` skips `enc::`-prefixed values, matching the existing `encv2::` skip, so a failed legacy decrypt can no longer be corrupted on the next save.