### PR TITLE
Show NotFound for unmatched SPA routes

### DIFF
--- a/docs/spa-unmatched-route-404-design.md
+++ b/docs/spa-unmatched-route-404-design.md
@@ -1,0 +1,351 @@
+# SPA unmatched-route 404 — design (Defect A)
+
+**Status:** Design only — no implementation until this document is accepted.  
+**Scope:** First defect only — blank screen when React Router matches no route.  
+**Out of scope for this change:** inventing `/guides/:id` smart redirects, `returnUrl` allowlisting, docs path cleanup (follow-ups).
+
+---
+
+## 1. Existing routing
+
+### 1.1 Router selection (Electron vs browser)
+
+| Runtime | Detection | Router | URL shape |
+|---------|-----------|--------|-----------|
+| Electron | `isElectron()` (`window.electron`, UA, `process.versions.electron`, `file:`) | `HashRouter` | `…/index.html#/projects/…` |
+| Browser / Azure Container Apps | not Electron | `BrowserRouter` | `https://host/projects/…` |
+
+Source: `src/client/src/utils/environment.ts` (`getRouterType`), `src/client/src/App.tsx`.
+
+**Implication for any redirect:** always use React Router `navigate('/')` (or `<Link to="/">`). Do **not** use `window.location.href = '/'` for the happy path — that breaks HashRouter (drops the hash route and can leave Electron on a useless path).
+
+### 1.2 Shell stack (order matters)
+
+From `App.tsx`, inside the chosen `Router`:
+
+1. `StartupGate` — **browser only** (`enabled={routerType === 'browser'}`); polls `GET ${API_BASE_URL}/startup` until `ready`. Electron skips.
+2. `AuthProvider` — cookie session; `GET /api/auth/me` on mount.
+3. `GuideAntsGuideProvider` — flyout; reads route via `matchPath` (does not own routing).
+4. `AuthExpiredHandler` — on `auth-expired`, `navigate(/login?returnUrl=…)` for non-public paths.
+5. `UrlCorrector` — hash malformation only (`##`, missing `#/` in hash mode). Does **not** rewrite unknown SPA paths.
+6. `AppContent` — `<Routes>` / `<Route>` table (sole route owner).
+
+Outside / beside:
+
+- **ErrorBoundary** wraps the tree → `ErrorScreen` on thrown render errors (different from unmatched routes).
+- **OAuth HashRouter special case** in `App.tsx`: if hash mode and pathname is `/oauth/callback` or `/redirect`, render `OAuthCallback` **before** mounting `HashRouter` (path lives on the document URL, not the hash).
+
+### 1.3 Complete client route table (`AppContent.tsx`)
+
+#### Public (no `ProtectedRoute`)
+
+| Path | Page |
+|------|------|
+| `/login` | Login |
+| `/register` | Register |
+| `/oauth/callback` | OAuthCallback |
+| `/redirect` | OAuthCallback |
+| `/terms` | Terms |
+| `/privacy` | Privacy |
+| `/public/:friendlyName` | PublicGuide |
+
+#### Authenticated (`ProtectedRoute`)
+
+| Path | Extra guard | Page |
+|------|-------------|------|
+| `/pending` | role Pending only (others → `/`) | Pending |
+| `/change-password` | `mustChangePassword` | ChangePassword |
+| `/` | — | Home |
+| `/projects` | — | Projects |
+| `/conversations` | — | Conversations |
+| `/usage` | — | Usage |
+| `/cli/authorize` | — | CliAuthorize |
+| `/settings` | — | Settings |
+| `/settings/system-guides` | Admin; else `/settings` | SystemGuidesWorkspace |
+| `/new-project` | Editor (blocks Reader → `/`) | NewProject |
+| `/projects/:projectId` | + ProjectProvider | ProjectDetails |
+| `/projects/:projectId/edit` | Editor + ProjectProvider | EditProject |
+| `/projects/:projectId/notebooks/:notebookId` | + ProjectProvider | NotebookDetails |
+| `/projects/:projectId/notebooks/:notebookId/edit` | Editor + ProjectProvider | EditNotebook |
+| `/projects/:projectId/notebooks/:notebookId/files/preview` | + ProjectProvider | FilePreviewPage |
+| `/projects/:projectId/guides` | Admin + ProjectProvider | GuidesDashboard |
+| `/projects/:projectId/guides/guide/new` | Admin + ProjectProvider | GuideEditor |
+| `/projects/:projectId/guides/guide/:guideId` | Admin + ProjectProvider | GuideEditor |
+| `/projects/:projectId/guides/guide/:guideId/usage` | Admin + ProjectProvider | GuideUsagePage |
+| `/projects/:projectId/guides/assistant/new` | Admin + ProjectProvider | AssistantEditor |
+| `/projects/:projectId/guides/assistant/:assistantId` | Admin + ProjectProvider | AssistantEditor |
+| `/projects/:projectId/guides/assistant/:assistantId/usage` | Admin + ProjectProvider | GuideUsagePage |
+
+**There is no `path="*"` catch-all today.**
+
+### 1.4 Special cases (must not regress)
+
+| Case | Behavior today | Risk if 404 is wrong |
+|------|----------------|----------------------|
+| **Protected unknown path** | Unmatched → blank (no login redirect) | Catch-all must not sit *inside* a single catch-all ProtectedRoute that changes auth redirects for valid routes |
+| **Auth loading** | Spinner on protected routes | Catch-all must not wrap the whole tree |
+| **Pending / mustChangePassword** | Hard redirects to `/pending`, `/change-password` | Unchanged |
+| **Admin / Editor guards** | `Navigate` to fallback — **matched** routes, not 404 | `/projects/:id/guides` for Reader is redirect-to-home, not NotFound |
+| **Param routes with bad IDs** | Still **match** (e.g. `/projects/not-a-guid`) → page/API error UX | Must remain page-owned; **not** NotFound |
+| **Auth expiry** | Preserve `pathname+search` as `returnUrl` | Unchanged by this fix |
+| **Login `returnUrl`** | Any path starting with `/` accepted | Unchanged; bad returnUrl can still land on NotFound after login (acceptable for this change) |
+| **OAuth callback (browser)** | Routes `/oauth/callback`, `/redirect` | Must still match before `*` |
+| **OAuth callback (Electron hash)** | Pre-router branch on document pathname | Untouched |
+| **UrlCorrector** | Hash-only fixes + reload | Untouched |
+| **StartupGate** | Blocks Router until API ready (browser) | NotFound only reachable after gate + Router mount |
+| **GuideAnts Guide bridge** | Navigates only known app paths | Untouched |
+| **Server SPA fallback** | Non-`/api` GETs get `index.html` 200 | Unchanged; client NotFound is the user-visible fix |
+| **API paths `/api/guides/...`** | Never hit React Router | Untouched |
+
+### 1.5 Existing visual pattern for full-page messages
+
+`ErrorScreen` (`src/client/src/components/ErrorScreen.tsx`) is the established full-page style:
+
+- `min-h-screen bg-gray-50`, centered card
+- GuideAnts mark (`/code-ants.png`) + “GuideAnts Notebooks” / “AI for people”
+- White `rounded-lg shadow-lg` card, title, message, primary blue button, secondary gray home control
+- Optional collapsible “Technical Details”
+
+`ErrorBoundary` already uses this component. The 404 UI must reuse it (same layout/classes/branding), not invent a new visual system.
+
+---
+
+## 2. The defect (Defect A)
+
+### 2.1 Symptom
+
+Browser URL (example incident):
+
+`https://…/guides/a71c69b4-69b5-4bb1-b80a-474e9e3b469d`
+
+- Document title: `GuideAnts Notebooks`
+- DOM: `#root` → `<div class="h-full"></div>` only
+- Auth and `/api/startup` succeed
+- No page component mounts; no error UI; no console route diagnostic
+
+### 2.2 Cause
+
+1. Server `MapFallback` serves SPA shell for any UI GET (including `/guides/...`) with HTTP 200.
+2. Client route table has no match for `/guides/:id` (and never has).
+3. `<Routes>` with no match and no `path="*"` renders **nothing**.
+
+### 2.3 Correct URLs for the same guide entity
+
+| Intent | Path |
+|--------|------|
+| Run notebook | `/projects/{projectId}/notebooks/{notebookId}` |
+| Edit guide definition (Admin) | `/projects/{projectId}/guides/guide/{guideId}` |
+| Public published guide | `/public/{friendlyName}` |
+
+### 2.4 Why this is critical
+
+Any bookmark, agent `goto`, markdown link, or typo to an unmatched path produces a **silent white screen** indistinguishable from a total client crash. Electron and browser are both affected once the router has no match.
+
+---
+
+## 3. Proposed changes (minimal)
+
+### 3.1 Goals
+
+1. Unmatched paths show a real NotFound screen in **existing `ErrorScreen` style**.
+2. Auto-redirect to **home** (`/`) after **30 seconds**.
+3. Zero intentional changes to: auth, OAuth, StartupGate, UrlCorrector, ProtectedRoute guards, param-route matching, Electron router selection.
+
+### 3.2 Code changes (narrow)
+
+| Change | File(s) | Notes |
+|--------|---------|-------|
+| Add `NotFoundPage` | `src/client/src/pages/NotFound.tsx` (new) | Thin page: render `ErrorScreen` with 404 copy; own 30s timer + `navigate('/')` |
+| Register catch-all | `src/client/src/components/AppContent.tsx` | **Last** route only: `<Route path="*" element={<NotFoundPage />} />` — **public** (no `ProtectedRoute`) |
+| Optional test id | on NotFound / ErrorScreen wrapper | e.g. `data-testid="not-found-page"` for Playwright |
+
+**Do not** in this change:
+
+- Add `/guides/:guideId` rewrite/recovery
+- Change `Login` / `returnUrl` validation
+- Change `ErrorBoundary` behavior
+- Change server `MapFallback` / `IsUiPath`
+- Touch Electron-only OAuth pre-router branch
+- Use `window.location.href` for the auto-redirect or primary Home action
+
+### 3.3 `NotFoundPage` behavior
+
+| Element | Spec |
+|---------|------|
+| Visual | `ErrorScreen` with title like `Page not found`; message that the address is not a valid GuideAnts page; optional technical details = current pathname (+ search) |
+| Primary action | “Go to Home” → `navigate('/')` (immediate); cancel pending timer |
+| Secondary | Keep `ErrorScreen` home control if used, or rely on primary — avoid duplicate divergent behaviors |
+| Auto-redirect | `useEffect` → `setTimeout(30_000)` → `navigate('/')`; clear timeout on unmount / on manual navigate |
+| Countdown copy | Optional short line: “Redirecting to home in Ns…” (updates each second) — must still look like existing gray helper text under the card actions |
+| Auth | Public route: unauthenticated users see NotFound; after redirect to `/`, existing `ProtectedRoute` sends them to login |
+| Electron | Same component; `navigate('/')` updates hash route to `#/` |
+
+### 3.4 Explicit non-goals / non-matches
+
+These must **continue** to hit their existing matched routes (not NotFound):
+
+- `/login`, `/register`, `/terms`, `/privacy`, `/public/anything`
+- `/oauth/callback`, `/redirect`
+- `/projects/:projectId/...` even with nonsense GUIDs
+- `/settings`, `/settings/system-guides` (admin redirect stays admin redirect)
+- `/` and all other listed authenticated routes
+
+Only paths with **no** matching pattern (e.g. `/guides`, `/guides/{uuid}`, `/foo`, `/this/does/not/exist`) hit `*`.
+
+### 3.5 Regression surface (why this is safe if kept minimal)
+
+- Catch-all is lowest priority in React Router v6/v7 route ranking.
+- No changes to guard components → role redirects unchanged.
+- No `window.location` hard navigations → HashRouter safe.
+- No server pipeline change → API and SPA fallback unchanged.
+- NotFound is a leaf page inside existing providers (toast/auth available but unused for core UX).
+
+---
+
+## 4. Test plan (Playwright — real browser, no mocks)
+
+### 4.1 Harness
+
+| Item | Choice |
+|------|--------|
+| Runner | `@playwright/test` under `walkthroughs/` (existing headed Chrome + `baseURL`, default `http://localhost:5107`) **or** a sibling suite `walkthroughs/scenarios/routing/` using the same `playwright.config.ts` |
+| App under test | Real local stack (`guideants-webapi-ui` on `:5107`) — same as walkthroughs |
+| Auth | Real login via existing walkthrough auth helper (`walkthroughs/lib/auth.ts` / `signedIn` fixture) — **no** mocked `AuthContext` |
+| Timers | Use Playwright clock (`page.clock.install` + `fastForward`) to advance the 30s redirect without wall-clock waits; do **not** mock `navigate` or stub React Router |
+| Electron | See §4.4 — separate thin check; primary suite is BrowserRouter (web) |
+
+Do **not** use Vitest/RTL mocks for this suite. Unit tests of timer math alone are insufficient.
+
+### 4.2 Shared fixtures / helpers (real)
+
+- `signedIn` — session cookie against real API
+- `signedOut` — cleared cookies / fresh context
+- Known good IDs from env or walkthrough defaults (project / notebook already used by toolbar tour)
+- Admin user for guide-editor smoke; Reader user if available for guard smoke
+
+### 4.3 Cases mapped to §1 special cases + defect
+
+Each row is a Playwright test (or a clearly named `test.step` group). Assertions are concrete.
+
+#### A. Defect A — unmatched routes show NotFound
+
+| ID | Setup | Action | Checks |
+|----|-------|--------|--------|
+| A1 | signed in | `goto /guides/{any-guid}` (incident shape) | `data-testid=not-found-page` visible; GuideAnts branding visible; **not** blank `#root` only; URL path still `/guides/…` |
+| A2 | signed in | `goto /this-route-does-not-exist` | NotFound visible |
+| A3 | signed in | `goto /guides` | NotFound visible |
+| A4 | signed out | `goto /guides/{guid}` | NotFound visible (public catch-all); **not** forced through login first |
+
+#### B. Auto-redirect (30 seconds)
+
+| ID | Setup | Action | Checks |
+|----|-------|--------|--------|
+| B1 | signed in; clock installed | open unmatched path; `clock.fastForward(29999)` | still on NotFound; URL unchanged |
+| B2 | signed in; clock installed | `fastForward` past 30000 | URL is home `/` (or ends with `/`); Home shell visible (e.g. projects/home content or known home test id / heading — same signals walkthroughs use) |
+| B3 | signed in | open NotFound; click “Go to Home” before 30s | immediate navigate to `/`; timer must not later fight navigation (stay on home) |
+
+#### C. Matched public routes — must not become NotFound
+
+| ID | Action | Checks |
+|----|--------|--------|
+| C1 | `goto /login` (signed out) | Login form / “Sign in” — **not** NotFound |
+| C2 | `goto /register` | Register UI — not NotFound |
+| C3 | `goto /terms` | Terms content — not NotFound |
+| C4 | `goto /privacy` | Privacy content — not NotFound |
+| C5 | `goto /public/{known-or-unknown-friendly}` | PublicGuide page chrome (or its own empty/error state) — **not** the NotFound page component |
+
+#### D. Matched authenticated routes — smoke (no NotFound)
+
+| ID | Setup | Action | Checks |
+|----|-------|--------|--------|
+| D1 | signed in | `goto /` | Home — not NotFound |
+| D2 | signed in | `goto /projects` | Projects list — not NotFound |
+| D3 | signed in | `goto /projects/{validProjectId}/notebooks/{validNotebookId}` | Notebook shell (toolbar / title) — not NotFound |
+| D4 | Admin | `goto /projects/{id}/guides/guide/{validGuideId}` | Guide editor chrome — not NotFound |
+| D5 | signed in | `goto /settings` | Settings — not NotFound |
+| D6 | signed in | `goto /conversations` | Conversations — not NotFound |
+
+#### E. Guards still redirect (matched routes — not NotFound)
+
+| ID | Setup | Action | Checks |
+|----|-------|--------|--------|
+| E1 | Reader (or non-Admin) | `goto /projects/{id}/guides` | Ends on admin fallback (`/` or allowed page) — **NotFound must not appear** |
+| E2 | Reader | `goto /new-project` | Redirected away (home) — not NotFound |
+| E3 | signed out | `goto /projects/{id}` | Login with `returnUrl` containing that project path — not NotFound |
+
+#### F. Param match vs catch-all
+
+| ID | Action | Checks |
+|----|--------|--------|
+| F1 | signed in; `goto /projects/00000000-0000-0000-0000-000000000000` | **Not** NotFound (route matched). May show project error/spinner/empty — page-owned |
+| F2 | signed in; `goto /projects/{valid}/notebooks/00000000-0000-0000-0000-000000000000` | **Not** NotFound; notebook page error handling |
+
+#### G. Auth / OAuth / expiry paths untouched
+
+| ID | Setup | Action | Checks |
+|----|-------|--------|--------|
+| G1 | signed out | `goto /oauth/callback` (no code) | OAuthCallback loading then redirect home/login path — **not** NotFound flash as final state |
+| G2 | signed in on `/` | Trigger real 401 on an API call that broadcasts auth-expired **or** dispatch `auth-expired` via `page.evaluate` on the real event bus | Lands on `/login?returnUrl=…` — NotFound not involved |
+| G3 | signed out; login with `returnUrl=/guides/dead` | Complete real login | Lands on NotFound for that path (or home if product later allowlists — **this change expects NotFound**), then B2 still applies |
+
+#### H. Server + client contract
+
+| ID | Action | Checks |
+|----|--------|--------|
+| H1 | `goto /guides/{guid}` | Document response is SPA (status 200 from server is OK); client shows NotFound |
+| H2 | `request.get /api/guides/{validGuideId}` (API context with cookies) | JSON 200 — unrelated to NotFound; guards against accidental server route breakage in same PR |
+
+#### I. Style conformance (light visual contract)
+
+| ID | Checks |
+|----|--------|
+| I1 | NotFound shows `img[alt="GuideAnts"]` (or `/code-ants.png`), title “GuideAnts Notebooks”, card with 404 title |
+| I2 | Primary button uses visible “Go to Home” (or equivalent) and is clickable |
+
+### 4.4 Electron / HashRouter
+
+Full Electron packaging in CI is heavy. For this change:
+
+| ID | Approach | Checks |
+|----|----------|--------|
+| EL1 | Code review + static guarantee: NotFound uses only `navigate` / `<Link>`, never `window.location.href` for home redirect | PR checklist |
+| EL2 | Optional follow-up: headed Electron smoke manually — open `#/guides/test`, confirm NotFound, wait/fast-forward, confirm `#/` home | Document as manual release check if no Electron Playwright job exists |
+
+Do **not** mock `isElectron()` in the web Playwright suite; that would not prove HashRouter behavior and violates the “no mocks” intent for routing.
+
+### 4.5 Pass / fail criteria
+
+- All A–I automated cases green against local `:5107` with real auth.
+- No existing walkthrough scenario (`notebook/toolbar-tour`, `settings/change-quant`) regressed.
+- Manual EL1 checklist signed off in the PR.
+
+### 4.6 Suggested commands (after implementation)
+
+```powershell
+# App stack already running on :5107
+cd walkthroughs
+npm test -- scenarios/routing/not-found.spec.ts
+```
+
+(Exact filename TBD at implementation; suite lives next to other walkthrough scenarios.)
+
+---
+
+## 5. Implementation order (when approved)
+
+1. Land this doc (done).
+2. Implement `NotFoundPage` + `path="*"` only.
+3. Add Playwright suite §4.3.
+4. Run walkthrough smoke + new routing suite.
+5. Follow-ups (separate PRs): `/guides/:id` recovery, `returnUrl` allowlist, docs path fixes.
+
+---
+
+## 6. Acceptance checklist
+
+- [ ] Unmatched browser paths show ErrorScreen-styled NotFound (not blank).
+- [ ] Auto-redirect to `/` after 30s via React Router navigation.
+- [ ] Manual Go Home works and cancels the timer.
+- [ ] All documented matched routes and guards unchanged.
+- [ ] Playwright cases A–I pass without mocking Auth/Router.
+- [ ] Electron redirect uses `navigate`, not `window.location.href`.

