### PR TITLE
Keep long thinking turns alive and preserve streamed partials

### DIFF
--- a/src/client/src/contexts/__tests__/ConversationContext.streamingContracts.test.tsx
+++ b/src/client/src/contexts/__tests__/ConversationContext.streamingContracts.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+vi.unmock('../ConversationContext');
+
+const mockShowToast = vi.fn();
+let capturedOnError: ((err: Error) => void) | undefined;
+let capturedOnEvent: ((event: { type: string; data: any }) => void) | undefined;
+
+vi.mock('../../services/api', () => ({
+  api: {
+    projects: {
+      notebooks: {
+        conversations: {
+          get: vi.fn().mockResolvedValue({ messages: [], assistantName: 'Demo Guide' }),
+          sendMessageStream: vi.fn().mockImplementation(
+            async (_p, _n, _c, _payload, onEvent, onError) => {
+              capturedOnEvent = onEvent;
+              capturedOnError = onError;
+              return Promise.resolve();
+            },
+          ),
+          editMessage: vi.fn().mockResolvedValue({}),
+          undoLast: vi.fn().mockResolvedValue({}),
+          getAll: vi.fn().mockResolvedValue([]),
+          cancelTurn: vi.fn().mockResolvedValue(undefined),
+        },
+        getNotebook: vi.fn().mockResolvedValue({}),
+      },
+      notebookTemplates: {
+        getAll: vi.fn().mockResolvedValue([]),
+        getAssistants: vi.fn().mockResolvedValue([]),
+      },
+      assistants: {
+        getConversationStarters: vi.fn().mockResolvedValue([]),
+      },
+      folders: {
+        getFolderTree: vi.fn().mockResolvedValue({}),
+      },
+    },
+  },
+}));
+
+vi.mock('../../utils/notebookAuth', () => ({
+  ensureValidTokensForTemplate: vi.fn().mockResolvedValue({ needsAuth: false, missingProviders: [] }),
+}));
+
+vi.mock('../conversation/runtimeChecks', () => ({
+  checkRuntimeStatus: vi.fn().mockResolvedValue({ state: 'ready' }),
+  getRuntimeBlockingMessage: vi.fn().mockReturnValue('Runtime not ready'),
+  dispatchRuntimeStatusWindowEvent: vi.fn(),
+  getNotebookRuntimeReadyCache: vi.fn(() => new Set<string>()),
+  clearNotebookRuntimeReadyCache: vi.fn(),
+}));
+
+vi.mock('../NotebookContext', () => ({
+  useNotebook: () => ({
+    loadNotebookFiles: vi.fn().mockResolvedValue(undefined),
+  }),
+  NotebookProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../../components/common/Toast', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../../services/userService', () => ({
+  userService: {
+    getCurrentUser: vi.fn().mockResolvedValue({ id: 'user-1', name: 'Test User', email: 'test@example.com' }),
+    getUserById: vi.fn().mockResolvedValue({ id: 'user-1', name: 'Test User', email: 'test@example.com' }),
+  },
+}));
+
+import { ConversationProvider, useConversation } from '../ConversationContext';
+import { api } from '../../services/api';
+
+const defaultAssistants = [
+  { name: 'Demo Guide', model: 'gpt-4', avatarUrl: '/a.png', id: 'assistant-1' },
+];
+
+function renderProvider() {
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter>
+      <ConversationProvider
+        projectId="test-project"
+        notebookId="test-notebook"
+        conversationId="test-conversation"
+        guideId="guide-1"
+        assistants={defaultAssistants}
+      >
+        {children}
+      </ConversationProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('ConversationContext streaming contracts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnError = undefined;
+    capturedOnEvent = undefined;
+    vi.mocked(api.projects.notebooks.conversations.get).mockResolvedValue({
+      messages: [],
+      assistantName: 'Demo Guide',
+    } as any);
+  });
+
+  it('retains partial content and surfaces streamingError on idle timeout', async () => {
+    const { result } = renderHook(() => useConversation(), { wrapper: renderProvider() });
+    await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+
+    await act(async () => {
+      capturedOnEvent?.({ type: 'assistant_message', data: { contentDelta: 'partial streamed thinking' } });
+    });
+
+    await act(async () => {
+      capturedOnError?.(Object.assign(
+        new Error('The conversation stream stopped sending data. The server is no longer answering this request.'),
+        { name: 'StreamIdleTimeoutError' },
+      ));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isStreaming).toBe(false);
+      expect(result.current.streamingError).toMatch(/stopped sending data/i);
+    });
+
+    const assistant = result.current.messages.find(m => m.role.toLowerCase() === 'assistant');
+    expect(assistant?.content).toContain('partial streamed thinking');
+    expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Chat Request Failed',
+    }));
+  });
+
+  it('retains partial content without streamingError on explicit cancel', async () => {
+    const { result } = renderHook(() => useConversation(), { wrapper: renderProvider() });
+    await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+
+    await act(async () => {
+      capturedOnEvent?.({ type: 'assistant_message', data: { contentDelta: 'partial before cancel' } });
+    });
+
+    await act(async () => {
+      result.current.cancelStream();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isStreaming).toBe(false);
+      expect(result.current.streamingError).toBeUndefined();
+    });
+
+    const assistant = result.current.messages.find(m => m.role.toLowerCase() === 'assistant');
+    expect(assistant?.content).toContain('partial before cancel');
+    expect(mockShowToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
+++ b/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
@@ -329,7 +329,7 @@ describe('useConversationActions', () => {
       }));
     });
 
