### PR TITLE
Add Qwen 3.8 27B to the llama catalog and keep catalog edit usable wh…

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -24,6 +24,9 @@ GA_AI_SLIM_IMAGE=guideants-ai:slim-latest
 GA_DOCUMENTSERVER_IMAGE=ghcr.io/euro-office/documentserver:latest
 CUDA_VISIBLE_DEVICES=1,0
 GA_LLAMA_CUDA_VISIBLE_DEVICES=
+# q8_0 KV cache halves KV VRAM vs f16 (requires flash attention, which CUDA defaults to on).
+GA_LLAMA_CACHE_TYPE_K=q8_0
+GA_LLAMA_CACHE_TYPE_V=q8_0
 GA_ASR_CUDA_VISIBLE_DEVICES=1
 GA_TTS_CUDA_VISIBLE_DEVICES=0
 GA_EMB_CUDA_VISIBLE_DEVICES=0

--- a/docker/build/guideants-ai/lib/guideants_hf/preset_validation.py
+++ b/docker/build/guideants-ai/lib/guideants_hf/preset_validation.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from guideants_hf.router_mmproj import canonicalize_mmproj_disable_keys
+
 INFRASTRUCTURE_KEYS = frozenset({"model", "mmproj", "version"})
 
 # Router shell bootstrap keys belong on the llama-server parent process CLI (start-llama.sh),
@@ -91,7 +93,7 @@ def normalize_preset_map(preset: dict[str, Any] | None) -> dict[str, str]:
             )
         seen_lower[lower] = key
         normalized[key] = value
