### PR TITLE
Improve ReadWeb errors and align copied paths with sandbox CWD

### DIFF
--- a/src/client/src/components/notebook/sidebar/NotebookFolderTree.tsx
+++ b/src/client/src/components/notebook/sidebar/NotebookFolderTree.tsx
@@ -692,12 +692,9 @@ const NotebookFolderNodeComponent: React.FC<NotebookFolderNodeProps> = ({
   const handleCopyPaths = useCallback((paths: string[]) => {
     setShowContextMenu(false);
     setShowFileContextMenu(false);
-    // Scope paths under the notebook name so identically-named folders in
-    // different notebooks don't produce indistinguishable copied paths.
-    const namespace = notebookName?.trim().replace(/^\/+|\/+$/g, '');
-    const scopedPaths = namespace ? paths.map(p => `${namespace}/${p}`) : paths;
-    void copyPaths(scopedPaths);
-  }, [copyPaths, notebookName]);
+    // CWD-relative paths (from Output/) so pasted/copied paths work in chat tools.
+    void copyPaths(paths);
+  }, [copyPaths]);
 
   const handleDownloadFile = useCallback(async () => {
     if (!selectedContextFile || !projectId || !notebookId) {

--- a/src/client/src/components/notebook/sidebar/__tests__/NotebookFolderTree.extended.test.tsx
+++ b/src/client/src/components/notebook/sidebar/__tests__/NotebookFolderTree.extended.test.tsx
@@ -956,24 +956,24 @@ describe('NotebookFolderTree extended coverage', () => {
   });
 
   describe('copy path', () => {
-    it('copies a file path to the clipboard scoped under the notebook name', async () => {
+    it('copies a file path to the clipboard as cwd-relative', async () => {
       const { user, writeText } = setupClipboard();
       renderTree();
 
       fireEvent.contextMenu(screen.getByText('readme.txt'));
       await user.click(await findPortalButton('Copy path'));
 
-      expect(writeText).toHaveBeenCalledWith('/Test Notebook/readme.txt');
+      expect(writeText).toHaveBeenCalledWith('../readme.txt');
     });
 
-    it('copies a folder path to the clipboard scoped under the notebook name', async () => {
+    it('copies a folder path to the clipboard as cwd-relative', async () => {
       const { user, writeText } = setupClipboard();
       renderTree();
 
       fireEvent.contextMenu(screen.getByText('Docs'));
       await user.click(await findPortalButton('Copy path'));
 
-      expect(writeText).toHaveBeenCalledWith('/Test Notebook/Docs');
+      expect(writeText).toHaveBeenCalledWith('../Docs');
     });
 
     it('does not show Copy path for the root folder', () => {
@@ -982,7 +982,7 @@ describe('NotebookFolderTree extended coverage', () => {
       expect(screen.queryByText('Copy path')).not.toBeInTheDocument();
     });
 
-    it('copies multiple selected paths joined by newlines, each scoped under the notebook name', async () => {
+    it('copies multiple selected paths joined by newlines, each cwd-relative', async () => {
       const { user, writeText } = setupClipboard();
       renderTree();
 
@@ -990,17 +990,7 @@ describe('NotebookFolderTree extended coverage', () => {
       fireEvent.contextMenu(screen.getByText('readme.txt'));
       await user.click(await findPortalButton(/Copy \d+ Paths?/));
 
-      expect(writeText).toHaveBeenCalledWith('/Test Notebook/Assets\n/Test Notebook/Docs\n/Test Notebook/readme.txt');
-    });
-
-    it('falls back to a bare root-relative path when notebookName is not provided', async () => {
-      const { user, writeText } = setupClipboard();
-      renderTree({ notebookName: undefined });
-
-      fireEvent.contextMenu(screen.getByText('readme.txt'));
-      await user.click(await findPortalButton('Copy path'));
-
-      expect(writeText).toHaveBeenCalledWith('/readme.txt');
+      expect(writeText).toHaveBeenCalledWith('../Assets\n../Docs\n../readme.txt');
     });
   });
 
@@ -1064,7 +1054,7 @@ describe('NotebookFolderTree extended coverage', () => {
       fireEvent.contextMenu(screen.getByText('Assets'));
       await user.click(await findPortalButton(/Copy \d+ Paths?/));
 
-      expect(writeText).toHaveBeenCalledWith('/Test Notebook/Assets\n/Test Notebook/readme.txt');
+      expect(writeText).toHaveBeenCalledWith('../Assets\n../readme.txt');
     });
 
     it('right-clicking a folder outside the current selection collapses to just that folder', () => {

--- a/src/client/src/components/project/sidebar/__tests__/FolderTree.extended.test.tsx
+++ b/src/client/src/components/project/sidebar/__tests__/FolderTree.extended.test.tsx
@@ -724,24 +724,24 @@ describe('FolderTree extended coverage', () => {
   });
 
   describe('copy path', () => {
-    it('copies a file path to the clipboard as root-relative', async () => {
+    it('copies a file path to the clipboard as cwd-relative', async () => {
       const { user, writeText } = setupClipboard();
       renderTree();
 
       fireEvent.contextMenu(screen.getByText('notes.txt'));
       await user.click(await findPortalButton('Copy path'));
 
-      expect(writeText).toHaveBeenCalledWith('/notes.txt');
+      expect(writeText).toHaveBeenCalledWith('../notes.txt');
     });
 
-    it('copies a folder path to the clipboard as root-relative', async () => {
+    it('copies a folder path to the clipboard as cwd-relative', async () => {
       const { user, writeText } = setupClipboard();
       renderTree();
 
       fireEvent.contextMenu(screen.getByText('Archive'));
       await user.click(await findPortalButton('Copy path'));
 
-      expect(writeText).toHaveBeenCalledWith('/Archive');
+      expect(writeText).toHaveBeenCalledWith('../Archive');
     });
 
     it('does not show Copy path for the root folder', () => {
@@ -758,7 +758,7 @@ describe('FolderTree extended coverage', () => {
       fireEvent.contextMenu(screen.getByText('notes.txt'));
       await user.click(await findPortalButton(/Copy \d+ Paths/));
 
-      expect(writeText).toHaveBeenCalledWith('/Archive\n/guide.md\n/notes.txt');
+      expect(writeText).toHaveBeenCalledWith('../Archive\n../guide.md\n../notes.txt');
     });
   });
 
@@ -786,7 +786,7 @@ describe('FolderTree extended coverage', () => {
       fireEvent.contextMenu(screen.getByText('Archive'));
       await user.click(await findPortalButton(/Copy \d+ Paths/));
 
-      expect(writeText).toHaveBeenCalledWith('/Archive\n/guide.md');
+      expect(writeText).toHaveBeenCalledWith('../Archive\n../guide.md');
     });
 
     it('right-clicking a folder outside the current selection collapses to just that folder', () => {

--- a/src/client/src/hooks/__tests__/useCopyPath.test.tsx
+++ b/src/client/src/hooks/__tests__/useCopyPath.test.tsx
@@ -19,34 +19,34 @@ describe('useCopyPath', () => {
     });
   });
 
-  it('copies a single path as root-relative', async () => {
+  it('copies a single path as cwd-relative', async () => {
     const { result } = renderHook(() => useCopyPath(), { wrapper });
 
     await act(async () => {
       await result.current.copyPaths(['docs/api.md']);
     });
 
-    expect(writeText).toHaveBeenCalledWith('/docs/api.md');
+    expect(writeText).toHaveBeenCalledWith('../docs/api.md');
   });
 
-  it('does not double-prefix a path that already starts with "/"', async () => {
+  it('strips Output/ so paths under CWD stay unprefixed', async () => {
     const { result } = renderHook(() => useCopyPath(), { wrapper });
 
     await act(async () => {
-      await result.current.copyPaths(['/already/rooted']);
+      await result.current.copyPaths(['Output/result.txt']);
     });
 
-    expect(writeText).toHaveBeenCalledWith('/already/rooted');
+    expect(writeText).toHaveBeenCalledWith('result.txt');
   });
 
-  it('joins multiple paths with newlines, each made root-relative', async () => {
+  it('joins multiple paths with newlines, each made cwd-relative', async () => {
     const { result } = renderHook(() => useCopyPath(), { wrapper });
 
     await act(async () => {
       await result.current.copyPaths(['a', 'b/c']);
     });
 
-    expect(writeText).toHaveBeenCalledWith('/a\n/b/c');
+    expect(writeText).toHaveBeenCalledWith('../a\n../b/c');
   });
 
   it('filters out empty paths before copying', async () => {
@@ -56,7 +56,7 @@ describe('useCopyPath', () => {
       await result.current.copyPaths(['', 'real']);
     });
 
-    expect(writeText).toHaveBeenCalledWith('/real');
+    expect(writeText).toHaveBeenCalledWith('../real');
   });
 
   it('does nothing when every path is empty', async () => {

--- a/src/client/src/hooks/useCopyPath.ts
+++ b/src/client/src/hooks/useCopyPath.ts
@@ -1,26 +1,22 @@
 import { useCallback } from 'react';
 import { useToast } from '../components/common/Toast';
 import { copyTextToClipboard } from '../utils/clipboard';
+import { toCwdRelativePath } from '../utils/cwdRelativePath';
 
 interface UseCopyPathResult {
     copyPaths: (paths: string[]) => Promise<void>;
 }
 
-/** Formats a workspace-relative path (e.g. "docs/api.md") as root-relative (e.g. "/docs/api.md"). */
-function toRootRelative(path: string): string {
-    return path.startsWith('/') ? path : `/${path}`;
-}
-
 /**
- * Copies one or more workspace-relative paths to the clipboard as root-relative
- * paths (leading "/"), newline-joined, and reports the result via toast. Shared
- * by the project and notebook file trees.
+ * Copies one or more notebook-root-relative paths to the clipboard as
+ * sandbox-CWD-relative paths (see `toCwdRelativePath`), newline-joined, and
+ * reports the result via toast. Shared by the project and notebook file trees.
  */
 export function useCopyPath(): UseCopyPathResult {
     const { showToast } = useToast();
 
     const copyPaths = useCallback(async (paths: string[]) => {
-        const normalized = paths.filter(Boolean).map(toRootRelative);
+        const normalized = paths.filter(Boolean).map(toCwdRelativePath).filter(Boolean);
         if (normalized.length === 0) return;
         const text = normalized.join('\n');
         const copied = await copyTextToClipboard(text);

--- a/src/client/src/utils/__tests__/cwdRelativePath.test.ts
+++ b/src/client/src/utils/__tests__/cwdRelativePath.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { toCwdRelativePath } from '../cwdRelativePath';
+
+describe('toCwdRelativePath', () => {
+    it('prefixes notebook-root paths with ../', () => {
+        expect(toCwdRelativePath('Shared/docs')).toBe('../Shared/docs');
+        expect(toCwdRelativePath('readme.txt')).toBe('../readme.txt');
+    });
+
+    it('strips a leading Output/ segment (CWD is Output/)', () => {
+        expect(toCwdRelativePath('Output/result.txt')).toBe('result.txt');
+        expect(toCwdRelativePath('Output/nested/out.txt')).toBe('nested/out.txt');
+    });
+
+    it('normalizes slashes and drops a leading slash', () => {
+        expect(toCwdRelativePath('\\Shared\\docs')).toBe('../Shared/docs');
+        expect(toCwdRelativePath('/Shared/docs')).toBe('../Shared/docs');
+    });
+
+    it('returns empty for blank input', () => {
+        expect(toCwdRelativePath('')).toBe('');
+        expect(toCwdRelativePath('   ')).toBe('');
+    });
+});

--- a/src/client/src/utils/cwdRelativePath.ts
+++ b/src/client/src/utils/cwdRelativePath.ts
@@ -1,0 +1,26 @@
+/**
+ * Convert a notebook-root-relative path into a path usable from the sandbox CWD
+ * (unpublished notebooks: CWD is Output/).
+ *
+ * Mirrors server `ContextOptionFilesResolver.ToCwdRelativePath(..., isPublished: false)`:
+ * - `Output/foo/bar` → `foo/bar`
+ * - `Shared/docs` → `../Shared/docs`
+ */
+export function toCwdRelativePath(notebookRelativePath: string): string {
+    const normalized = notebookRelativePath
+        .replace(/\\/g, '/')
+        .trim()
+        .replace(/^\/+/, '');
+
+    if (!normalized) {
+        return normalized;
+    }
+
+    const outputPrefix = 'Output/';
+    if (normalized.length >= outputPrefix.length
+        && normalized.slice(0, outputPrefix.length).toLowerCase() === outputPrefix.toLowerCase()) {
+        return normalized.slice(outputPrefix.length);
+    }
+
+    return `../${normalized}`;
+}

--- a/src/server/GuideAntsApi.Tests/Services/ReadWebFetchErrorsTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/ReadWebFetchErrorsTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using GuideAntsApi.Services;
+
+namespace GuideAntsApi.Tests.Services;
+
+[TestClass]
+public sealed class ReadWebFetchErrorsTests
+{
+    [TestMethod]
+    public void BuildMessage_WhenNotFound_ReturnsDoNotRetryGuidance()
+    {
+        var message = ReadWebFetchErrors.BuildMessage(404, "HTTP 404", 404, "HTTP 404");
+
+        message.Should().Be(
+            "404 Not Found. This URL does not exist. Do not retry — fix the path or use local file search.");
+    }
+
+    [TestMethod]
+    public void BuildMessage_WhenForbiddenDominatesNotFound_ReturnsForbiddenGuidance()
+    {
+        var message = ReadWebFetchErrors.BuildMessage(403, "HTTP 403", 404, "HTTP 404");
+
+        message.Should().Be(
+            "403 Forbidden. This host blocks unauthenticated access. Do not retry — use a different source or local files.");
+    }
+
+    [TestMethod]
+    public void BuildMessage_WhenTimedOut_ReturnsTimeoutGuidance()
+    {
+        var message = ReadWebFetchErrors.BuildMessage(null, "Direct fetch timed out", null, "Browser rendering timed out");
+
+        message.Should().Be(
+            "Timed out. Do not retry this URL — try a lighter page or a different tool.");
+    }
+
+    [TestMethod]
+    public void BuildMessage_WhenServerError_ReturnsRetryOnceGuidance()
+    {
+        var message = ReadWebFetchErrors.BuildMessage(500, "HTTP 500", 502, "HTTP 502");
+
+        message.Should().Be(
+            "Server error (5xx). You may retry once; if it fails again, use a different source.");
+    }
+
+    [TestMethod]
+    public void BuildMessage_WhenEmptyContent_ReturnsDifferentToolGuidance()
+    {
+        var message = ReadWebFetchErrors.BuildMessage(200, "HTML was empty or exceeded max size", 200, "HTTP 200");
+
+        message.Should().Be(
+            "Page returned no usable content. This may be an API endpoint or JS-only page — use a different tool.");
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/ReadWebHostPolicyTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/ReadWebHostPolicyTests.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using GuideAntsApi.Services;
+
+namespace GuideAntsApi.Tests.Services;
+
+[TestClass]
+public sealed class ReadWebHostPolicyTests
+{
+    [TestMethod]
+    [DataRow("github.com", true)]
+    [DataRow("api.github.com", true)]
+    [DataRow("raw.githubusercontent.com", true)]
+    [DataRow("gist.github.com", true)]
+    [DataRow("docs.github.com", true)]
+    [DataRow("example.com", false)]
+    public void IsAutoExclusionProtected_RecognizesGitHubHosts(string host, bool expected)
+    {
+        ReadWebHostPolicy.IsAutoExclusionProtected(host).Should().Be(expected);
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/ReadWebToolsTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/ReadWebToolsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using AntRunner.ToolCalling;
 using FluentAssertions;
 using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -123,7 +124,8 @@ public sealed class ReadWebToolsTests
 
         var result = await ReadWebTools.GetContentFromUrl("https://example.com/page");
 
-        result.Content.Should().Contain("Error:");
+        result.Content.Should().Be(
+            "403 Forbidden. This host blocks unauthenticated access. Do not retry — use a different source or local files.");
         browser.CallCount.Should().Be(1);
 
         var excludedHosts = await _context.ExcludedHosts.ToListAsync();
@@ -147,8 +149,122 @@ public sealed class ReadWebToolsTests
 
         var result = await ReadWebTools.GetContentFromUrl("https://example.com/page");
 
-        result.Content.Should().Contain("Error:");
+        result.Content.Should().Be(
+            "Server error (5xx). You may retry once; if it fails again, use a different source.");
         browser.CallCount.Should().Be(1);
+        (await _context.ExcludedHosts.CountAsync()).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task GetContentFromUrl_WhenNotFound_ReturnsInstructiveMessage()
+    {
+        var browser = new FakeBrowserRenderingClient
+        {
+            Result = new BrowserRenderedPageResult(false, null, "HTTP 404", "https://example.com/missing", 404)
+        };
+
+        InitializeTool(
+            new FakeHttpClientFactory(new StaticHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.NotFound))),
+            browser);
+
+        var result = await ReadWebTools.GetContentFromUrl("https://example.com/missing");
+
+        result.Content.Should().Be(
+            "404 Not Found. This URL does not exist. Do not retry — fix the path or use local file search.");
+        browser.CallCount.Should().Be(1);
+        (await _context.ExcludedHosts.CountAsync()).Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task GetContentFromUrl_WhenInvalidUrl_ReturnsInstructiveMessage()
+    {
+        InitializeTool(
+            new FakeHttpClientFactory(new StaticHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.OK))),
+            new FakeBrowserRenderingClient());
+
+        var result = await ReadWebTools.GetContentFromUrl("not-a-url");
+
+        result.Content.Should().Be("Invalid URL. Provide a complete https:// URL.");
+    }
+
+    [TestMethod]
+    public async Task GetContentFromUrl_WhenHostExcluded_ReturnsBlockedMessageWithoutFetching()
+    {
+        _context.ExcludedHosts.Add(new ExcludedHost
+        {
+            Host = "blocked.example.com",
+            Reason = "ReadWeb access denied.",
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+
+        var browser = new FakeBrowserRenderingClient();
+        var httpCalled = false;
+        InitializeTool(
+            new FakeHttpClientFactory(new StaticHttpMessageHandler(_ =>
+            {
+                httpCalled = true;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("<html><body><p>Hello</p></body></html>")
+                };
+            })),
+            browser);
+
+        var result = await ReadWebTools.GetContentFromUrl("https://blocked.example.com/page");
+
+        result.Content.Should().Be(ReadWebHostPolicy.ExcludedHostMessage);
+        httpCalled.Should().BeFalse();
+        browser.CallCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task GetContentFromUrl_WhenProtectedHostIsExcludedInDatabase_StillFetches()
+    {
+        _context.ExcludedHosts.Add(new ExcludedHost
+        {
+            Host = "api.github.com",
+            Reason = "ReadWeb access denied.",
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+
+        var browser = new FakeBrowserRenderingClient();
+        InitializeTool(
+            new FakeHttpClientFactory(new StaticHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("<html><body><p>Hello github</p></body></html>")
+                })),
+            browser);
+
+        var result = await ReadWebTools.GetContentFromUrl("https://api.github.com/repos/example/example");
+
+        result.Content.Should().Contain("Hello github");
+        browser.CallCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task GetContentFromUrl_WhenAccessDeniedOnProtectedHost_DoesNotWriteExcludedHost()
+    {
+        var browser = new FakeBrowserRenderingClient
+        {
+            Result = new BrowserRenderedPageResult(false, null, "forbidden", "https://api.github.com/repos/example/example", 403)
+        };
+
+        InitializeTool(
+            new FakeHttpClientFactory(new StaticHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.Forbidden))),
+            browser);
+
+        var result = await ReadWebTools.GetContentFromUrl("https://api.github.com/repos/example/example");
+
+        result.Content.Should().Be(
+            "403 Forbidden. This host blocks unauthenticated access. Do not retry — use a different source or local files.");
         (await _context.ExcludedHosts.CountAsync()).Should().Be(0);
     }
 

--- a/src/server/GuideAntsApi/Services/Conversations/AttachmentMessageBuilder.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/AttachmentMessageBuilder.cs
@@ -250,30 +250,11 @@ public static class AttachmentMessageBuilder
         }
     }
 
-    private static string GetAttachmentPath(NotebookFile notebookFile, string storagePath)
-    {
-        // Files in Output/ folder: return just the filename (backward compatible)
-        // Note: Resources files are copied into notebook Resources/ and symlinked into Output/ at creation/copy time.
-        // Returning the filename here ensures scripts can access via CWD when symlinks exist.
-        if (notebookFile.RelativePath.StartsWith("Output/", StringComparison.OrdinalIgnoreCase) || 
-            notebookFile.RelativePath.StartsWith("Output\\", StringComparison.OrdinalIgnoreCase))
-        {
-            return Path.GetFileName(notebookFile.RelativePath);
-        }
-        
-        // Files in Runs/<runId>/ folder: return just the filename (CWD is the run folder)
-        if (notebookFile.RelativePath.StartsWith("Runs/", StringComparison.OrdinalIgnoreCase) || 
-            notebookFile.RelativePath.StartsWith("Runs\\", StringComparison.OrdinalIgnoreCase))
-        {
-            return Path.GetFileName(notebookFile.RelativePath);
-        }
-        
-        // All other files: return the path relative to the script working directory (Output/ or Runs/<id>/)
-        // Working directory is: /storage/projectId/notebooks/notebookId/Output (or Runs/<id>)
-        // File path is relative to notebook root (e.g., "data/myfile.csv"), so from Output it is "../data/myfile.csv"
-        var relativeFromNotebookRoot = notebookFile.RelativePath.Replace("\\", "/").TrimStart('/');
-        return $"../{relativeFromNotebookRoot}";
-    }
+    private static string GetAttachmentPath(NotebookFile notebookFile, string _) =>
+        // Sandbox CWD is Output/ (unpublished). Match ContextOptionFilesResolver so
+        // attachment path text is usable by tools the same way as [@files] listings.
+        // Output/foo/bar → foo/bar; data/file.csv → ../data/file.csv
+        ContextOptionFilesResolver.ToCwdRelativePath(notebookFile.RelativePath, isPublished: false);
 
     private static ContentUploadType DetermineUploadType(string fileName)
     {

--- a/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
@@ -379,22 +379,8 @@ public class ConversationService : IConversationService
         }
     }
 
-    private static string BuildAttachmentPathForChat(string relativePath)
-    {
-        if (relativePath.StartsWith("Output/", StringComparison.OrdinalIgnoreCase) ||
-            relativePath.StartsWith("Output\\", StringComparison.OrdinalIgnoreCase))
-        {
-            return Path.GetFileName(relativePath);
-        }
-
-        if (relativePath.StartsWith("Runs/", StringComparison.OrdinalIgnoreCase) ||
-            relativePath.StartsWith("Runs\\", StringComparison.OrdinalIgnoreCase))
-        {
-            return Path.GetFileName(relativePath);
-        }
-
-        return $"../{relativePath.Replace("\\", "/").TrimStart('/')}";
-    }
+    private static string BuildAttachmentPathForChat(string relativePath) =>
+        ContextOptionFilesResolver.ToCwdRelativePath(relativePath, isPublished: false);
 
     private static ConversationStreamRunContext BuildRunContext(
         IConversationStreamPolicy policy,

--- a/src/server/GuideAntsApi/Services/ReadWebFetchErrors.cs
+++ b/src/server/GuideAntsApi/Services/ReadWebFetchErrors.cs
@@ -1,0 +1,101 @@
+using System.Net;
+
+namespace GuideAntsApi.Services;
+
+internal static class ReadWebFetchErrors
+{
+    internal static string BuildMessage(
+        int? directStatusCode,
+        string? directError,
+        int? renderStatusCode,
+        string? renderError)
+    {
+        return PickDominantFailure(directStatusCode, directError, renderStatusCode, renderError) switch
+        {
+            FetchFailureKind.Unauthorized =>
+                "401 Unauthorized. Credentials required. Do not retry without an authenticated tool.",
+            FetchFailureKind.Forbidden =>
+                "403 Forbidden. This host blocks unauthenticated access. Do not retry — use a different source or local files.",
+            FetchFailureKind.NotFound =>
+                "404 Not Found. This URL does not exist. Do not retry — fix the path or use local file search.",
+            FetchFailureKind.RateLimited =>
+                "429 Rate limited. Do not retry now — use a different source.",
+            FetchFailureKind.ServerError =>
+                "Server error (5xx). You may retry once; if it fails again, use a different source.",
+            FetchFailureKind.Timeout =>
+                "Timed out. Do not retry this URL — try a lighter page or a different tool.",
+            FetchFailureKind.EmptyContent =>
+                "Page returned no usable content. This may be an API endpoint or JS-only page — use a different tool.",
+            _ =>
+                "Request failed. Do not retry — use a different source or tool."
+        };
+    }
+
+    private static FetchFailureKind PickDominantFailure(
+        int? directStatusCode,
+        string? directError,
+        int? renderStatusCode,
+        string? renderError)
+    {
+        var direct = Classify(directStatusCode, directError);
+        var render = Classify(renderStatusCode, renderError);
+        return (FetchFailureKind)Math.Max((int)direct, (int)render);
+    }
+
+    private static FetchFailureKind Classify(int? statusCode, string? error)
+    {
+        if (statusCode is (int)HttpStatusCode.Unauthorized)
+            return FetchFailureKind.Unauthorized;
+
+        if (statusCode is (int)HttpStatusCode.Forbidden)
+            return FetchFailureKind.Forbidden;
+
+        if (statusCode is (int)HttpStatusCode.NotFound or (int)HttpStatusCode.Gone)
+            return FetchFailureKind.NotFound;
+
+        if (statusCode is (int)HttpStatusCode.TooManyRequests)
+            return FetchFailureKind.RateLimited;
+
+        if (statusCode is >= 500 and <= 599)
+            return FetchFailureKind.ServerError;
+
+        if (IsTimeout(error))
+            return FetchFailureKind.Timeout;
+
+        if (IsEmptyContent(error))
+            return FetchFailureKind.EmptyContent;
+
+        if (!string.IsNullOrWhiteSpace(error) &&
+            (error.Contains("forbidden", StringComparison.OrdinalIgnoreCase) ||
+             error.Contains("unauthorized", StringComparison.OrdinalIgnoreCase) ||
+             error.Contains("access denied", StringComparison.OrdinalIgnoreCase)))
+        {
+            return error.Contains("unauthorized", StringComparison.OrdinalIgnoreCase)
+                ? FetchFailureKind.Unauthorized
+                : FetchFailureKind.Forbidden;
+        }
+
+        return FetchFailureKind.Unknown;
+    }
+
+    private static bool IsTimeout(string? error) =>
+        !string.IsNullOrWhiteSpace(error) &&
+        error.Contains("timed out", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsEmptyContent(string? error) =>
+        !string.IsNullOrWhiteSpace(error) &&
+        (error.Contains("empty", StringComparison.OrdinalIgnoreCase) ||
+         error.Contains("exceeded max size", StringComparison.OrdinalIgnoreCase));
+
+    private enum FetchFailureKind
+    {
+        Unknown = 0,
+        EmptyContent = 1,
+        Timeout = 2,
+        ServerError = 3,
+        RateLimited = 4,
+        NotFound = 5,
+        Forbidden = 6,
+        Unauthorized = 7
+    }
+}

--- a/src/server/GuideAntsApi/Services/ReadWebHostPolicy.cs
+++ b/src/server/GuideAntsApi/Services/ReadWebHostPolicy.cs
@@ -1,0 +1,33 @@
+namespace GuideAntsApi.Services;
+
+internal static class ReadWebHostPolicy
+{
+    internal const string ExcludedHostMessage =
+        "Host is blocked due to prior failures. Do not fetch from this host — use search or local files.";
+
+    private static readonly HashSet<string> AutoExclusionProtectedHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "github.com",
+        "api.github.com",
+        "raw.githubusercontent.com",
+        "gist.github.com",
+    };
+
+    internal static bool IsAutoExclusionProtected(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            return false;
+
+        if (AutoExclusionProtectedHosts.Contains(host))
+            return true;
+
+        return host.EndsWith(".github.com", StringComparison.OrdinalIgnoreCase) ||
+               host.EndsWith(".githubusercontent.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool ShouldHonorExcludedHost(string host, IExcludedHostService excludedHostService, IReadOnlySet<string> excludedHosts) =>
+        !IsAutoExclusionProtected(host) && excludedHostService.IsHostExcluded(host, excludedHosts);
+
+    internal static bool ShouldAutoExcludeHost(string host, bool accessDenied) =>
+        accessDenied && !IsAutoExclusionProtected(host);
+}

--- a/src/server/GuideAntsApi/Services/ReadWebTools.cs
+++ b/src/server/GuideAntsApi/Services/ReadWebTools.cs
@@ -39,13 +39,13 @@ public static class ReadWebTools
         var errorResult = new MarkdownConversionResult();
         if (_serviceProvider == null)
         {
-            errorResult.Content = "Error: ReadWeb tool services are not initialized.";
+            errorResult.Content = "ReadWeb is unavailable. Report to the user.";
             return errorResult;
         }
 
         if (!TryCreateHttpUri(url, out var uri))
         {
-            errorResult.Content = "Error: Invalid URL format. Only HTTP and HTTPS URLs are supported.";
+            errorResult.Content = "Invalid URL. Provide a complete https:// URL.";
             return errorResult;
         }
 
@@ -58,6 +58,15 @@ public static class ReadWebTools
         var logger = scope.ServiceProvider.GetService<ILoggerFactory>()?
             .CreateLogger(typeof(ReadWebTools).FullName!)
             ?? NullLogger.Instance;
+
+        var excludedHosts = await excludedHostService.GetExcludedHostsAsync(cancellationToken);
+        if (ReadWebHostPolicy.ShouldHonorExcludedHost(uri.Host, excludedHostService, excludedHosts))
+        {
+            logger.LogInformation("ReadWeb skipped fetch for excluded host {Host}.", uri.Host);
+            errorResult.Content = ReadWebHostPolicy.ExcludedHostMessage;
+            return errorResult;
+        }
+
         var totalStopwatch = Stopwatch.StartNew();
 
         logger.LogInformation("ReadWeb start for host {Host}.", uri.Host);
@@ -91,7 +100,7 @@ public static class ReadWebTools
             return ConvertHtmlToMarkdown(rendered.Html, baseUri);
         }
 
-        if (ShouldExcludeForAccessDenied(directFetch, rendered))
+        if (ReadWebHostPolicy.ShouldAutoExcludeHost(uri.Host, ShouldExcludeForAccessDenied(directFetch, rendered)))
         {
             await excludedHostService.TryAddExcludedHostAsync(
                 uri.Host,
@@ -100,6 +109,15 @@ public static class ReadWebTools
 
             logger.LogInformation(
                 "ReadWeb excluded host {Host} due to access denied. DirectStatus={DirectStatus}, RenderStatus={RenderStatus}, ElapsedMs={ElapsedMs}.",
+                uri.Host,
+                directFetch.StatusCode,
+                rendered.StatusCode,
+                totalStopwatch.ElapsedMilliseconds);
+        }
+        else if (ShouldExcludeForAccessDenied(directFetch, rendered))
+        {
+            logger.LogInformation(
+                "ReadWeb skipped excluding protected host {Host}. DirectStatus={DirectStatus}, RenderStatus={RenderStatus}, ElapsedMs={ElapsedMs}.",
                 uri.Host,
                 directFetch.StatusCode,
                 rendered.StatusCode,
@@ -115,7 +133,11 @@ public static class ReadWebTools
                 totalStopwatch.ElapsedMilliseconds);
         }
 
-        errorResult.Content = "Error: Request failed or timed out.";
+        errorResult.Content = ReadWebFetchErrors.BuildMessage(
+            directFetch.StatusCode,
+            directFetch.Error,
+            rendered.StatusCode,
+            rendered.Error);
         return errorResult;
     }
 


### PR DESCRIPTION
Return status-specific ReadWeb failure messages (401/403/404/429/5xx/timeout) instead of a generic error, protect GitHub hosts from auto-exclusion, and honor excluded-host blocks before fetching. Copy-path and attachment paths now use CWD-relative format matching ContextOptionFilesResolver so pasted paths work in chat tools.