-    it('handles stream onError AbortError', async () => {
+    it('handles stream onError AbortError without force refresh', async () => {
       let onError: ((err: Error) => void) | undefined;
       vi.mocked(api.projects.notebooks.conversations.sendMessageStream).mockImplementation(
         async (_p, _n, _c, _payload, _onEvent, errCb) => {
@@ -337,7 +337,7 @@ describe('useConversationActions', () => {
         },
       );
 
-      const { actions, dispatch } = mountActions();
+      const { actions, dispatch, deps } = mountActions();
 
       await act(async () => {
         await actions.sendMessage('hello');
@@ -349,6 +349,45 @@ describe('useConversationActions', () => {
 
       expect(dispatch).toHaveBeenCalledWith({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
       expect(dispatch).toHaveBeenCalledWith({ type: 'COMPLETE_STREAMING_TURN' });
+      expect(deps.refreshConversation).not.toHaveBeenCalled();
+      expect(deps.showToast).not.toHaveBeenCalled();
+      const errorDispatches = dispatch.mock.calls.filter(
+        ([action]) => action.type === 'SET_STREAMING_ERROR' && typeof action.payload === 'string' && action.payload.length > 0,
+      );
+      expect(errorDispatches).toHaveLength(0);
+    });
+
+    it('handles stream onError StreamIdleTimeoutError without force refresh but with error UI', async () => {
+      let onError: ((err: Error) => void) | undefined;
+      vi.mocked(api.projects.notebooks.conversations.sendMessageStream).mockImplementation(
+        async (_p, _n, _c, _payload, _onEvent, errCb) => {
+          onError = errCb;
+        },
+      );
+
+      const { actions, dispatch, deps } = mountActions();
+
+      await act(async () => {
+        await actions.sendMessage('hello');
+      });
+
+      act(() => {
+        onError?.(Object.assign(
+          new Error('The conversation stream stopped sending data. The server is no longer answering this request.'),
+          { name: 'StreamIdleTimeoutError' },
+        ));
+      });
+
+      expect(dispatch).toHaveBeenCalledWith({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'COMPLETE_STREAMING_TURN' });
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STREAMING_ERROR',
+        payload: 'The conversation stream stopped sending data. The server is no longer answering this request.',
+      });
+      expect(deps.refreshConversation).not.toHaveBeenCalled();
+      expect(deps.showToast).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Chat Request Failed',
+      }));
     });
 
     it('handles stream onError generic failure', async () => {
@@ -376,6 +415,7 @@ describe('useConversationActions', () => {
       expect(deps.showToast).toHaveBeenCalledWith(expect.objectContaining({
         title: 'Chat Request Failed',
       }));
+      expect(deps.refreshConversation).toHaveBeenCalledWith({ force: true });
     });
 
     it('invokes onComplete callback to clear attachments and refresh files', async () => {

--- a/src/client/src/contexts/conversation/useConversationActions.ts
+++ b/src/client/src/contexts/conversation/useConversationActions.ts
@@ -168,6 +168,38 @@ export function useConversationActions(
           } as any,
           handleStreamingEvent,
           (error) => {
+            const isUserCancel = error.name === 'AbortError';
+            const isIdleTimeout = error.name === 'StreamIdleTimeoutError';
+
+            if (isUserCancel) {
+              console.log('Stream cancelled by user - finalizing partial content without force refresh');
+              dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
+              dispatch({ type: 'COMPLETE_STREAMING_TURN' });
+              dispatch({ type: 'SET_CANCELLING', payload: false });
+              setCurrentStreamController(null);
+              setActiveStreamTurnId?.(null);
+              return;
+            }
+
+            if (isIdleTimeout) {
+              console.log('Stream idle timeout - finalizing partial content without force refresh');
+              dispatch({ type: 'SET_STREAMING', payload: false });
+              dispatch({ type: 'SET_CANCELLING', payload: false });
+              dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
+              dispatch({ type: 'CONVERT_STREAMING_IDS' });
+              dispatch({ type: 'COMPLETE_STREAMING_TURN' });
+              setCurrentStreamController(null);
+              setActiveStreamTurnId?.(null);
+              const streamErrorMessage = error.message || 'The conversation stream stopped sending data.';
+              dispatch({ type: 'SET_STREAMING_ERROR', payload: streamErrorMessage });
+              showToast({
+                type: 'error',
+                title: 'Chat Request Failed',
+                message: streamErrorMessage,
+              });
+              return;
+            }
+
             const reconcile = async () => {
               if (refreshConversation) {
                 try {
@@ -177,17 +209,6 @@ export function useConversationActions(
                 }
               }
             };
-
-            if (error.name === 'AbortError' || error.message.includes('aborted')) {
-              console.log('Stream was cancelled by user - finalizing partial content');
-              void reconcile();
-              dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
-              dispatch({ type: 'COMPLETE_STREAMING_TURN' });
-              dispatch({ type: 'SET_CANCELLING', payload: false });
-              setCurrentStreamController(null);
-              setActiveStreamTurnId?.(null);
-              return;
-            }
 
             console.error('Streaming error:', error);
             void reconcile();

--- a/src/server/GuideAntsApi.IntegrationTests/Infrastructure/FakeChatCompletionClientFactory.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Infrastructure/FakeChatCompletionClientFactory.cs
@@ -15,6 +15,7 @@ internal enum FakeChatScenario
     ToolCallsCancelBeforeExecution,
     ToolCallThenReply,
     ThinkingStream,
+    LongThinkingStream,
     RepeatedToolCalls,
     PartialTimeoutStream,
 }
@@ -106,6 +107,7 @@ internal sealed class FakeChatCompletionClient : IChatCompletionClient
             FakeChatScenario.ToolCallsCancelBeforeExecution => ToolCallsCancelBeforeExecutionAsync(onChunk),
             FakeChatScenario.ToolCallThenReply => ToolCallThenReplyAsync(onChunk, cancellationToken),
             FakeChatScenario.ThinkingStream => ThinkingStreamAsync(onChunk, cancellationToken),
+            FakeChatScenario.LongThinkingStream => LongThinkingStreamAsync(onChunk, cancellationToken),
             FakeChatScenario.RepeatedToolCalls => RepeatedToolCallsAsync(request, onChunk),
             FakeChatScenario.PartialTimeoutStream => PartialTimeoutStreamAsync(onChunk, cancellationToken),
             _ => DefaultStreamAsync(onChunk)
@@ -232,6 +234,28 @@ internal sealed class FakeChatCompletionClient : IChatCompletionClient
         return new ChatCompletionResponse(
             [new ChatChoice(message, "stop")],
             CreateUsage());
+    }
+
+    private async Task<ChatCompletionResponse> LongThinkingStreamAsync(
+        Action<ChatCompletionChunk> onChunk,
+        CancellationToken cancellationToken)
+    {
+        foreach (var word in _behavior.ThinkingText.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            onChunk(new ChatCompletionChunk(
+            [
+                new ChatChoiceDelta(new ChatDelta(ChatRole.Assistant, word + " "), "thinking")
+            ]));
+            await Task.Delay(_behavior.ChunkDelayMs, cancellationToken);
+        }
+
+        onChunk(new ChatCompletionChunk(
+        [
+            new ChatChoiceDelta(new ChatDelta(ChatRole.Assistant, _behavior.FinalAssistantText), null)
+        ]));
+
+        return CreateResponse(_behavior.FinalAssistantText, finishReason: "stop");
     }
 
     private async Task<ChatCompletionResponse> PartialTimeoutStreamAsync(

--- a/src/server/GuideAntsApi.IntegrationTests/Services/Conversations/ConversationServiceIntegrationTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Services/Conversations/ConversationServiceIntegrationTests.cs
@@ -1256,6 +1256,90 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
     }
 
     [TestMethod]
+    public async Task SendMessageStream_Checkpoints_thinking_before_terminalization()
+    {
+        Guid projectId;
+        Guid notebookId;
+        Guid conversationId;
+        using (var scope = SharedFactory!.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            (projectId, notebookId) = await SeedProjectNotebookAsync(db);
+            conversationId = await SeedConversationAsync(db, notebookId, "Thinking heartbeat");
+        }
+
+        FakeChatCompletionBehavior.Instance.Reset();
+        FakeChatCompletionBehavior.Instance.Scenario = FakeChatScenario.LongThinkingStream;
+        FakeChatCompletionBehavior.Instance.ChunkDelayMs = 40;
+        FakeChatCompletionBehavior.Instance.ThinkingText = string.Join(
+            ' ',
+            Enumerable.Range(1, 25).Select(i => $"word{i}"));
+        FakeChatCompletionBehavior.Instance.FinalAssistantText = "should not be reached before cancel";
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var streamTask = Task.Run(async () =>
+        {
+            try
+            {
+                await SendConversationStreamUntilCancelledAsync(
+                    projectId,
+                    notebookId,
+                    conversationId,
+                    new { instructions = "Long thinking heartbeat", assistantName = "assistant" },
+                    cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // expected when the HTTP stream is aborted
+            }
+        });
+
+        var sawHeartbeat = false;
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            using var pollScope = SharedFactory!.Services.CreateScope();
+            var db = pollScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var turn = await db.ConversationTurns
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.NotebookConversationId == conversationId);
+            if (turn is { Status: "streaming", CheckpointVersion: > 0 })
+            {
+                turn.LastUpdated.Should().BeAfter(turn.Created);
+
+                var checkpointedAssistant = await db.NotebookConversationMessages
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(m =>
+                        m.NotebookConversationId == conversationId && m.Role == DataModelChatRole.Assistant);
+                checkpointedAssistant.Should().NotBeNull();
+                checkpointedAssistant!.ThinkingBlocksJson.Should().NotBeNullOrWhiteSpace();
+                checkpointedAssistant.ThinkingBlocksJson.Should().Contain("word");
+
+                sawHeartbeat = true;
+                break;
+            }
+
+            await Task.Delay(100);
+        }
+
+        sawHeartbeat.Should().BeTrue("thinking-only stream should checkpoint before terminalization");
+
+        await cts.CancelAsync();
+        await streamTask;
+
+        using var verifyScope = SharedFactory!.Services.CreateScope();
+        var db2 = verifyScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await WaitForTurnStatusAsync(db2, conversationId, "cancelled");
+
+        var assistant = await db2.NotebookConversationMessages
+            .Where(m => m.NotebookConversationId == conversationId && m.Role == DataModelChatRole.Assistant)
+            .SingleAsync();
+        assistant.ThinkingBlocksJson.Should().NotBeNullOrWhiteSpace();
+        assistant.ThinkingBlocksJson.Should().Contain("word1");
+        assistant.Content.Should().NotBe("should not be reached before cancel");
+    }
+
+    [TestMethod]
     public async Task SendMessageStream_Complete_event_is_emitted_after_unlock_for_stream_client_and_observers()
     {
         Guid projectId;

--- a/src/server/GuideAntsApi.IntegrationTests/Services/Conversations/ConversationTurnRecoverySqlIntegrationTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Services/Conversations/ConversationTurnRecoverySqlIntegrationTests.cs
@@ -1,0 +1,173 @@
+using FluentAssertions;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.IntegrationTests.Infrastructure;
+using GuideAntsApi.Services.Conversations.Persistence;
+using GuideAntsApi.Services.Conversations.Recovery;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using DataModelChatRole = GuideAntsApi.DataModel.Models.ChatRole;
+
+namespace GuideAntsApi.IntegrationTests.Services.Conversations;
+
+[TestClass]
+public sealed class ConversationTurnRecoverySqlIntegrationTests : BaseEndpointTest
+{
+    [ClassInitialize]
+    public static Task ClassInitialize(TestContext context) => InitializeSharedFactoryAsync(context);
+
+    [ClassCleanup]
+    public static Task ClassCleanup() => DisposeSharedFactoryAsync();
+
+    [TestMethod]
+    public async Task TryClaimStaleTurnAsync_only_one_concurrent_claim_succeeds()
+    {
+        var (turnId, executionId, cutoff, _) = await SeedStaleStreamingTurnAsync();
+
+        await using var db1 = SharedFactory!.Services.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await using var db2 = SharedFactory.Services.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var claim1 = ConversationTurnRecoveryService.TryClaimStaleTurnAsync(db1, turnId, executionId, cutoff, CancellationToken.None);
+        var claim2 = ConversationTurnRecoveryService.TryClaimStaleTurnAsync(db2, turnId, executionId, cutoff, CancellationToken.None);
+        var results = await Task.WhenAll(claim1, claim2);
+
+        results.Count(r => r).Should().Be(1);
+
+        await using var verify = SharedFactory.Services.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var turn = await verify.ConversationTurns.SingleAsync(t => t.Id == turnId);
+        turn.Status.Should().Be("interrupted");
+        turn.TerminationCode.Should().Be("stream_interrupted");
+    }
+
+    [TestMethod]
+    public async Task TryClaimStaleTurnAsync_loses_when_checkpoint_advances_last_updated()
+    {
+        var (turnId, executionId, cutoff, messageId) = await SeedStaleStreamingTurnAsync(includeAssistant: true);
+        var persistence = SharedFactory!.Services.CreateScope().ServiceProvider.GetRequiredService<IConversationPersistence>();
+
+        var checkpointed = await persistence.CheckpointTurnAsync(
+            turnId,
+            messageId,
+            content: string.Empty,
+            thinkingBlocksJson: """[{"type":"thinking","thinking":"heartbeat","signature":""}]""",
+            checkpointVersion: 1,
+            CancellationToken.None);
+        checkpointed.Should().BeTrue();
+
+        await using var db = SharedFactory.Services.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var claimed = await ConversationTurnRecoveryService.TryClaimStaleTurnAsync(
+            db,
+            turnId,
+            executionId,
+            cutoff,
+            CancellationToken.None);
+
+        claimed.Should().BeFalse();
+
+        var turn = await db.ConversationTurns.AsNoTracking().SingleAsync(t => t.Id == turnId);
+        turn.Status.Should().Be("streaming");
+        turn.CheckpointVersion.Should().Be(1);
+        turn.LastUpdated.Should().BeOnOrAfter(cutoff);
+    }
+
+    [TestMethod]
+    public async Task RecoverStaleTurns_terminalizes_orphaned_streaming_turn_on_sql()
+    {
+        var (turnId, _, _, _) = await SeedStaleStreamingTurnAsync(includeAssistant: true);
+        using var scope = SharedFactory!.Services.CreateScope();
+        var service = new ConversationTurnRecoveryService(
+            scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>(),
+            scope.ServiceProvider.GetRequiredService<GuideAntsApi.Services.Conversations.Streaming.ConversationStreamRunRegistry>(),
+            scope.ServiceProvider.GetRequiredService<ILogger<ConversationTurnRecoveryService>>());
+
+        await service.RecoverStaleTurnsAsync(CancellationToken.None);
+
+        await using var verify = SharedFactory.Services.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var turn = await verify.ConversationTurns.SingleAsync(t => t.Id == turnId);
+        turn.Status.Should().Be("interrupted");
+        turn.TerminationCode.Should().Be("stream_interrupted");
+
+        var assistant = await verify.NotebookConversationMessages
+            .Where(m => m.NotebookConversationId == turn.NotebookConversationId && m.Role == DataModelChatRole.Assistant)
+            .SingleAsync();
+        assistant.IsStreaming.Should().BeFalse();
+    }
+
+    private async Task<(Guid TurnId, Guid ExecutionId, DateTime Cutoff, Guid MessageId)> SeedStaleStreamingTurnAsync(
+        bool includeAssistant = false)
+    {
+        var cutoff = DateTime.UtcNow - ConversationTurnRecoveryService.StaleAfter - TimeSpan.FromMinutes(1);
+        var staleAt = cutoff.AddMinutes(-1);
+        var turnId = Guid.NewGuid();
+        var executionId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+        var messageId = Guid.NewGuid();
+
+        using var scope = SharedFactory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var guideId = await db.Assistants
+            .Where(a => a.Kind == AssistantKind.Guide && a.IsActive)
+            .Select(a => a.Id)
+            .FirstAsync();
+
+        var project = new Project
+        {
+            Id = Guid.NewGuid(),
+            Title = "Recovery SQL",
+            Slug = $"recovery-{Guid.NewGuid():N}",
+            Created = DateTime.UtcNow
+        };
+        db.Projects.Add(project);
+
+        var notebook = new Notebook
+        {
+            Id = Guid.NewGuid(),
+            Title = "Recovery NB",
+            Slug = $"nb-{Guid.NewGuid():N}",
+            ProjectId = project.Id,
+            GuideId = guideId,
+            Created = DateTime.UtcNow
+        };
+        db.Notebooks.Add(notebook);
+
+        db.NotebookConversations.Add(new NotebookConversation
+        {
+            Id = conversationId,
+            NotebookId = notebook.Id,
+            Title = "Recovery convo",
+            Created = DateTime.UtcNow
+        });
+
+        db.ConversationTurns.Add(new ConversationTurn
+        {
+            Id = turnId,
+            NotebookConversationId = conversationId,
+            TurnIndex = 1,
+            AssistantName = "Guide",
+            Status = "streaming",
+            ExecutionId = executionId,
+            Created = staleAt,
+            LastUpdated = staleAt
+        });
+
+        if (includeAssistant)
+        {
+            db.NotebookConversationMessages.Add(new NotebookConversationMessage
+            {
+                Id = messageId,
+                NotebookConversationId = conversationId,
+                TurnIndex = 1,
+                MessageSequence = 2,
+                Role = DataModelChatRole.Assistant,
+                Content = "partial",
+                IsStreaming = true,
+                Created = staleAt
+            });
+        }
+
+        await db.SaveChangesAsync();
+        return (turnId, executionId, cutoff, messageId);
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationPersistenceCheckpointTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationPersistenceCheckpointTests.cs
@@ -1,0 +1,155 @@
+using FluentAssertions;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.Services.Conversations.Persistence;
+using GuideAntsApi.Tests.BackgroundJobs;
+using GuideAntsApi.Tests.TestUtils;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using DataModelChatRole = GuideAntsApi.DataModel.Models.ChatRole;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class ConversationPersistenceCheckpointTests
+{
+    [TestMethod]
+    public async Task CheckpointTurnAsync_advances_version_last_updated_and_thinking()
+    {
+        var (persistence, conversationId, turnId, messageId, staleLastUpdated) = await SeedStreamingTurnAsync();
+
+        var ok = await persistence.CheckpointTurnAsync(
+            turnId,
+            messageId,
+            content: string.Empty,
+            thinkingBlocksJson: """[{"type":"thinking","thinking":"reasoning heartbeat","signature":""}]""",
+            checkpointVersion: 1,
+            CancellationToken.None);
+
+        ok.Should().BeTrue();
+
+        await using var db = new ApplicationDbContext(_options);
+        var turn = await db.ConversationTurns.SingleAsync(t => t.Id == turnId);
+        turn.CheckpointVersion.Should().Be(1);
+        turn.LastUpdated.Should().BeAfter(staleLastUpdated);
+        turn.Status.Should().Be("streaming");
+
+        var assistant = await db.NotebookConversationMessages.SingleAsync(m => m.Id == messageId);
+        assistant.ThinkingBlocksJson.Should().Contain("reasoning heartbeat");
+    }
+
+    [TestMethod]
+    public async Task CheckpointTurnAsync_rejects_stale_checkpoint_version()
+    {
+        var (persistence, _, turnId, messageId, _) = await SeedStreamingTurnAsync();
+
+        (await persistence.CheckpointTurnAsync(
+            turnId,
+            messageId,
+            "first",
+            null,
+            checkpointVersion: 2,
+            CancellationToken.None)).Should().BeTrue();
+
+        (await persistence.CheckpointTurnAsync(
+            turnId,
+            messageId,
+            "stale",
+            null,
+            checkpointVersion: 2,
+            CancellationToken.None)).Should().BeFalse();
+
+        await using var db = new ApplicationDbContext(_options);
+        var assistant = await db.NotebookConversationMessages.SingleAsync(m => m.Id == messageId);
+        assistant.Content.Should().Be("first");
+    }
+
+    [TestMethod]
+    public async Task CheckpointTurnAsync_refuses_terminal_turn()
+    {
+        var (persistence, _, turnId, messageId, _) = await SeedStreamingTurnAsync();
+
+        await using (var db = new ApplicationDbContext(_options))
+        {
+            var turn = await db.ConversationTurns.SingleAsync(t => t.Id == turnId);
+            turn.Status = "interrupted";
+            await db.SaveChangesAsync();
+        }
+
+        (await persistence.CheckpointTurnAsync(
+            turnId,
+            messageId,
+            "late",
+            null,
+            checkpointVersion: 1,
+            CancellationToken.None)).Should().BeFalse();
+    }
+
+    private DbContextOptions<ApplicationDbContext> _options = null!;
+
+    private async Task<(
+        ConversationPersistence Persistence,
+        Guid ConversationId,
+        Guid TurnId,
+        Guid MessageId,
+        DateTime StaleLastUpdated)> SeedStreamingTurnAsync()
+    {
+        _options = BackgroundJobTestHelpers.CreateInMemoryOptions($"checkpoint-{Guid.NewGuid():N}");
+        var projectId = Guid.NewGuid();
+        var notebookId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+        var turnId = Guid.NewGuid();
+        var messageId = Guid.NewGuid();
+        var staleLastUpdated = DateTime.UtcNow.AddMinutes(-10);
+
+        await using (var seed = new ApplicationDbContext(_options))
+        {
+            seed.Projects.Add(new Project { Id = projectId, Title = "P", Slug = "p", Created = DateTime.UtcNow });
+            seed.Notebooks.Add(new Notebook
+            {
+                Id = notebookId,
+                ProjectId = projectId,
+                Title = "NB",
+                Slug = "nb",
+                Created = DateTime.UtcNow
+            });
+            seed.NotebookConversations.Add(new NotebookConversation
+            {
+                Id = conversationId,
+                NotebookId = notebookId,
+                Title = "Chat",
+                Created = DateTime.UtcNow
+            });
+            seed.ConversationTurns.Add(new ConversationTurn
+            {
+                Id = turnId,
+                NotebookConversationId = conversationId,
+                TurnIndex = 1,
+                AssistantName = "Guide",
+                Status = "streaming",
+                ExecutionId = Guid.NewGuid(),
+                Created = staleLastUpdated,
+                LastUpdated = staleLastUpdated
+            });
+            seed.NotebookConversationMessages.Add(new NotebookConversationMessage
+            {
+                Id = messageId,
+                NotebookConversationId = conversationId,
+                TurnIndex = 1,
+                MessageSequence = 2,
+                Role = DataModelChatRole.Assistant,
+                Content = string.Empty,
+                IsStreaming = true,
+                Created = staleLastUpdated
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        var db = new ApplicationDbContext(_options);
+        var persistence = new ConversationPersistence(
+            new TestServiceScopeFactory(db),
+            Mock.Of<ILogger<ConversationPersistence>>());
+        return (persistence, conversationId, turnId, messageId, staleLastUpdated);
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationStreamRunRegistryTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationStreamRunRegistryTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using GuideAntsApi.Services.Conversations.Streaming;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class ConversationStreamRunRegistryTests
+{
+    [TestMethod]
+    public void IsActive_is_true_only_while_registered()
+    {
+        var registry = new ConversationStreamRunRegistry();
+        var turnId = Guid.NewGuid();
+
+        registry.IsActive(turnId).Should().BeFalse();
+
+        _ = registry.Register(turnId, CancellationToken.None);
+        registry.IsActive(turnId).Should().BeTrue();
+
+        registry.Unregister(turnId);
+        registry.IsActive(turnId).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void RequestCancel_cancels_active_run_token()
+    {
+        var registry = new ConversationStreamRunRegistry();
+        var turnId = Guid.NewGuid();
+        var token = registry.Register(turnId, CancellationToken.None);
+
+        token.IsCancellationRequested.Should().BeFalse();
+        registry.RequestCancel(turnId).Should().BeTrue();
+        token.IsCancellationRequested.Should().BeTrue();
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationTurnRecoveryServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationTurnRecoveryServiceTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.Services.Conversations.Persistence;
+using GuideAntsApi.Services.Conversations.Recovery;
+using GuideAntsApi.Services.Conversations.Streaming;
+using GuideAntsApi.Tests.BackgroundJobs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class ConversationTurnRecoveryServiceTests
+{
+    [TestMethod]
+    public async Task RecoverStaleTurns_skips_turn_still_active_in_run_registry()
+    {
+        var (options, turnId, _) = await SeedStaleStreamingTurnAsync();
+        var registry = new ConversationStreamRunRegistry();
+        _ = registry.Register(turnId, CancellationToken.None);
+
+        var service = CreateService(options, registry);
+        await service.RecoverStaleTurnsAsync(CancellationToken.None);
+
+        await using var db = new ApplicationDbContext(options);
+        var turn = await db.ConversationTurns.SingleAsync(t => t.Id == turnId);
+        turn.Status.Should().Be("streaming");
+        turn.TerminationCode.Should().BeNull();
+    }
+
+    private static ConversationTurnRecoveryService CreateService(
+        DbContextOptions<ApplicationDbContext> options,
+        ConversationStreamRunRegistry registry)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(options);
+        services.AddScoped(sp => new ApplicationDbContext(sp.GetRequiredService<DbContextOptions<ApplicationDbContext>>()));
+        services.AddScoped<IConversationPersistence>(_ =>
+        {
+            var persistence = new Mock<IConversationPersistence>();
+            persistence
+                .Setup(p => p.PruneIncompleteToolCallsAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            return persistence.Object;
+        });
+
+        return new ConversationTurnRecoveryService(
+            services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+            registry,
+            Mock.Of<ILogger<ConversationTurnRecoveryService>>());
+    }
+
+    private static async Task<(DbContextOptions<ApplicationDbContext> Options, Guid TurnId, Guid ConversationId)> SeedStaleStreamingTurnAsync()
+    {
+        var options = BackgroundJobTestHelpers.CreateInMemoryOptions($"turn-recovery-{Guid.NewGuid():N}");
+        var projectId = Guid.NewGuid();
+        var notebookId = Guid.NewGuid();
+        var conversationId = Guid.NewGuid();
+        var turnId = Guid.NewGuid();
+        var staleAt = DateTime.UtcNow - ConversationTurnRecoveryService.StaleAfter - TimeSpan.FromMinutes(1);
+
+        await using (var seed = new ApplicationDbContext(options))
+        {
+            seed.Projects.Add(new Project { Id = projectId, Title = "P", Slug = "p", Created = DateTime.UtcNow });
+            seed.Notebooks.Add(new Notebook
+            {
+                Id = notebookId,
+                ProjectId = projectId,
+                Title = "NB",
+                Slug = "nb",
+                Created = DateTime.UtcNow
+            });
+            seed.NotebookConversations.Add(new NotebookConversation
+            {
+                Id = conversationId,
+                NotebookId = notebookId,
+                Title = "Chat",
+                Created = DateTime.UtcNow
+            });
+            seed.ConversationTurns.Add(new ConversationTurn
+            {
+                Id = turnId,
+                NotebookConversationId = conversationId,
+                TurnIndex = 1,
+                AssistantName = "Guide",
+                Status = "streaming",
+                ExecutionId = Guid.NewGuid(),
+                Created = staleAt,
+                LastUpdated = staleAt
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        return (options, turnId, conversationId);
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/StreamingAssistantProgressCheckpointTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/StreamingAssistantProgressCheckpointTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using GuideAntsApi.Services.Conversations.Streaming;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class StreamingAssistantProgressCheckpointTests
+{
+    [TestMethod]
+    public void ShouldCheckpoint_returns_false_until_flush_interval()
+    {
+        var scheduler = new StreamingAssistantProgressCheckpoint(flushInterval: 5);
+
+        for (var i = 0; i < 4; i++)
+        {
+            scheduler.ShouldCheckpoint().Should().BeFalse();
+        }
+
+        scheduler.ShouldCheckpoint().Should().BeTrue();
+        scheduler.FlushCounter.Should().Be(5);
+    }
+
+    [TestMethod]
+    public void ShouldCheckpoint_repeats_every_flush_interval()
+    {
+        var scheduler = new StreamingAssistantProgressCheckpoint(flushInterval: 3);
+
+        scheduler.ShouldCheckpoint().Should().BeFalse();
+        scheduler.ShouldCheckpoint().Should().BeFalse();
+        scheduler.ShouldCheckpoint().Should().BeTrue();
+        scheduler.ShouldCheckpoint().Should().BeFalse();
+        scheduler.ShouldCheckpoint().Should().BeFalse();
+        scheduler.ShouldCheckpoint().Should().BeTrue();
+        scheduler.FlushCounter.Should().Be(6);
+    }
+
+    [TestMethod]
+    public void Constructor_rejects_non_positive_interval()
+    {
+        var act = () => new StreamingAssistantProgressCheckpoint(flushInterval: 0);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/src/server/GuideAntsApi/Properties/AssemblyInfo.cs
+++ b/src/server/GuideAntsApi/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("GuideAntsApi.Tests")]
+[assembly: InternalsVisibleTo("GuideAntsApi.IntegrationTests")]

--- a/src/server/GuideAntsApi/Services/Conversations/Recovery/ConversationTurnRecoveryService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Recovery/ConversationTurnRecoveryService.cs
@@ -1,6 +1,7 @@
 using GuideAntsApi.DataModel;
 using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Services.Conversations.Persistence;
+using GuideAntsApi.Services.Conversations.Streaming;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -10,20 +11,24 @@ namespace GuideAntsApi.Services.Conversations.Recovery;
 
 /// <summary>
 /// Recovers stale <c>streaming</c> turns that lost their in-process finalizer (crash, host restart, lost client).
+/// Must not terminalize turns that still have an active in-process stream worker.
 /// </summary>
 public sealed class ConversationTurnRecoveryService : BackgroundService
 {
     private static readonly TimeSpan PollInterval = TimeSpan.FromMinutes(1);
-    private static readonly TimeSpan StaleAfter = TimeSpan.FromMinutes(3);
+    internal static readonly TimeSpan StaleAfter = TimeSpan.FromMinutes(3);
 
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ConversationStreamRunRegistry _runRegistry;
     private readonly ILogger<ConversationTurnRecoveryService> _logger;
 
     public ConversationTurnRecoveryService(
         IServiceScopeFactory scopeFactory,
+        ConversationStreamRunRegistry runRegistry,
         ILogger<ConversationTurnRecoveryService> logger)
     {
         _scopeFactory = scopeFactory;
+        _runRegistry = runRegistry;
         _logger = logger;
     }
 
@@ -51,7 +56,11 @@ public sealed class ConversationTurnRecoveryService : BackgroundService
         }
     }
 
-    private async Task RecoverStaleTurnsAsync(CancellationToken ct)
+    /// <summary>
+    /// Contract: skip turns still registered in <see cref="ConversationStreamRunRegistry"/>;
+    /// terminalize orphaned streaming turns whose LastUpdated is older than <see cref="StaleAfter"/>.
+    /// </summary>
+    internal async Task RecoverStaleTurnsAsync(CancellationToken ct)
     {
         using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
@@ -74,22 +83,16 @@ public sealed class ConversationTurnRecoveryService : BackgroundService
 
         foreach (var stale in staleTurns)
         {
-            var claimed = await db.ConversationTurns
-                .Where(t =>
-                    t.Id == stale.Id
-                    && t.Status == "streaming"
-                    && t.LastUpdated < cutoff
-                    && t.ExecutionId == stale.ExecutionId)
-                .ExecuteUpdateAsync(
-                    setters => setters
-                        .SetProperty(t => t.Status, "interrupted")
-                        .SetProperty(t => t.TerminalizedAt, DateTime.UtcNow)
-                        .SetProperty(t => t.TerminationCode, "stream_interrupted")
-                        .SetProperty(t => t.TerminationDetail, "Turn recovered after the stream stopped heartbeating.")
-                        .SetProperty(t => t.LastUpdated, DateTime.UtcNow),
-                    ct);
+            if (_runRegistry.IsActive(stale.Id))
+            {
+                _logger.LogDebug(
+                    "Skipping stale-turn recovery for {TurnId}; in-process stream is still active",
+                    stale.Id);
+                continue;
+            }
 
-            if (claimed == 0)
+            var claimed = await TryClaimStaleTurnAsync(db, stale.Id, stale.ExecutionId, cutoff, ct);
+            if (!claimed)
             {
                 continue;
             }
@@ -133,5 +136,34 @@ public sealed class ConversationTurnRecoveryService : BackgroundService
                 stale.NotebookConversationId,
                 stale.TurnIndex);
         }
+    }
+
+    /// <summary>
+    /// Atomically claims a stale streaming turn. Returns false when another worker already
+    /// terminalized the turn or a concurrent heartbeat advanced <see cref="ConversationTurn.LastUpdated"/>.
+    /// </summary>
+    internal static async Task<bool> TryClaimStaleTurnAsync(
+        ApplicationDbContext db,
+        Guid turnId,
+        Guid? executionId,
+        DateTime cutoff,
+        CancellationToken ct)
+    {
+        var claimed = await db.ConversationTurns
+            .Where(t =>
+                t.Id == turnId
+                && t.Status == "streaming"
+                && t.LastUpdated < cutoff
+                && t.ExecutionId == executionId)
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(t => t.Status, "interrupted")
+                    .SetProperty(t => t.TerminalizedAt, DateTime.UtcNow)
+                    .SetProperty(t => t.TerminationCode, "stream_interrupted")
+                    .SetProperty(t => t.TerminationDetail, "Turn recovered after the stream stopped heartbeating.")
+                    .SetProperty(t => t.LastUpdated, DateTime.UtcNow),
+                ct);
+
+        return claimed > 0;
     }
 }

--- a/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamEngine.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamEngine.cs
@@ -155,9 +155,8 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
             var filenameUrlMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var assistantMessageIds = new List<Guid>();
             var thinkingEmittedInStream = false;
-            var flushCounter = 0;
+            var progressCheckpoint = new StreamingAssistantProgressCheckpoint(flushInterval: 20);
             var checkpointVersion = 0;
-            const int flushInterval = 20;
             var fileUrlContext = policy.BuildFileUrlContext(context.Conversation, context.PublisherId, context.HostUrl);
             var turnTraceCollector = new TurnTraceCollector(context.AssistantName, context.ModelDeploymentId);
             context.ChatOptions.TraceCollector = turnTraceCollector;
@@ -228,7 +227,6 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
                 if (isThinking)
                 {
                     thinkingEmittedInStream = true;
-                    currentThinkingContent.Append(e.ContentDelta);
                 }
 
                 if (currentAssistantMessageId == null)
@@ -247,56 +245,56 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
                     assistantMessageIds.Add(msgId);
                 }
 
-                if (!isThinking)
+                if (isThinking)
+                {
+                    currentThinkingContent.Append(e.ContentDelta);
+                }
+                else
                 {
                     currentAssistantContent.Append(e.ContentDelta);
-                    flushCounter++;
+                }
 
-                    if (flushCounter % flushInterval == 0)
+                if (progressCheckpoint.ShouldCheckpoint() && currentAssistantMessageId != null)
+                {
+                    try
                     {
-                        try
-                        {
-                            if (currentAssistantMessageId != null)
-                            {
-                                checkpointVersion++;
-                                string? thinkingJson = currentThinkingContent.Length > 0
-                                    ? JsonSerializer.Serialize(
-                                        new[] { ChatThinkingBlock.ForThinking(currentThinkingContent.ToString(), string.Empty) },
-                                        JsonOptions)
-                                    : null;
-                                _persistence.CheckpointTurnAsync(
-                                    context.DbTurn.Id,
-                                    currentAssistantMessageId.Value,
-                                    currentAssistantContent.ToString(),
-                                    thinkingJson,
-                                    checkpointVersion,
-                                    CancellationToken.None).GetAwaiter().GetResult();
-                            }
+                        checkpointVersion++;
+                        string? thinkingJson = currentThinkingContent.Length > 0
+                            ? JsonSerializer.Serialize(
+                                new[] { ChatThinkingBlock.ForThinking(currentThinkingContent.ToString(), string.Empty) },
+                                JsonOptions)
+                            : null;
+                        _persistence.CheckpointTurnAsync(
+                            context.DbTurn.Id,
+                            currentAssistantMessageId.Value,
+                            currentAssistantContent.ToString(),
+                            thinkingJson,
+                            checkpointVersion,
+                            CancellationToken.None).GetAwaiter().GetResult();
 
-                            if (!policy.SupportsExternalToolResume)
-                            {
-                                _ = Task.Run(async () =>
-                                {
-                                    try
-                                    {
-                                        await policy.BroadcastStreamingProgressAsync(
-                                            context.ConversationId,
-                                            context.User,
-                                            currentAssistantContent.Length,
-                                            flushCounter,
-                                            CancellationToken.None);
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        _logger.LogWarning(ex, "Failed to broadcast streaming progress");
-                                    }
-                                });
-                            }
-                        }
-                        catch
+                        if (!isThinking && !policy.SupportsExternalToolResume)
                         {
-                            // logged on finalization
+                            _ = Task.Run(async () =>
+                            {
+                                try
+                                {
+                                    await policy.BroadcastStreamingProgressAsync(
+                                        context.ConversationId,
+                                        context.User,
+                                        currentAssistantContent.Length,
+                                        progressCheckpoint.FlushCounter,
+                                        CancellationToken.None);
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger.LogWarning(ex, "Failed to broadcast streaming progress");
+                                }
+                            });
                         }
+                    }
+                    catch
+                    {
+                        // logged on finalization
                     }
                 }
 

--- a/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamRunRegistry.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamRunRegistry.cs
@@ -41,4 +41,10 @@ public sealed class ConversationStreamRunRegistry
             return false;
         }
     }
+
+    /// <summary>
+    /// True while an in-process stream worker is registered for <paramref name="turnId"/>.
+    /// Stale-turn recovery must not terminalize these; wall-clock silence during thinking is normal.
+    /// </summary>
+    public bool IsActive(Guid turnId) => _activeRuns.ContainsKey(turnId);
 }

--- a/src/server/GuideAntsApi/Services/Conversations/Streaming/StreamingAssistantProgressCheckpoint.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Streaming/StreamingAssistantProgressCheckpoint.cs
@@ -1,0 +1,32 @@
+namespace GuideAntsApi.Services.Conversations.Streaming;
+
+/// <summary>
+/// Counts streamed deltas and signals when a persistence checkpoint should run.
+/// Buffering lives in the stream engine; this type is O(1) per delta.
+/// </summary>
+internal sealed class StreamingAssistantProgressCheckpoint
+{
+    private readonly int _flushInterval;
+    private int _flushCounter;
+
+    public StreamingAssistantProgressCheckpoint(int flushInterval = 20)
+    {
+        if (flushInterval <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(flushInterval));
+        }
+
+        _flushInterval = flushInterval;
+    }
+
+    public int FlushCounter => _flushCounter;
+
+    /// <summary>
+    /// Records one delta. Returns true when a checkpoint should be persisted.
+    /// </summary>
+    public bool ShouldCheckpoint()
+    {
+        _flushCounter++;
+        return _flushCounter % _flushInterval == 0;
+    }
+}


### PR DESCRIPTION
Shakeout of issues found running super-long qwen one-shot tests running for tens of minutes and 100k+ tokens.

Checkpoint on thinking deltas, skip recovery for in-process runs, restore atomic stale-turn claims, and stop force-refresh from wiping cancel/idle local content while still surfacing idle-timeout failures.