-    return normalized
+    return canonicalize_mmproj_disable_keys(normalized)
 
 
 def apply_preset_mode(

--- a/docker/build/guideants-ai/lib/guideants_hf/router_mmproj.py
+++ b/docker/build/guideants-ai/lib/guideants_hf/router_mmproj.py
@@ -4,14 +4,55 @@ from __future__ import annotations
 
 from guideants_hf.env_default_preset import apply_env_defaults_to_extras
 
-NO_MMPROJ_KEYS = frozenset({"no-mmproj", "no_mmproj"})
+# CLI spellings llama.cpp's INI parser does not accept (hyphens are stripped to
+# `nommproj`, which is not a registered preset option). Canonicalize to mmproj-auto=false.
+NO_MMPROJ_KEYS = frozenset({"no-mmproj", "no_mmproj", "nommproj", "no-mmproj-auto", "nommprojauto"})
 MMPROJ_AUTO_KEY = "mmproj-auto"
 MMPROJ_AUTO_DISABLED_VALUE = "false"
+_FALSEY_VALUES = frozenset({"", "0", "false", "no", "off"})
+
+
+def llama_option_token(key: str) -> str:
+    """Match llama.cpp INI option names after hyphen/underscore stripping."""
+    return "".join(ch for ch in key.strip().lower() if ch not in "-_")
+
+
+def _is_falsey(value: str) -> bool:
+    return value.strip().lower() in _FALSEY_VALUES
 
 
 def preset_disables_mmproj(extras: dict[str, str]) -> bool:
     """True when the alias preset explicitly disables vision projector loading."""
-    return any(key.strip().lower() in NO_MMPROJ_KEYS for key in extras)
+    for key, value in extras.items():
+        token = llama_option_token(key)
+        if token in {"nommproj", "nommprojauto"}:
+            return True
+        if token == "mmprojauto" and _is_falsey(value):
+            return True
+    return False
+
+
+def canonicalize_mmproj_disable_keys(preset: dict[str, str]) -> dict[str, str]:
+    """Rewrite CLI-shaped mmproj disable flags to mmproj-auto=false."""
+    if not preset:
+        return preset
+    disable = False
+    rewritten: dict[str, str] = {}
+    for key, value in preset.items():
+        token = llama_option_token(key)
+        if token in {"nommproj", "nommprojauto"}:
+            disable = True
+            continue
+        if token == "mmprojauto":
+            if _is_falsey(value):
+                disable = True
+            else:
+                rewritten[MMPROJ_AUTO_KEY] = value
+            continue
+        rewritten[key] = value
+    if disable:
+        rewritten[MMPROJ_AUTO_KEY] = MMPROJ_AUTO_DISABLED_VALUE
+    return rewritten
 
 
 def resolve_router_runtime_config_path(canonical_path: str) -> str:
@@ -29,7 +70,7 @@ def materialize_router_extras_for_runtime(extras: dict[str, str]) -> dict[str, s
     runtime_extras = {
         key: value
         for key, value in effective.items()
-        if key.strip().lower() not in NO_MMPROJ_KEYS
+        if llama_option_token(key) not in {"nommproj", "nommprojauto"}
     }
     runtime_extras[MMPROJ_AUTO_KEY] = MMPROJ_AUTO_DISABLED_VALUE
     return runtime_extras

--- a/docker/build/guideants-ai/lib/guideants_hf/unrecognized_preset.py
+++ b/docker/build/guideants-ai/lib/guideants_hf/unrecognized_preset.py
@@ -1,0 +1,92 @@
+"""Recover from llama.cpp 'option not recognized in preset' by mutating canonical INI."""
+
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+from guideants_hf.router_mmproj import (
+    MMPROJ_AUTO_DISABLED_VALUE,
+    MMPROJ_AUTO_KEY,
+    llama_option_token,
+)
+
+UNRECOGNIZED_OPTION_RE = re.compile(
+    r"option '([^']+)' not recognized in preset '([^']+)'",
+    re.IGNORECASE,
+)
+
+
+def parse_unrecognized_option_error(log_text: str) -> tuple[str, str] | None:
+    """Return (option_token, alias) from llama.cpp's latest fatal preset parse error."""
+    matches = list(UNRECOGNIZED_OPTION_RE.finditer(log_text))
+    if not matches:
+        return None
+    match = matches[-1]
+    return match.group(1).strip().lower(), match.group(2).strip()
+
+
+def drop_unrecognized_option_from_entries(
+    entries: dict,
+    *,
+    option_token: str,
+    alias: str,
+) -> bool:
+    """Remove extras whose hyphen-stripped name equals option_token.
+
+    mmproj-disable spellings are rewritten to mmproj-auto=false so vision-off
+    intent survives. Returns True when the alias extras changed.
+    """
+    section = entries.get(alias)
+    if section is None:
+        return False
+    token = llama_option_token(option_token)
+    extras = dict(section.extras)
+    changed = False
+    mmproj_disable = token in {"nommproj", "nommprojauto"}
+    for key in list(extras.keys()):
+        if llama_option_token(key) != token:
+            continue
+        del extras[key]
+        changed = True
+    if mmproj_disable:
+        extras[MMPROJ_AUTO_KEY] = MMPROJ_AUTO_DISABLED_VALUE
+        changed = True
+    if not changed:
+        return False
+    section.extras = extras
+    return True
+
+
+def sanitize_canonical_from_log(
+    canonical_path: str,
+    log_path: str,
+    *,
+    parse_router_ini: Callable[[str], dict],
+    serialize_router_ini: Callable[[dict], str],
+) -> bool:
+    """Drop the unrecognized option named in log_path from canonical_path. True if rewritten."""
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+            log_text = handle.read()
+    except OSError:
+        return False
+    parsed = parse_unrecognized_option_error(log_text)
+    if parsed is None:
+        return False
+    option_token, alias = parsed
+    try:
+        with open(canonical_path, "r", encoding="utf-8") as handle:
+            canonical = handle.read()
+    except OSError:
+        return False
+    entries = parse_router_ini(canonical)
+    if not drop_unrecognized_option_from_entries(
+        entries, option_token=option_token, alias=alias
+    ):
+        return False
+    payload = serialize_router_ini(entries)
+    with open(canonical_path, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(payload)
+        handle.flush()
+    return True

--- a/docker/build/guideants-ai/llama-admin-service/catalog/manifest.json
+++ b/docker/build/guideants-ai/llama-admin-service/catalog/manifest.json
@@ -773,6 +773,214 @@
       }
     },
     {
+      "id": "qwen3.8-27b",
+      "display": {
+        "name": "Qwen 3.8 27B",
+        "description": "Dense Qwen 3.8 vision model. Hybrid thinking with reasoning_effort (xhigh default). In-GGUF draft-mtp and preserve reasoning.",
+        "labels": [
+          "Text",
+          "Vision",
+          "Reasoning",
+          "Tool use",
+          "MTP"
+        ],
+        "license": "Apache-2.0",
+        "documentationUrl": "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF",
+        "recommendedQuantLabels": [
+          "UD-Q4_K_XL"
+        ]
+      },
+      "source": {
+        "repository": "unsloth/Qwen3.8-27B-GGUF",
+        "revision": "main"
+      },
+      "defaults": {
+        "catalogModelId": "qwen3.8-27b-local",
+        "routerModelId": "Qwen3.8-27B-GGUF",
+        "targetDirectory": "Qwen3.8-27B-GGUF",
+        "mmproj": {
+          "path": "mmproj-F16.gguf"
+        },
+        "routerPreset": {
+          "ctx-size": "262144",
+          "image-min-tokens": "1024",
+          "reasoning-preserve": "true",
+          "spec-type": "draft-mtp",
+          "spec-draft-n-max": "2"
+        },
+        "chatBehavior": {
+          "combineSystemAndDeveloperMessages": true,
+          "samplingParametersJson": {
+            "temperature": {
+              "key": "temperature",
+              "label": "Temperature",
+              "description": "Controls randomness: lower is focused, higher is creative",
+              "min": 0.0,
+              "max": 2.0,
+              "step": 0.1,
+              "default": 1.0,
+              "displayOrder": 0,
+              "exposedInGuideBuilder": true
+            },
+            "top_p": {
+              "key": "top_p",
+              "label": "Top P",
+              "description": "Nucleus sampling: controls diversity of token selection",
+              "min": 0.0,
+              "max": 1.0,
+              "step": 0.05,
+              "default": 0.95,
+              "displayOrder": 1,
+              "exposedInGuideBuilder": true
+            },
+            "top_k": {
+              "key": "top_k",
+              "label": "Top K",
+              "description": "Limits number of token candidates considered",
+              "min": 1,
+              "max": 100,
+              "step": 1,
+              "default": 20,
+              "displayOrder": 2,
+              "exposedInGuideBuilder": true
+            },
+            "min_p": {
+              "key": "min_p",
+              "label": "Min P",
+              "description": "Minimum probability threshold for token selection",
+              "min": 0.0,
+              "max": 1.0,
+              "step": 0.01,
+              "default": 0.0,
+              "displayOrder": 3,
+              "exposedInGuideBuilder": false
+            },
+            "presence_penalty": {
+              "key": "presence_penalty",
+              "label": "Presence Penalty",
+              "description": "Reduces repetition (0=off; Unsloth thinking default is 0, instruct/none uses 1.5)",
+              "min": 0.0,
+              "max": 2.0,
+              "step": 0.1,
+              "default": 0.0,
+              "displayOrder": 4,
+              "exposedInGuideBuilder": true
+            },
+            "repetition_penalty": {
+              "key": "repetition_penalty",
+              "label": "Repetition Penalty",
+              "description": "Penalizes repeated tokens (1.0=disabled)",
+              "min": 1.0,
+              "max": 2.0,
+              "step": 0.1,
+              "default": 1.0,
+              "displayOrder": 5,
+              "exposedInGuideBuilder": false
+            }
+          },
+          "thinkingControlJson": {
+            "defaultChoice": "xhigh",
+            "choiceActions": {
+              "none": [
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.enable_thinking",
+                  "value": false
+                },
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.preserve_thinking",
+                  "value": false
+                },
+                {
+                  "target": "RequestField",
+                  "key": "reasoning_format",
+                  "value": "none"
+                }
+              ],
+              "low": [
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.enable_thinking",
+                  "value": true
+                },
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.reasoning_effort",
+                  "value": "low"
+                },
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.preserve_thinking",
+                  "value": true
+                }
+              ],
+              "medium": [
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.enable_thinking",
+                  "value": true
+                },
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.reasoning_effort",
+                  "value": "medium"
+                },
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.preserve_thinking",
+                  "value": true
+                }
+              ],
+              "xhigh": [
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.enable_thinking",
+                  "value": true
+                },
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.reasoning_effort",
+                  "value": "xhigh"
+                },
+                {
+                  "target": "NestedRequestField",
+                  "key": "chat_template_kwargs.preserve_thinking",
+                  "value": true
+                }
+              ]
+            }
+          },
+          "thoughtBlockPattern": "<think>[\\s\\S]*?</think>",
+          "requestFieldsWhenToolsPresent": {
+            "parallel_tool_calls": false
+          }
+        }
+      },
+      "quantMetadata": {
+        "recommendedLabels": [
+          "UD-Q4_K_XL",
+          "UD-Q3_K_XL",
+          "UD-Q5_K_XL"
+        ],
+        "guidance": {
+          "UD-Q4_K_XL": {
+            "summary": "Unsloth default 4-bit. Typical 17–19GB RAM+VRAM."
+          },
+          "UD-Q3_K_XL": {
+            "summary": "Unsloth 3-bit option. Typical 13–16GB."
+          },
+          "UD-Q5_K_XL": {
+            "summary": "Higher quality toward Unsloth 6-bit ~24GB class."
+          }
+        }
+      },
+      "hardwareNotes": {
+        "summary": "Dense 27B vision with in-GGUF draft-mtp. Unsloth: 4-bit 17–19GB, 6-bit 24GB, 8-bit 31GB (RAM+VRAM). Native context 262144. MTP needs extra VRAM headroom.",
+        "contextClass": "large"
+      }
+    },
+    {
       "id": "muse-glimmer-30b",
       "display": {
         "name": "Muse Glimmer 30B",

--- a/docker/build/guideants-ai/llama-admin-service/llama_admin_service.py
+++ b/docker/build/guideants-ai/llama-admin-service/llama_admin_service.py
@@ -1484,8 +1484,9 @@ def post_router_entry(request: RouterEntryUpsertRequest) -> dict[str, Any]:
             "iniSha256": runtime_apply.ini_sha256,
             "remediation": runtime_apply.remediation,
         }
-        if not runtime_apply.applied:
-            raise HTTPException(status_code=502, detail=response)
+        # INI commit is the operator recovery path. llama-server may be crash-looping
+        # on a bad preset; returning 502 here hid the editor that can fix it.
+        response["applyStatus"] = "applied" if runtime_apply.applied else "ini_committed_reload_pending"
     return response
 
 

--- a/docker/build/guideants-ai/llama-admin-service/tests/test_live_manifest_drift.py
+++ b/docker/build/guideants-ai/llama-admin-service/tests/test_live_manifest_drift.py
@@ -1,4 +1,4 @@
-"""Live manifest-drift suite for all 15 curated repositories.
+"""Live manifest-drift suite for all 16 curated repositories.
 
 Run explicitly (not part of default deterministic unit discovery):
 
@@ -43,14 +43,14 @@ class LiveManifestDriftTests(unittest.TestCase):
         cls.token = _resolve_live_token()
         llama_catalog.cached_manifest.cache_clear()
         cls.manifest = cached_manifest()
-        if len(cls.manifest.get("models", [])) != 15:
-            raise AssertionError(f"Expected 15 manifest definitions, found {len(cls.manifest.get('models', []))}")
+        if len(cls.manifest.get("models", [])) != 16:
+            raise AssertionError(f"Expected 16 manifest definitions, found {len(cls.manifest.get('models', []))}")
         global _manifest_ids
         _manifest_ids = [str(model["id"]) for model in cls.manifest["models"] if isinstance(model.get("id"), str)]
 
-    def test_manifest_has_fifteen_named_entries(self) -> None:
+    def test_manifest_has_sixteen_named_entries(self) -> None:
         ids = [model["id"] for model in self.manifest["models"]]
-        self.assertEqual(15, len(set(ids)))
+        self.assertEqual(16, len(set(ids)))
 
     def _resolve_entry(self, catalog_id: str) -> None:
         try:

--- a/docker/build/guideants-ai/llama-admin-service/tests/test_llama_catalog.py
+++ b/docker/build/guideants-ai/llama-admin-service/tests/test_llama_catalog.py
@@ -23,7 +23,7 @@ class LlamaCatalogServiceTests(unittest.TestCase):
         self.assertEqual(1, response["schemaVersion"])
         self.assertEqual("llama", response["task"])
         self.assertEqual("2026-07-10", response["catalogVersion"])
-        self.assertEqual(15, len(response["models"]))
+        self.assertEqual(16, len(response["models"]))
         self.assertNotIn("selectedQuant", response)
         self.assertNotIn("defaultQuant", response)
 

--- a/docker/build/guideants-ai/llama-admin-service/tests/test_llama_schema.py
+++ b/docker/build/guideants-ai/llama-admin-service/tests/test_llama_schema.py
@@ -33,7 +33,7 @@ class LlamaSchemaTests(unittest.TestCase):
 
     def test_shipped_manifest_validates(self) -> None:
         validate_manifest_instance(self.manifest)
-        self.assertEqual(15, len(self.manifest["models"]))
+        self.assertEqual(16, len(self.manifest["models"]))
 
     def test_rejects_file_arrays_on_definition(self) -> None:
         bad = copy.deepcopy(self.manifest["models"][0])

--- a/docker/build/guideants-ai/llama-admin-service/tests/test_router_mmproj.py
+++ b/docker/build/guideants-ai/llama-admin-service/tests/test_router_mmproj.py
@@ -29,7 +29,27 @@ class RouterMmprojTests(unittest.TestCase):
 
     def test_preset_disables_mmproj_accepts_boolean_flag(self) -> None:
         self.assertTrue(preset_disables_mmproj({"no-mmproj": ""}))
+        self.assertTrue(preset_disables_mmproj({"nommproj": ""}))
+        self.assertTrue(preset_disables_mmproj({"mmproj-auto": "false"}))
         self.assertFalse(preset_disables_mmproj({"spec-type": "draft-mtp"}))
+        self.assertFalse(preset_disables_mmproj({"mmproj-auto": "true"}))
+
+    def test_materialize_translates_hyphenless_nommproj(self) -> None:
+        canonical = (
+            "version = 1\n\n"
+            "[alias]\n"
+            "model = /models-local/llama/a/model.gguf\n"
+            "mmproj = /models-local/llama/a/mmproj-F16.gguf\n"
+            "nommproj = \n"
+        )
+        runtime = materialize_router_ini_text(
+            canonical,
+            parse_router_ini=router.parse_router_ini,
+            serialize_router_ini_for_runtime=router.serialize_router_ini_for_runtime,
+        )
+        self.assertIn("mmproj-auto = false", runtime)
+        self.assertNotIn("nommproj", runtime)
+        self.assertNotIn("mmproj =", runtime)
 
     def test_materialize_translates_no_mmproj_to_mmproj_auto_false(self) -> None:
         canonical = (
@@ -168,10 +188,86 @@ class RouterMmprojTests(unittest.TestCase):
             runtime = handle.read()
 
         self.assertIn("mmproj = /models-local/llama/a/mmproj-F16.gguf", canonical)
-        self.assertIn("no-mmproj =", canonical)
+        self.assertIn("mmproj-auto = false", canonical)
+        self.assertNotIn("no-mmproj", canonical)
         self.assertIn("mmproj-auto = false", runtime)
         self.assertNotIn("no-mmproj", runtime)
         self.assertNotIn("mmproj =", runtime)
+
+
+class UnrecognizedPresetTests(unittest.TestCase):
+    def test_parse_nommproj_error(self) -> None:
+        from guideants_hf.unrecognized_preset import parse_unrecognized_option_error
+
+        parsed = parse_unrecognized_option_error(
+            "failed to initialize router models: option 'nommproj' not recognized in preset 'Qwen3.8-27B-GGUF'"
+        )
+        self.assertEqual(parsed, ("nommproj", "Qwen3.8-27B-GGUF"))
+
+    def test_parse_uses_latest_unrecognized_option(self) -> None:
+        from guideants_hf.unrecognized_preset import parse_unrecognized_option_error
+
+        parsed = parse_unrecognized_option_error(
+            "option 'nommproj' not recognized in preset 'Qwen3.8-27B-GGUF'\n"
+            "option 'foobar' not recognized in preset 'alias'\n"
+        )
+        self.assertEqual(parsed, ("foobar", "alias"))
+
+    def test_drop_nommproj_rewrites_to_mmproj_auto(self) -> None:
+        from guideants_hf.unrecognized_preset import drop_unrecognized_option_from_entries
+
+        entries = router.parse_router_ini(
+            "version = 1\n\n[Qwen3.8-27B-GGUF]\nmodel = /m/a.gguf\nmmproj = /m/p.gguf\nnommproj = \nctx-size = 8\n"
+        )
+        changed = drop_unrecognized_option_from_entries(
+            entries, option_token="nommproj", alias="Qwen3.8-27B-GGUF"
+        )
+        self.assertTrue(changed)
+        extras = entries["Qwen3.8-27B-GGUF"].extras
+        self.assertEqual(extras["mmproj-auto"], "false")
+        self.assertNotIn("nommproj", extras)
+        self.assertEqual(extras["ctx-size"], "8")
+
+    def test_drop_unknown_key_by_hyphenless_token(self) -> None:
+        from guideants_hf.unrecognized_preset import drop_unrecognized_option_from_entries
+
+        entries = router.parse_router_ini(
+            "version = 1\n\n[alias]\nmodel = /m/a.gguf\nmmproj = \nfoo-bar = 1\nctx-size = 8\n"
+        )
+        changed = drop_unrecognized_option_from_entries(
+            entries, option_token="foobar", alias="alias"
+        )
+        self.assertTrue(changed)
+        self.assertNotIn("foo-bar", entries["alias"].extras)
+        self.assertEqual(entries["alias"].extras["ctx-size"], "8")
+
+    def test_sanitize_canonical_from_log_rewrites_file(self) -> None:
+        from guideants_hf.unrecognized_preset import sanitize_canonical_from_log
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        canonical_path = os.path.join(tmp.name, "router-models.ini")
+        log_path = os.path.join(tmp.name, "llama-server.log")
+        with open(canonical_path, "w", encoding="utf-8") as handle:
+            handle.write(
+                "version = 1\n\n[Qwen3.8-27B-GGUF]\nmodel = /m/a.gguf\nmmproj = /m/p.gguf\nno-mmproj = \n"
+            )
+        with open(log_path, "w", encoding="utf-8") as handle:
+            handle.write(
+                "E srv  llama_server: failed to initialize router models: option 'nommproj' not recognized in preset 'Qwen3.8-27B-GGUF'\n"
+            )
+        self.assertTrue(
+            sanitize_canonical_from_log(
+                canonical_path,
+                log_path,
+                parse_router_ini=router.parse_router_ini,
+                serialize_router_ini=router.serialize_router_ini,
+            )
+        )
+        with open(canonical_path, encoding="utf-8") as handle:
+            rewritten = handle.read()
+        self.assertIn("mmproj-auto = false", rewritten)
+        self.assertNotIn("no-mmproj", rewritten)
 
 
 if __name__ == "__main__":

--- a/docker/build/guideants-ai/llama-admin-service/tests/test_router_preset.py
+++ b/docker/build/guideants-ai/llama-admin-service/tests/test_router_preset.py
@@ -222,6 +222,16 @@ class RouterPresetTests(unittest.TestCase):
         self.assertEqual(preset["n-gpu-layers"], "999")
         self.assertEqual(preset["jinja"], "true")
 
+    def test_canonicalizes_no_mmproj_cli_spellings(self) -> None:
+        from guideants_hf.preset_validation import normalize_preset_map
+
+        preset = normalize_preset_map({"no-mmproj": "", "ctx-size": "131072"})
+        self.assertEqual(preset["mmproj-auto"], "false")
+        self.assertNotIn("no-mmproj", preset)
+        hyphenless = normalize_preset_map({"nommproj": "", "spec-type": "draft-mtp"})
+        self.assertEqual(hyphenless["mmproj-auto"], "false")
+        self.assertNotIn("nommproj", hyphenless)
+
     def test_fixture_preset_shape(self) -> None:
         fixture = json.loads((CONTRACTS_ROOT / "admin-router-entries-post-request.fixture.json").read_text(encoding="utf-8"))
         preset = router.normalize_preset_map(fixture["preset"])

--- a/docker/build/guideants-ai/llama-admin-service/tests/test_start_llama_global_args.py
+++ b/docker/build/guideants-ai/llama-admin-service/tests/test_start_llama_global_args.py
@@ -23,13 +23,7 @@ class StartLlamaGlobalArgsTests(unittest.TestCase):
             fake_server.chmod(fake_server.stat().st_mode | stat.S_IEXEC)
 
             script_copy = tmp_path / "start-llama.sh"
-            script_copy.write_text(
-                START_LLAMA.read_text(encoding="utf-8").replace(
-                    "exec /app/llama-server",
-                    f"exec {fake_server}",
-                ),
-                encoding="utf-8",
-            )
+            script_copy.write_text(START_LLAMA.read_text(encoding="utf-8"), encoding="utf-8")
             script_copy.chmod(script_copy.stat().st_mode | stat.S_IEXEC)
 
             router_canonical = tmp_path / "router-models.ini"
@@ -44,6 +38,7 @@ class StartLlamaGlobalArgsTests(unittest.TestCase):
             lib_root = REPO_ROOT / "docker/build/guideants-ai/lib"
             admin_root = REPO_ROOT / "docker/build/guideants-ai/llama-admin-service"
             run_env["PYTHONPATH"] = f"{lib_root}:{admin_root}"
+            run_env["GA_LLAMA_SERVER_BIN"] = str(fake_server)
             run_env.setdefault("GA_LLAMA_MODELS_PRESET", str(router_canonical))
             run_env.setdefault("GA_LLAMA_MODELS_RUNTIME_PRESET", str(router_runtime))
 
@@ -95,13 +90,7 @@ class StartLlamaGlobalArgsTests(unittest.TestCase):
             fake_server.write_text("#!/bin/sh\nprintf '%s\\n' \"$@\"\n", encoding="utf-8")
             fake_server.chmod(fake_server.stat().st_mode | stat.S_IEXEC)
             script_copy = tmp_path / "start-llama.sh"
-            script_copy.write_text(
-                START_LLAMA.read_text(encoding="utf-8").replace(
-                    "exec /app/llama-server",
-                    f"exec {fake_server}",
-                ),
-                encoding="utf-8",
-            )
+            script_copy.write_text(START_LLAMA.read_text(encoding="utf-8"), encoding="utf-8")
             script_copy.chmod(script_copy.stat().st_mode | stat.S_IEXEC)
 
             run_env = os.environ.copy()
@@ -111,6 +100,7 @@ class StartLlamaGlobalArgsTests(unittest.TestCase):
                     "GA_LLAMA_NO_MMAP": "1",
                     "GA_LLAMA_MODELS_PRESET": str(router_canonical),
                     "GA_LLAMA_MODELS_RUNTIME_PRESET": str(router_runtime),
+                    "GA_LLAMA_SERVER_BIN": str(fake_server),
                 },
             )
             lib_root = REPO_ROOT / "docker/build/guideants-ai/lib"