--- a/src/client/src/components/AppContent.tsx
+++ b/src/client/src/components/AppContent.tsx
@@ -26,6 +26,7 @@ import Pending from '../pages/Pending';
 import ChangePassword from '../pages/ChangePassword';
 import OAuthCallback from '../pages/OAuthCallback';
 import CliAuthorize from '../pages/CliAuthorize';
+import NotFoundPage from '../pages/NotFound';
 import { ProtectedRoute } from './ProtectedRoute';
 
 function ProjectProviderWrapper({ children }: { children: React.ReactNode }) {
@@ -95,6 +96,7 @@ const AppContent = () => {
       <Route path="/projects/:projectId/guides/assistant/:assistantId/usage" element={withAdminProtection(withProjectProvider(<GuideUsagePage />))} />
       <Route path="/projects/:projectId/guides/assistant/new" element={withAdminProtection(withProjectProvider(<AssistantEditor />))} />
       <Route path="/projects/:projectId/guides/assistant/:assistantId" element={withAdminProtection(withProjectProvider(<AssistantEditor />))} />
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );
 };

--- a/src/client/src/pages/NotFound.tsx
+++ b/src/client/src/pages/NotFound.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import ErrorScreen from '../components/ErrorScreen';
+
+const REDIRECT_MS = 30_000;
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [secondsLeft, setSecondsLeft] = useState(Math.ceil(REDIRECT_MS / 1000));
+
+  const goHome = useCallback(() => {
+    navigate('/');
+  }, [navigate]);
+
+  useEffect(() => {
+    const startedAt = Date.now();
+
+    const tick = () => {
+      const remainingMs = REDIRECT_MS - (Date.now() - startedAt);
+      setSecondsLeft(Math.max(0, Math.ceil(remainingMs / 1000)));
+    };
+
+    tick();
+    const intervalId = window.setInterval(tick, 250);
+    const timeoutId = window.setTimeout(() => {
+      navigate('/');
+    }, REDIRECT_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [navigate]);
+
+  const pathDetails = `${location.pathname}${location.search}`;
+
+  return (
+    <div data-testid="not-found-page">
+      <ErrorScreen
+        title="Page not found"
+        message="This address is not a valid GuideAnts page. Check the link or go home to continue."
+        error={pathDetails}
+        showRetryButton={false}
+        showBackButton={false}
+        customActions={
+          <>
+            <button
+              type="button"
+              onClick={goHome}
+              className="w-full px-6 py-3 text-white font-medium rounded-lg transition-colors bg-blue-600 hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Go to Home
+            </button>
+            <p className="mt-3 text-sm text-gray-500">
+              Redirecting to home in {secondsLeft}s…
+            </p>
+          </>
+        }
+      />
+    </div>
+  );
+}

--- a/walkthroughs/scenarios/routing/not-found.spec.ts
+++ b/walkthroughs/scenarios/routing/not-found.spec.ts
@@ -1,0 +1,430 @@
+import { expect, notebookPath, test } from '../../fixtures/walkthrough.js';
+import { signIn, walkthroughPassword } from '../../lib/auth.js';
+import { prepareChromeWindow } from '../../lib/window.js';
+
+const INCIDENT_GUID = 'a71c69b4-69b5-4bb1-b80a-474e9e3b469d';
+const ZERO_GUID = '00000000-0000-0000-0000-000000000000';
+
+function projectIdFromNotebookPath(): string {
+  const match = notebookPath().match(/^\/projects\/([^/]+)/);
+  if (!match) {
+    throw new Error(`WALKTHROUGH_NOTEBOOK_PATH missing project id: ${notebookPath()}`);
+  }
+  return match[1];
+}
+
+function guideEditorPath(): string | undefined {
+  return process.env.WALKTHROUGH_GUIDE_PATH;
+}
+
+function guideApiId(): string | undefined {
+  return process.env.WALKTHROUGH_GUIDE_ID;
+}
+
+function readerCredentials(): { email: string; password: string } | undefined {
+  const email = process.env.WALKTHROUGH_READER_EMAIL;
+  const password = process.env.WALKTHROUGH_READER_PASSWORD ?? walkthroughPassword();
+  if (!email) {
+    return undefined;
+  }
+  return { email, password };
+}
+
+async function expectNotFound(page: import('@playwright/test').Page): Promise<void> {
+  const notFound = page.getByTestId('not-found-page');
+  await expect(notFound).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole('img', { name: 'GuideAnts' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'GuideAnts Notebooks' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Page not found' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Go to Home' })).toBeVisible();
+}
+
+async function expectNotNotFound(page: import('@playwright/test').Page): Promise<void> {
+  await expect(page.getByTestId('not-found-page')).toHaveCount(0);
+}
+
+async function expectHomeShell(page: import('@playwright/test').Page): Promise<void> {
+  await expect(page).toHaveURL((url) => url.pathname === '/' || url.pathname === '');
+  await expectNotNotFound(page);
+  await expect(page.getByRole('button', { name: 'Open Settings' })).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Install fake timers, let them run at real speed through StartupGate/auth, then
+ * pause once NotFound is visible so tests can fast-forward the redirect.
+ */
+async function gotoNotFoundWithClock(
+  page: import('@playwright/test').Page,
+  path: string,
+): Promise<void> {
+  await page.clock.install();
+  await page.clock.resume();
+  await page.goto(path, { waitUntil: 'domcontentloaded' });
+  await expectNotFound(page);
+  // pauseAt rejects targets in the past; pad slightly because resume() keeps moving.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const target = await page.evaluate(() => Date.now() + 50);
+    try {
+      await page.clock.pauseAt(target);
+      return;
+    } catch (error) {
+      if (!String(error).includes('Cannot fast-forward to the past')) {
+        throw error;
+      }
+    }
+  }
+  throw new Error('Could not pause Playwright clock after NotFound mounted');
+}
+
+async function redirectSecondsLeft(page: import('@playwright/test').Page): Promise<number> {
+  const label = page.getByText(/Redirecting to home in \d+s/);
+  await expect(label).toBeVisible();
+  const text = await label.innerText();
+  const match = text.match(/(\d+)/);
+  if (!match) {
+    throw new Error(`Could not parse redirect countdown: ${text}`);
+  }
+  return Number(match[1]);
+}
+
+test.describe('SPA unmatched-route 404', () => {
+  test.describe('A. Defect A — unmatched routes show NotFound', () => {
+    test('A1 signed in — /guides/{guid} shows NotFound', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await page.goto(`/guides/${INCIDENT_GUID}`, { waitUntil: 'domcontentloaded' });
+      await expectNotFound(page);
+      await expect(page).toHaveURL(new RegExp(`/guides/${INCIDENT_GUID}$`));
+    });
+
+    test('A2 signed in — unknown path shows NotFound', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await page.goto('/this-route-does-not-exist', { waitUntil: 'domcontentloaded' });
+      await expectNotFound(page);
+    });
+
+    test('A3 signed in — /guides shows NotFound', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await page.goto('/guides', { waitUntil: 'domcontentloaded' });
+      await expectNotFound(page);
+    });
+
+    test('A4 signed out — /guides/{guid} shows NotFound without login first', async ({
+      page,
+      timeline,
+      pointer: _pointer,
+    }) => {
+      await prepareChromeWindow(page, timeline);
+      await page.context().clearCookies();
+      await page.goto(`/guides/${INCIDENT_GUID}`, { waitUntil: 'domcontentloaded' });
+      await expectNotFound(page);
+      await expect(page).not.toHaveURL(/\/login/);
+    });
+  });
+
+  test.describe('B. Auto-redirect (30 seconds)', () => {
+    test('B1 still on NotFound just before redirect fires', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await gotoNotFoundWithClock(page, `/guides/${INCIDENT_GUID}`);
+      const secondsLeft = await redirectSecondsLeft(page);
+      // Stay one displayed second shy of fire (countdown uses Math.ceil).
+      await page.clock.fastForward(Math.max(0, (secondsLeft - 1) * 1000));
+      await expectNotFound(page);
+      await expect(page).toHaveURL(new RegExp(`/guides/${INCIDENT_GUID}$`));
+    });
+
+    test('B2 redirects home after countdown elapses', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await gotoNotFoundWithClock(page, `/guides/${INCIDENT_GUID}`);
+      const secondsLeft = await redirectSecondsLeft(page);
+      await page.clock.fastForward(secondsLeft * 1000 + 500);
+      await expectHomeShell(page);
+    });
+
+    test('B3 Go to Home cancels timer', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await gotoNotFoundWithClock(page, `/guides/${INCIDENT_GUID}`);
+      await page.getByRole('button', { name: 'Go to Home' }).click();
+      await expectHomeShell(page);
+      await page.clock.fastForward(35_000);
+      await expectHomeShell(page);
+    });
+  });
+
+  test.describe('C. Matched public routes — must not become NotFound', () => {
+    test('C1 /login', async ({ page, timeline, pointer: _pointer }) => {
+      await prepareChromeWindow(page, timeline);
+      await page.context().clearCookies();
+      await page.goto('/login', { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible({ timeout: 30_000 });
+    });
+
+    test('C2 /register', async ({ page, timeline, pointer: _pointer }) => {
+      await prepareChromeWindow(page, timeline);
+      await page.context().clearCookies();
+      await page.goto('/register', { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page.getByRole('heading', { name: 'Create Account' })).toBeVisible({
+        timeout: 30_000,
+      });
+    });
+
+    test('C3 /terms', async ({ page, timeline, pointer: _pointer }) => {
+      await prepareChromeWindow(page, timeline);
+      await page.goto('/terms', { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page.getByRole('heading', { name: 'Terms of Service' })).toBeVisible({
+        timeout: 30_000,
+      });
+    });
+
+    test('C4 /privacy', async ({ page, timeline, pointer: _pointer }) => {
+      await prepareChromeWindow(page, timeline);
+      await page.goto('/privacy', { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page.getByRole('heading', { name: 'Privacy Policy' })).toBeVisible({
+        timeout: 30_000,
+      });
+    });
+
+    test('C5 /public/{friendly} is PublicGuide, not NotFound', async ({
+      page,
+      timeline,
+      pointer: _pointer,
+    }) => {
+      await prepareChromeWindow(page, timeline);
+      await page.goto('/public/this-friendly-name-does-not-exist', {
+        waitUntil: 'domcontentloaded',
+      });
+      await expectNotNotFound(page);
+      await expect(
+        page.getByRole('heading', { name: /Guide not found|Failed to load guide/ }),
+      ).toBeVisible({ timeout: 30_000 });
+    });
+  });
+
+  test.describe('D. Matched authenticated routes — smoke', () => {
+    test('D1 / home', async ({ page, signedIn: _signedIn }) => {
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await expectHomeShell(page);
+    });
+
+    test('D2 /projects', async ({ page, signedIn: _signedIn }) => {
+      await page.goto('/projects', { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible({
+        timeout: 30_000,
+      });
+    });
+
+    test('D3 valid notebook path', async ({ page, signedIn: _signedIn }) => {
+      await page.goto(notebookPath(), { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page.getByTestId('notebook-service-toolbar')).toBeVisible({ timeout: 30_000 });
+    });
+
+    test('D4 guide editor path', async ({ page, signedIn: _signedIn }) => {
+      const path = guideEditorPath();
+      test.skip(!path, 'Set WALKTHROUGH_GUIDE_PATH for D4');
+      await page.goto(path!, { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page).toHaveURL(new RegExp(path!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    });
+
+    test('D5 /settings', async ({ page, signedIn: _signedIn }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible({
+        timeout: 30_000,
+      });
+    });
+
+    test('D6 /conversations', async ({ page, signedIn: _signedIn }) => {
+      await page.goto('/conversations', { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page.getByRole('heading', { name: 'All Conversations' })).toBeVisible({
+        timeout: 30_000,
+      });
+    });
+  });
+
+  test.describe('E. Guards still redirect (not NotFound)', () => {
+    test('E1 non-admin guides dashboard redirects away', async ({
+      page,
+      timeline,
+      pointer: _pointer,
+    }) => {
+      const reader = readerCredentials();
+      test.skip(!reader, 'Set WALKTHROUGH_READER_EMAIL for E1');
+      await prepareChromeWindow(page, timeline);
+      await page.context().clearCookies();
+      await page.goto('/login', { waitUntil: 'domcontentloaded' });
+      await page.getByRole('textbox', { name: 'Email' }).fill(reader!.email);
+      await page.getByRole('textbox', { name: 'Password' }).fill(reader!.password);
+      await page.getByRole('button', { name: 'Sign In' }).click();
+      await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: 30_000 });
+      await page.goto(`/projects/${projectIdFromNotebookPath()}/guides`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await expectNotNotFound(page);
+      await expect(page).not.toHaveURL(/\/guides$/);
+    });
+
+    test('E2 reader /new-project redirects home', async ({
+      page,
+      timeline,
+      pointer: _pointer,
+    }) => {
+      const reader = readerCredentials();
+      test.skip(!reader, 'Set WALKTHROUGH_READER_EMAIL for E2');
+      await prepareChromeWindow(page, timeline);
+      await page.context().clearCookies();
+      await page.goto('/login', { waitUntil: 'domcontentloaded' });
+      await page.getByRole('textbox', { name: 'Email' }).fill(reader!.email);
+      await page.getByRole('textbox', { name: 'Password' }).fill(reader!.password);
+      await page.getByRole('button', { name: 'Sign In' }).click();
+      await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: 30_000 });
+      await page.goto('/new-project', { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expectHomeShell(page);
+    });
+
+    test('E3 signed out /projects/{id} goes to login with returnUrl', async ({
+      page,
+      timeline,
+      pointer: _pointer,
+    }) => {
+      const projectPath = `/projects/${projectIdFromNotebookPath()}`;
+      await prepareChromeWindow(page, timeline);
+      await page.context().clearCookies();
+      await page.goto(projectPath, { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+      await expect(page).toHaveURL(/\/login\?/);
+      const url = new URL(page.url());
+      expect(url.searchParams.get('returnUrl')).toContain(projectPath);
+      await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible({ timeout: 30_000 });
+    });
+  });
+
+  test.describe('F. Param match vs catch-all', () => {
+    test('F1 nonsense project id still matches route', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await page.goto(`/projects/${ZERO_GUID}`, { waitUntil: 'domcontentloaded' });
+      await expectNotNotFound(page);
+    });
+
+    test('F2 nonsense notebook id still matches route', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await page.goto(`/projects/${projectIdFromNotebookPath()}/notebooks/${ZERO_GUID}`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await expectNotNotFound(page);
+    });
+  });
+
+  test.describe('G. Auth / OAuth / expiry paths untouched', () => {
+    test('G1 /oauth/callback without code does not end on NotFound', async ({
+      page,
+      timeline,
+      pointer: _pointer,
+    }) => {
+      await prepareChromeWindow(page, timeline);
+      await page.context().clearCookies();
+      await page.goto('/oauth/callback', { waitUntil: 'domcontentloaded' });
+      await expect
+        .poll(async () => page.url(), { timeout: 30_000 })
+        .not.toContain('/oauth/callback');
+      await expectNotNotFound(page);
+    });
+
+    test('G2 auth-expired lands on login with returnUrl', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await expectHomeShell(page);
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent('auth-expired', { detail: { reason: 'walkthrough' } }),
+        );
+      });
+      await expect(page).toHaveURL(/\/login\?/, { timeout: 30_000 });
+      await expectNotNotFound(page);
+      const url = new URL(page.url());
+      expect(url.searchParams.get('returnUrl')).toBeTruthy();
+    });
+
+    test('G3 login returnUrl to unmatched path lands on NotFound', async ({
+      page,
+      timeline,
+      pointer: _pointer,
+    }) => {
+      await prepareChromeWindow(page, timeline);
+      await page.context().clearCookies();
+      await signIn(page, timeline, { returnPath: `/guides/${INCIDENT_GUID}` });
+      await expectNotFound(page);
+      await expect(page).toHaveURL(new RegExp(`/guides/${INCIDENT_GUID}$`));
+    });
+  });
+
+  test.describe('H. Server + client contract', () => {
+    test('H1 SPA shell serves unmatched path; client shows NotFound', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      const response = await page.goto(`/guides/${INCIDENT_GUID}`, {
+        waitUntil: 'domcontentloaded',
+      });
+      expect(response?.status()).toBe(200);
+      await expectNotFound(page);
+    });
+
+    test('H2 API guides endpoint still serves JSON', async ({
+      page,
+      request,
+      signedIn: _signedIn,
+    }) => {
+      const id = guideApiId();
+      test.skip(!id, 'Set WALKTHROUGH_GUIDE_ID for H2');
+      // Ensure session cookie exists from signedIn; reuse browser cookies for API.
+      const cookies = await page.context().cookies();
+      const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+      const response = await request.get(`/api/guides/${id}`, {
+        headers: cookieHeader ? { Cookie: cookieHeader } : undefined,
+      });
+      expect(response.status()).toBe(200);
+      expect(response.headers()['content-type'] ?? '').toMatch(/json/i);
+    });
+  });
+
+  test.describe('I. Style conformance', () => {
+    test('I1–I2 NotFound branding and Go to Home', async ({
+      page,
+      signedIn: _signedIn,
+    }) => {
+      await page.goto('/foo/bar', { waitUntil: 'domcontentloaded' });
+      await expectNotFound(page);
+      await expect(page.locator('img[src="/code-ants.png"]')).toBeVisible();
+      const home = page.getByRole('button', { name: 'Go to Home' });
+      await expect(home).toBeVisible();
+      await home.click();
+      await expectHomeShell(page);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a public React Router catch-all (`path="*"`) that renders an `ErrorScreen`-styled NotFound page instead of a blank `#root`.
- Auto-redirect to home via `navigate('/')` after 30 seconds; manual **Go to Home** cancels the timer (HashRouter-safe).
- Add Playwright coverage under `walkthroughs/scenarios/routing/not-found.spec.ts` and capture the design in `docs/spa-unmatched-route-404-design.md`.

## Test plan
- [x] `cd walkthroughs && npm test -- scenarios/routing/not-found.spec.ts` against local `:5107` (real auth) — 25 passed, 4 skipped (optional env: guide path / reader / guide API id)
- [x] Manually verified via suite: `/guides/<guid>` and unmatched paths show NotFound (`data-testid=not-found-page`), not blank
- [x] **Go to Home** and clock-advanced 30s redirect land on `/`
- [x] Matched routes (`/login`, `/projects`, notebook path, settings, conversations) unchanged; param routes with bad IDs still match
- [x] EL1: NotFound uses only `navigate` / no `window.location.href` for home