@@ -156,17 +146,12 @@ class StartLlamaGlobalArgsTests(unittest.TestCase):
             fake_server.write_text("#!/bin/sh\nprintf '%s\\n' \"$@\"\n", encoding="utf-8")
             fake_server.chmod(fake_server.stat().st_mode | stat.S_IEXEC)
             script_copy = tmp_path / "start-llama.sh"
-            script_copy.write_text(
-                START_LLAMA.read_text(encoding="utf-8").replace(
-                    "exec /app/llama-server",
-                    f"exec {fake_server}",
-                ),
-                encoding="utf-8",
-            )
+            script_copy.write_text(START_LLAMA.read_text(encoding="utf-8"), encoding="utf-8")
             script_copy.chmod(script_copy.stat().st_mode | stat.S_IEXEC)
 
             run_env = os.environ.copy()
             run_env["GA_LLAMA_MODELS_PRESET"] = str(missing)
+            run_env["GA_LLAMA_SERVER_BIN"] = str(fake_server)
             lib_root = REPO_ROOT / "docker/build/guideants-ai/lib"
             admin_root = REPO_ROOT / "docker/build/guideants-ai/llama-admin-service"
             run_env["PYTHONPATH"] = f"{lib_root}:{admin_root}"

--- a/docker/build/guideants-ai/start-llama.sh
+++ b/docker/build/guideants-ai/start-llama.sh
@@ -103,7 +103,11 @@ if [ ! -f "$ROUTER_CANONICAL" ]; then
     exit 1
 fi
 
-PYTHONPATH="/app/lib:/app/llama-admin-service${PYTHONPATH:+:$PYTHONPATH}" python3 - "$ROUTER_CANONICAL" "$ROUTER_RUNTIME" <<'PY'
+PYTHONPATH="/app/lib:/app/llama-admin-service${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH
+
+materialize_runtime_ini() {
+    python3 - "$ROUTER_CANONICAL" "$ROUTER_RUNTIME" <<'PY'
 import sys
 
 from guideants_hf.router_mmproj import materialize_router_ini_text
@@ -120,15 +124,47 @@ runtime = materialize_router_ini_text(
 with open(runtime_path, "w", encoding="utf-8", newline="\n") as handle:
     handle.write(runtime)
 PY
-
-if [ ! -f "$ROUTER_RUNTIME" ]; then
-    echo "ERROR: router runtime preset not written at '$ROUTER_RUNTIME'." >&2
-    exit 1
-fi
+}
 
 ARGS+=(--models-preset "$ROUTER_RUNTIME")
 [ -n "$GA_LLAMA_MODELS_MAX" ] && ARGS+=(--models-max "$GA_LLAMA_MODELS_MAX")
 [ "$GA_LLAMA_NO_AUTOLOAD" = "1" ] && ARGS+=(--no-models-autoload)
 ARGS+=(--host "${GA_LLAMA_HOST:-127.0.0.1}")
 ARGS+=(--port "${GA_LLAMA_PORT:-8080}")
-exec /app/llama-server "${ARGS[@]}"
+
+LLAMA_SERVER="${GA_LLAMA_SERVER_BIN:-/app/llama-server}"
+LLAMA_SERVER_LOG="${GA_LLAMA_SERVER_LOG:-/run/llama-server.log}"
+
+# Entrypoint respawns this script when llama-server exits. If the previous
+# process died on an unrecognized preset key, strip it from canonical INI
+# before rematerializing so we do not restore the poison key and crash-loop.
+if [ -f "$LLAMA_SERVER_LOG" ]; then
+    python3 - "$ROUTER_CANONICAL" "$LLAMA_SERVER_LOG" <<'PY' || true
+import sys
+
+from guideants_hf.unrecognized_preset import sanitize_canonical_from_log
+import llama_router_ini as router_ini
+
+ok = sanitize_canonical_from_log(
+    sys.argv[1],
+    sys.argv[2],
+    parse_router_ini=router_ini.parse_router_ini,
+    serialize_router_ini=router_ini.serialize_router_ini,
+)
+if ok:
+    print(
+        f"stripped unrecognized llama.cpp preset option from {sys.argv[1]}",
+        file=sys.stderr,
+    )
+sys.exit(0)
+PY
+fi
+
+materialize_runtime_ini
+
+if [ ! -f "$ROUTER_RUNTIME" ]; then
+    echo "ERROR: router runtime preset not written at '$ROUTER_RUNTIME'." >&2
+    exit 1
+fi
+
+exec "$LLAMA_SERVER" "${ARGS[@]}"

--- a/src/client/src/features/localModelOnboarding/__tests__/phase7Advanced.test.ts
+++ b/src/client/src/features/localModelOnboarding/__tests__/phase7Advanced.test.ts
@@ -40,6 +40,16 @@ describe('routerPreset', () => {
     );
     expect(preset).toEqual({ 'ctx-size': '131072', 'spec-type': 'draft-mtp' });
   });
+
+  it('canonicalizes no-mmproj CLI spellings to mmproj-auto=false', () => {
+    const preset = buildEffectivePresetRecord(
+      [{ key: 'no-mmproj', value: '' }, { key: 'spec-type', value: 'draft-mtp' }],
+      '131072',
+      '',
+    );
+    expect(preset).toEqual({ 'ctx-size': '131072', 'spec-type': 'draft-mtp', 'mmproj-auto': 'false' });
+    expect(preset).not.toHaveProperty('no-mmproj');
+  });
 });
 
 describe('artifactGroups', () => {

--- a/src/client/src/features/localModelOnboarding/installed/AliasPresetSavePanel.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/AliasPresetSavePanel.tsx
@@ -70,6 +70,8 @@ export interface AliasPresetSavePanelProps {
   routerEntry: LlamaRouterEntryDto | null;
   /** Fallback when router entry is unavailable (e.g. provenance snapshot). */
   fallbackPreset?: Record<string, string>;
+  fallbackModelPath?: string;
+  fallbackMmprojPath?: string;
 }
 
 /**
@@ -80,7 +82,13 @@ export interface AliasPresetSavePanelProps {
  * removed keys and makes Delete appear to fail after reload.
  */
 export const AliasPresetSavePanel = forwardRef<AliasPresetSavePanelHandle, AliasPresetSavePanelProps>(
-  function AliasPresetSavePanel({ alias, routerEntry, fallbackPreset = {} }, ref) {
+  function AliasPresetSavePanel({
+    alias,
+    routerEntry,
+    fallbackPreset = {},
+    fallbackModelPath = '',
+    fallbackMmprojPath = '',
+  }, ref) {
     const authoritativePreset = useMemo(() => {
       return routerEntry?.preset && Object.keys(routerEntry.preset).length > 0
         ? routerEntry.preset
@@ -127,7 +135,8 @@ export const AliasPresetSavePanel = forwardRef<AliasPresetSavePanelHandle, Alias
       ref,
       () => ({
         async saveRouterPreset() {
-          if (!routerEntry) {
+          const modelPath = routerEntry?.modelPath?.trim() || fallbackModelPath.trim();
+          if (!modelPath) {
             throw new Error('Router entry is unavailable. Refresh and try again.');
           }
           if (validationErrors.length > 0) {
@@ -136,8 +145,8 @@ export const AliasPresetSavePanel = forwardRef<AliasPresetSavePanelHandle, Alias
 
           await api.settings.putLlamaRouterEntry(alias, {
             alias,
-            modelPath: routerEntry.modelPath,
-            mmprojPath: routerEntry.mmprojPath ?? '',
+            modelPath,
+            mmprojPath: routerEntry?.mmprojPath ?? fallbackMmprojPath,
             preset: effectivePreset,
             // WYSIWYG: removed rows must leave the INI, not survive via merge.
             presetMode: 'replace',
@@ -146,7 +155,7 @@ export const AliasPresetSavePanel = forwardRef<AliasPresetSavePanelHandle, Alias
           });
         },
       }),
-      [alias, cacheRamDraft, ctxSizeDraft, effectivePreset, routerEntry, validationErrors],
+      [alias, cacheRamDraft, ctxSizeDraft, effectivePreset, fallbackMmprojPath, fallbackModelPath, routerEntry, validationErrors],
     );
 
     return (
@@ -194,7 +203,9 @@ export const AliasPresetSavePanel = forwardRef<AliasPresetSavePanelHandle, Alias
         />
 
         {!routerEntry ? (
-          <p className="text-xs text-amber-800">Live router entry not loaded — refresh catalog edit.</p>
+          <p className="text-xs text-amber-800">
+            Live router entry not loaded — editing the last saved snapshot. Save still writes the INI.
+          </p>
         ) : null}
       </div>
     );

--- a/src/client/src/features/localModelOnboarding/installed/LlamaInstalledSummary.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/LlamaInstalledSummary.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { api } from '../../../services/api';
-import type { LlamaInstallationDetailDto, LlamaRouterEntryDto } from '../../../types/settings';
+import type { InstallationArtifactDto, LlamaInstallationDetailDto, LlamaRouterEntryDto } from '../../../types/settings';
 import type { ActiveModelOperationState } from '../../../pages/settings/types';
 import { getErrorMessage } from '../../../pages/settings/utils';
 import { formatBytes } from '../curated/format';
@@ -20,6 +20,21 @@ export interface LlamaInstalledSummaryProps {
   onOperationStarted: (operation: ActiveModelOperationState) => void;
 }
 
+function containerArtifactPath(targetDirectory: string, artifact?: InstallationArtifactDto): string {
+  if (!artifact) {
+    return '';
+  }
+  const relative = artifact.installedRelativePath.trim();
+  if (relative) {
+    return `/models-local/llama/${relative.replace(/^\/+/, '')}`;
+  }
+  const fileName = artifact.repositoryPath.split('/').pop()?.trim();
+  if (!fileName || !targetDirectory.trim()) {
+    return '';
+  }
+  return `/models-local/llama/${targetDirectory.trim()}/${fileName}`;
+}
+
 export const LlamaInstalledSummary = forwardRef<LlamaInstalledSummaryHandle, LlamaInstalledSummaryProps>(
   function LlamaInstalledSummary({ modelId, onChanged, onOperationStarted }, ref) {
   const presetPanelRef = useRef<AliasPresetSavePanelHandle>(null);
@@ -27,22 +42,40 @@ export const LlamaInstalledSummary = forwardRef<LlamaInstalledSummaryHandle, Lla
   const [routerEntry, setRouterEntry] = useState<LlamaRouterEntryDto | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [routerEntriesError, setRouterEntriesError] = useState<string | null>(null);
   const [changeQuantOpen, setChangeQuantOpen] = useState(false);
 
   const reload = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setRouterEntriesError(null);
+
+    const installationPromise = api.settings.getLlamaInstallationDetail(modelId);
+    const entriesPromise = api.settings.getLlamaRouterEntries();
+
+    let installation: LlamaInstallationDetailDto;
     try {
-      const [installation, entries] = await Promise.all([
-        api.settings.getLlamaInstallationDetail(modelId),
-        api.settings.getLlamaRouterEntries(),
-      ]);
+      installation = await installationPromise;
       setDetail(installation);
-      setRouterEntry(entries.entries.find((entry) => entry.alias === installation.routerModelId) ?? null);
-    } catch (loadError) {
-      setError(getErrorMessage(loadError, 'Failed to load installation detail.'));
-    } finally {
       setLoading(false);
+    } catch (loadError) {
+      setDetail(null);
+      setRouterEntry(null);
+      setError(getErrorMessage(loadError, 'Failed to load installation detail.'));
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const entries = await entriesPromise;
+      setRouterEntry(
+        entries.entries.find((entry) => entry.alias === installation.routerModelId) ?? null,
+      );
+    } catch (entriesError) {
+      setRouterEntry(null);
+      setRouterEntriesError(
+        getErrorMessage(entriesError, 'Live router entries unavailable. Editing last saved snapshot.'),
+      );
     }
   }, [modelId]);
 
@@ -82,14 +115,24 @@ export const LlamaInstalledSummary = forwardRef<LlamaInstalledSummaryHandle, Lla
   }
 
   const isCurated = !!detail.catalogId;
+  const fallbackModelPath = containerArtifactPath(detail.targetDirectory, detail.modelArtifacts[0]);
+  const fallbackMmprojPath = containerArtifactPath(detail.targetDirectory, detail.projectorArtifacts[0]);
 
   return (
     <div className="space-y-4">
+      {routerEntriesError ? (
+        <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950">
+          {routerEntriesError} Save still writes the router INI.
+        </div>
+      ) : null}
+
       <AliasPresetSavePanel
         ref={presetPanelRef}
         alias={detail.routerModelId}
         routerEntry={routerEntry}
         fallbackPreset={detail.routerPresetSnapshot}
+        fallbackModelPath={fallbackModelPath}
+        fallbackMmprojPath={fallbackMmprojPath}
       />
 
       <ModelChatBehaviorPanel detail={detail} onChanged={handleChanged} />

--- a/src/client/src/features/localModelOnboarding/installed/__tests__/AliasPresetSavePanel.test.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/__tests__/AliasPresetSavePanel.test.tsx
@@ -114,6 +114,35 @@ describe('AliasPresetSavePanel', () => {
     });
   });
 
+  it('saves from fallback paths when the live router entry is missing', async () => {
+    vi.mocked(api.settings.putLlamaRouterEntry).mockResolvedValue(undefined as never);
+    const panelRef = createRef<AliasPresetSavePanelHandle>();
+
+    render(
+      <AliasPresetSavePanel
+        ref={panelRef}
+        alias="Qwen3.8-27B-GGUF"
+        routerEntry={null}
+        fallbackPreset={{ 'ctx-size': '131272' }}
+        fallbackModelPath="/models-local/llama/Qwen3.8-27B-GGUF/model.gguf"
+        fallbackMmprojPath="/models-local/llama/Qwen3.8-27B-GGUF/mmproj-F16.gguf"
+      />,
+    );
+
+    await panelRef.current?.saveRouterPreset();
+
+    await waitFor(() => {
+      expect(api.settings.putLlamaRouterEntry).toHaveBeenCalledWith(
+        'Qwen3.8-27B-GGUF',
+        expect.objectContaining({
+          modelPath: '/models-local/llama/Qwen3.8-27B-GGUF/model.gguf',
+          mmprojPath: '/models-local/llama/Qwen3.8-27B-GGUF/mmproj-F16.gguf',
+          preset: expect.objectContaining({ 'ctx-size': '131272' }),
+        }),
+      );
+    });
+  });
+
   it('does not render a separate save button', () => {
     render(
       <AliasPresetSavePanel

--- a/src/client/src/features/localModelOnboarding/installed/__tests__/LlamaInstalledSummary.test.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/__tests__/LlamaInstalledSummary.test.tsx
@@ -45,4 +45,13 @@ describe('LlamaInstalledSummary', () => {
     expect(screen.getByTestId('model-chat-behavior-panel')).toBeInTheDocument();
     expect(screen.queryByText(/Management mode/i)).not.toBeInTheDocument();
   });
+
+  it('still renders the preset editor when live router entries fail', async () => {
+    vi.mocked(api.settings.getLlamaRouterEntries).mockRejectedValue(new Error('Llama router entries unavailable'));
+
+    render(<LlamaInstalledSummary modelId="llama/qwen" onOperationStarted={vi.fn()} />);
+
+    expect(await screen.findByTestId('alias-preset-save-panel')).toBeInTheDocument();
+    expect(screen.getByText(/router entries unavailable/i)).toBeInTheDocument();
+  });
 });

--- a/src/client/src/features/localModelOnboarding/routerPreset.ts
+++ b/src/client/src/features/localModelOnboarding/routerPreset.ts
@@ -87,7 +87,41 @@ export function buildEffectivePresetRecord(
   if (trimmedCacheRam) {
     preset['cache-ram'] = trimmedCacheRam;
   }
-  return preset;
+  return canonicalizeMmprojDisableKeys(preset);
+}
+
+function llamaOptionToken(key: string): string {
+  return key.trim().toLowerCase().replace(/[-_]/g, '');
+}
+
+function isFalseyPresetValue(value: string): boolean {
+  return ['', '0', 'false', 'no', 'off'].includes(value.trim().toLowerCase());
+}
+
+/** Rewrite CLI-shaped mmproj disable flags to mmproj-auto=false before INI save. */
+export function canonicalizeMmprojDisableKeys(preset: Record<string, string>): Record<string, string> {
+  const rewritten: Record<string, string> = {};
+  let disableMmproj = false;
+  for (const [key, value] of Object.entries(preset)) {
+    const token = llamaOptionToken(key);
+    if (token === 'nommproj' || token === 'nommprojauto') {
+      disableMmproj = true;
+      continue;
+    }
+    if (token === 'mmprojauto') {
+      if (isFalseyPresetValue(value)) {
+        disableMmproj = true;
+      } else {
+        rewritten['mmproj-auto'] = value;
+      }
+      continue;
+    }
+    rewritten[key] = value;
+  }
+  if (disableMmproj) {
+    rewritten['mmproj-auto'] = 'false';
+  }
+  return rewritten;
 }
 
 /** Router shell keys belong on the process CLI, not in per-alias presets. */

--- a/src/server/GuideAntsApi/Endpoints/Settings/SettingsLlamaEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/Settings/SettingsLlamaEndpoints.cs
@@ -353,23 +353,8 @@ public static class SettingsLlamaEndpoints
                 var replaceRequest = request with { PresetMode = "replace" };
                 var result = await adminClient.PutRouterEntryAsync(replaceRequest, cancellationToken).ConfigureAwait(false);
                 await UpdateRouterPresetSnapshotAsync(db, replaceRequest, cancellationToken).ConfigureAwait(false);
-                if (result.RuntimeApply is { Applied: false })
-                {
-                    return Results.Json(
-                        new
-                        {
-                            ok = result.Ok,
-                            iniSha256 = result.IniSha256,
-                            runtimeApply = new
-                            {
-                                applied = result.RuntimeApply.Applied,
-                                iniSha256 = result.RuntimeApply.IniSha256,
-                                remediation = result.RuntimeApply.Remediation,
-                            },
-                        },
-                        statusCode: StatusCodes.Status502BadGateway);
-                }
-
+                // INI write is the recovery path when llama-server is down. Do not 502
+                // the catalog editor after a successful commit just because reload failed.
                 return Results.Ok(new
                 {
                     ok = result.Ok,

--- a/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelInstallationService.cs
+++ b/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelInstallationService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using GuideAntsApi.DataModel;
 using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Models.Settings;
@@ -14,14 +13,14 @@ public interface ILocalModelInstallationService
 public sealed class LocalModelInstallationService : ILocalModelInstallationService
 {
     private readonly ApplicationDbContext _db;
-    private readonly ILlamaRuntimeInventoryService _inventoryService;
 
     public LocalModelInstallationService(
         ApplicationDbContext db,
         ILlamaRuntimeInventoryService inventoryService)
     {
         _db = db;
-        _inventoryService = inventoryService;
+        // Inventory is live llama state; catalog edit must not wait on it.
+        _ = inventoryService;
     }
 
     public async Task<LlamaInstallationDetailDto> GetDetailAsync(
@@ -57,7 +56,7 @@ public sealed class LocalModelInstallationService : ILocalModelInstallationServi
                 statusCode: 404);
         }
 
-        return await MapDetailAsync(model, installation, cancellationToken).ConfigureAwait(false);
+        return MapDetailWithoutLiveRuntime(model, installation);
     }
 
     internal static SettingsModelDto MapModel(Model model) =>
@@ -78,15 +77,12 @@ public sealed class LocalModelInstallationService : ILocalModelInstallationServi
             ThinkingControlJson: model.ThinkingControlJson,
             RequestFieldsWhenToolsPresentJson: model.RequestFieldsWhenToolsPresentJson);
 
-    private async Task<LlamaInstallationDetailDto> MapDetailAsync(
+    private static LlamaInstallationDetailDto MapDetailWithoutLiveRuntime(
         Model model,
-        LocalModelInstallation installation,
-        CancellationToken cancellationToken)
+        LocalModelInstallation installation)
     {
-        var inventory = await _inventoryService.GetInventoryAsync(cancellationToken).ConfigureAwait(false);
-        var row = inventory.FirstOrDefault(i =>
-            string.Equals(i.RouterModelId, installation.RouterModelId, StringComparison.Ordinal));
-
+        // Catalog preset editing must not wait on llama-server /models. Live runtime
+        // state belongs on the Loaded models tab; this DTO is SQL provenance + snapshot.
         return new LlamaInstallationDetailDto(
             ModelId: model.ModelId,
             CatalogModel: MapModel(model),
@@ -103,8 +99,8 @@ public sealed class LocalModelInstallationService : ILocalModelInstallationServi
             ProjectorArtifacts: InstallationArtifactRecords.Parse(installation.ProjectorArtifactsJson),
             CompanionArtifacts: InstallationArtifactRecords.Parse(installation.CompanionArtifactsJson),
             RouterPresetSnapshot: InstallationArtifactRecords.ParsePresetSnapshot(installation.RouterPresetSnapshotJson),
-            RuntimeState: row?.RuntimeState ?? "unknown",
-            Loaded: string.Equals(row?.RuntimeState, "loaded", StringComparison.OrdinalIgnoreCase),
+            RuntimeState: "unknown",
+            Loaded: false,
             CreatedUtc: installation.CreatedUtc,
             UpdatedUtc: installation.UpdatedUtc);
     }


### PR DESCRIPTION
…en llama-server rejects a preset.

Qwen 3.8’s draft-mtp and reasoning-preserve keys crash older llama.cpp; stop 502ing a successful INI commit, rewrite no-mmproj to mmproj-auto=false, and strip unrecognized options on respawn so the editor can recover.