### PR TITLE
Keep conversation workers alive across SSE disconnects

### DIFF
--- a/src/client/src/contexts/ConversationContext.tsx
+++ b/src/client/src/contexts/ConversationContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useReducer, useMemo } from 'react';
 import { api } from '../services/api';
-import { userService } from '../services/userService';
 import { useNotebook } from './NotebookContext';
 import { useToast } from '../components/common/Toast';
 import { ensureValidTokensForTemplate } from '../utils/notebookAuth';
@@ -11,6 +10,11 @@ import { reducer, initialState } from './conversation/reducer';
 import { getNotebookRuntimeReadyCache, checkRuntimeStatus, clearNotebookRuntimeReadyCache } from './conversation/runtimeChecks';
 import { useStreamingEventHandler } from './conversation/useStreamingEventHandler';
 import { useConversationActions } from './conversation/useConversationActions';
+import {
+  appendStreamingPreviewMessage,
+  buildInlineUserProfiles,
+  fetchMissingUserProfiles,
+} from './conversation/conversationRefreshHelpers';
 
 const ConversationContext = createContext<ConversationContextProps | undefined>(undefined);
 
@@ -54,11 +58,19 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
   });
 
   const [currentStreamController, setCurrentStreamController] = React.useState<AbortController | null>(null);
-  const [activeStreamTurnId, setActiveStreamTurnId] = React.useState<string | null>(null);
+  const [observerStreamController, setObserverStreamController] = React.useState<AbortController | null>(null);
+  const reattachIfStreamingRef = React.useRef<(convo: any) => Promise<void>>(async () => {});
+  const onTurnIdAssignedRef = React.useRef<(turnId: string) => void>(() => {});
+  const onStreamTerminalRef = React.useRef<() => void>(() => {});
+  const [activeStreamTurnId, setActiveStreamTurnIdState] = React.useState<string | null>(null);
   const activeStreamTurnIdRef = React.useRef<string | null>(null);
-  React.useEffect(() => {
-    activeStreamTurnIdRef.current = activeStreamTurnId;
-  }, [activeStreamTurnId]);
+  const assignActiveStreamTurnId = React.useCallback((turnId: string | null) => {
+    activeStreamTurnIdRef.current = turnId;
+    setActiveStreamTurnIdState(turnId);
+    if (turnId) {
+      onTurnIdAssignedRef.current(turnId);
+    }
+  }, []);
   const getActiveStreamTurnId = React.useCallback(() => activeStreamTurnIdRef.current, []);
   const templateStartersRef = React.useRef<string[]>([]);
   const inflightRuntimeChecksRef = React.useRef<Set<string>>(new Set());
@@ -105,47 +117,23 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
     try {
       const convo = await api.projects.notebooks.conversations.get(projectId, notebookId, conversationId);
       if (convo) {
-        if (convo.messages) {
-          const idsSet = new Set<string>();
-          const profileMap: Record<string, any> = {};
-          convo.messages.forEach(m => { if (m.userId) idsSet.add(m.userId); });
-          convo.messages.forEach(m => {
-            if (m.userId && (m.userName || m.userEmail)) {
-              profileMap[m.userId] = {
-                ...(profileMap[m.userId] || {}),
-                id: m.userId,
-                name: m.userName,
-                email: m.userEmail,
-              };
-            }
-          });
-          try {
-            const me = await userService.getCurrentUser();
-            if (me?.id) {
-              idsSet.add(me.id);
-              profileMap[me.id] = { ...(profileMap[me.id] || {}), ...me };
-            }
-          } catch {}
-
-          const ids = Array.from(idsSet);
-          const idsToFetch = ids.filter(id => {
-            const cached = profileMap[id];
-            return !cached || (!cached.name && !cached.email);
-          });
-
-          if (idsToFetch.length > 0) {
-            const profiles = await Promise.all(idsToFetch.map(id => userService.getUserById(id as string).catch(() => null)));
-            idsToFetch.forEach((id, idx) => { if (id && profiles[idx]) profileMap[id] = profiles[idx]; });
-          }
-
-          dispatch({ type: 'SET_USER_PROFILES', payload: profileMap });
+        const baseMessages = convo.messages ?? [];
+        const inlineProfiles = buildInlineUserProfiles(baseMessages);
+        if (Object.keys(inlineProfiles).length > 0) {
+          dispatch({ type: 'SET_USER_PROFILES', payload: inlineProfiles });
         }
 
-        dispatch({ type: 'SET_MESSAGES', payload: convo.messages ?? [] });
+        const messages = appendStreamingPreviewMessage(
+          baseMessages,
+          convo.streamingPreview,
+          convo.assistantName,
+        );
+        dispatch({ type: 'SET_MESSAGES', payload: messages });
+
         if (convo.activeTurn?.turnId) {
-          setActiveStreamTurnId(convo.activeTurn.turnId);
+          assignActiveStreamTurnId(convo.activeTurn.turnId);
         } else if (convo.activeTurn?.status && convo.activeTurn.status !== 'streaming') {
-          setActiveStreamTurnId(null);
+          assignActiveStreamTurnId(null);
         }
 
         if (convo.assistantName) {
@@ -158,9 +146,19 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
           } else {
             console.warn('[llama-runtime] refresh: SKIPPED runtime check — assistant.id is falsy');
           }
-        } else if (convo.messages.length === 0 && !selectedAssistantRef.current) {
+        } else if (baseMessages.length === 0 && !selectedAssistantRef.current) {
           dispatch({ type: 'SET_ASSISTANT', payload: null });
         }
+
+        void reattachIfStreamingRef.current({ ...convo, messages });
+
+        void fetchMissingUserProfiles(baseMessages).then(profileMap => {
+          if (Object.keys(profileMap).length > 0) {
+            dispatch({ type: 'SET_USER_PROFILES', payload: profileMap });
+          }
+        }).catch(() => {
+          // best effort
+        });
       } else {
         console.warn(`Conversation ${conversationId} not found`);
         dispatch({ type: 'SET_MESSAGES', payload: [] });
@@ -323,18 +321,23 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
   // --- Cleanup on conversation change ---
   useEffect(() => {
     if (currentStreamController) {
-      console.log('🔥 Conversation changed, cancelling active stream');
+      console.log('🔥 Conversation changed, aborting active send stream');
       currentStreamController.abort();
       setCurrentStreamController(null);
-
-      dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
-      dispatch({ type: 'COMPLETE_STREAMING_TURN' });
-      dispatch({ type: 'SET_CANCELLING', payload: false });
-      dispatch({ type: 'CLEAR_ATTACHMENTS' });
     }
 
+    if (observerStreamController) {
+      console.log('🔥 Conversation changed, aborting observer stream');
+      observerStreamController.abort();
+      setObserverStreamController(null);
+    }
+
+    dispatch({ type: 'SET_CANCELLING', payload: false });
+    dispatch({ type: 'CLEAR_ATTACHMENTS' });
     dispatch({ type: 'SET_MESSAGES', payload: [] });
-  }, [conversationId]);
+    assignActiveStreamTurnId(null);
+    onStreamTerminalRef.current();
+  }, [conversationId, assignActiveStreamTurnId]);
 
   // --- Cleanup on unmount ---
   useEffect(() => {
@@ -342,6 +345,10 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
       if (currentStreamController) {
         currentStreamController.abort();
         setCurrentStreamController(null);
+      }
+      if (observerStreamController) {
+        observerStreamController.abort();
+        setObserverStreamController(null);
       }
     };
   }, []);
@@ -364,17 +371,23 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
   const handleStreamingEvent = useStreamingEventHandler(dispatch, state, {
     loadNotebookFiles, showToast,
     projectId, notebookId, conversationId, setCurrentStreamController,
-    setActiveStreamTurnId,
+    setActiveStreamTurnId: assignActiveStreamTurnId,
     refreshConversation: refresh,
+    onStreamTerminal: () => onStreamTerminalRef.current(),
   });
 
   const actions = useConversationActions(dispatch, state, {
     projectId, notebookId, conversationId,
     handleStreamingEvent, showToast, loadNotebookFiles,
     currentStreamController, setCurrentStreamController,
+    observerStreamController, setObserverStreamController,
     inflightRuntimeChecksRef, runtimeReadyCacheRef, assistantByName,
-    activeStreamTurnId, setActiveStreamTurnId, getActiveStreamTurnId, refreshConversation: refresh,
+    activeStreamTurnId, setActiveStreamTurnId: assignActiveStreamTurnId, getActiveStreamTurnId, refreshConversation: refresh,
   });
+
+  reattachIfStreamingRef.current = actions.reattachIfStreaming;
+  onTurnIdAssignedRef.current = actions.onTurnIdAssigned;
+  onStreamTerminalRef.current = actions.clearPendingStop;
 
   const currentAssistant = useMemo(() => {
     const name = state.selectedAssistant || undefined;

--- a/src/client/src/contexts/__tests__/ConversationContext.provider.test.tsx
+++ b/src/client/src/contexts/__tests__/ConversationContext.provider.test.tsx
@@ -734,7 +734,9 @@ describe('ConversationContext Provider', () => {
       });
 
       expect(mockUserService.getUserById).toHaveBeenCalledWith('user-9');
-      expect(result.current.userProfiles?.['user-9']?.name).toBe('Fetched Profile');
+      await waitFor(() => {
+        expect(result.current.userProfiles?.['user-9']?.name).toBe('Fetched Profile');
+      });
     });
 
     it('ignores llama runtime events for other notebooks', async () => {

--- a/src/client/src/contexts/__tests__/ConversationContext.streamingContracts.test.tsx
+++ b/src/client/src/contexts/__tests__/ConversationContext.streamingContracts.test.tsx
@@ -148,11 +148,25 @@ describe('ConversationContext streaming contracts', () => {
     });
 
     await act(async () => {
+      capturedOnEvent?.({ type: 'turn_created', data: { turnId: 'turn-stop-1' } });
       capturedOnEvent?.({ type: 'assistant_message', data: { contentDelta: 'partial before cancel' } });
     });
 
     await act(async () => {
       result.current.cancelStream();
+    });
+
+    expect(api.projects.notebooks.conversations.cancelTurn).toHaveBeenCalledWith(
+      'test-project',
+      'test-notebook',
+      'test-conversation',
+      'turn-stop-1',
+    );
+    expect(result.current.isCancelling).toBe(true);
+    expect(result.current.isStreaming).toBe(true);
+
+    await act(async () => {
+      capturedOnEvent?.({ type: 'cancelled', data: { status: 'cancelled' } });
     });
 
     await waitFor(() => {
@@ -163,5 +177,33 @@ describe('ConversationContext streaming contracts', () => {
     const assistant = result.current.messages.find(m => m.role.toLowerCase() === 'assistant');
     expect(assistant?.content).toContain('partial before cancel');
     expect(mockShowToast).not.toHaveBeenCalled();
+  });
+
+  it('posts cancelTurn when Stop is clicked before turn_created arrives', async () => {
+    const { result } = renderHook(() => useConversation(), { wrapper: renderProvider() });
+    await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+
+    await act(async () => {
+      result.current.cancelStream();
+    });
+
+    expect(api.projects.notebooks.conversations.cancelTurn).not.toHaveBeenCalled();
+    expect(result.current.isCancelling).toBe(true);
+    expect(result.current.isStreaming).toBe(true);
+
+    await act(async () => {
+      capturedOnEvent?.({ type: 'turn_created', data: { turnId: 'turn-late' } });
+    });
+
+    expect(api.projects.notebooks.conversations.cancelTurn).toHaveBeenCalledWith(
+      'test-project',
+      'test-notebook',
+      'test-conversation',
+      'turn-late',
+    );
   });
 });

--- a/src/client/src/contexts/conversation/__tests__/conversationRefreshHelpers.test.ts
+++ b/src/client/src/contexts/conversation/__tests__/conversationRefreshHelpers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendStreamingPreviewMessage } from '../conversationRefreshHelpers';
+
+describe('appendStreamingPreviewMessage', () => {
+  it('appends a streaming placeholder when preview is present', () => {
+    const result = appendStreamingPreviewMessage(
+      [{ id: 'u1', role: 'user', content: 'hi' } as any],
+      { messageId: 'msg-1', content: 'partial', turnIndex: 2 },
+      'Creative Guide',
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      id: 'streaming-msg-1',
+      role: 'assistant',
+      content: 'partial',
+      streaming: true,
+      turnIndex: 2,
+      assistantName: 'Creative Guide',
+    });
+  });
+
+  it('does not duplicate an existing preview placeholder', () => {
+    const messages = [
+      { id: 'streaming-msg-1', role: 'assistant', content: 'partial' } as any,
+    ];
+
+    const result = appendStreamingPreviewMessage(
+      messages,
+      { messageId: 'msg-1', content: 'partial', turnIndex: 2 },
+    );
+
+    expect(result).toBe(messages);
+  });
+});

--- a/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
+++ b/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
@@ -3,21 +3,6 @@ import { renderHook, act } from '@testing-library/react';
 import type { ExtendedConversationState } from '../types';
 import { createMockMessage, createMockAssistantMessage } from '../../../test/conversationContextTestUtils';
 
-vi.mock('../../../services/api', () => ({
-  api: {
-    projects: {
-      notebooks: {
-        conversations: {
-          sendMessageStream: vi.fn().mockResolvedValue(undefined),
-          editMessage: vi.fn().mockResolvedValue({}),
-          undoLast: vi.fn().mockResolvedValue({}),
-          get: vi.fn().mockResolvedValue({ messages: [] }),
-        },
-      },
-    },
-  },
-}));
-
 vi.mock('../../../utils/notebookAuth', () => ({
   ensureValidTokensForTemplate: vi.fn().mockResolvedValue({ needsAuth: false, missingProviders: [] }),
 }));
@@ -75,6 +60,8 @@ function createDeps(overrides: Partial<Parameters<typeof useConversationActions>
     loadNotebookFiles: vi.fn().mockResolvedValue(undefined),
     currentStreamController: null as AbortController | null,
     setCurrentStreamController,
+    observerStreamController: null as AbortController | null,
+    setObserverStreamController: vi.fn(),
     inflightRuntimeChecksRef,
     runtimeReadyCacheRef,
     activeStreamTurnId: null as string | null,
@@ -112,9 +99,13 @@ describe('useConversationActions', () => {
     dispatchEventSpy = vi.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
     vi.mocked(ensureValidTokensForTemplate).mockResolvedValue({ needsAuth: false, missingProviders: [] });
     vi.mocked(checkRuntimeStatus).mockResolvedValue({ state: 'ready' });
-    vi.mocked(api.projects.notebooks.conversations.sendMessageStream).mockResolvedValue(undefined);
-    vi.mocked(api.projects.notebooks.conversations.editMessage).mockResolvedValue({});
-    vi.mocked(api.projects.notebooks.conversations.undoLast).mockResolvedValue({});
+    const conversations = api.projects.notebooks.conversations as Record<string, unknown>;
+    conversations.sendMessageStream = vi.fn().mockResolvedValue(undefined);
+    conversations.observeConversationEvents = vi.fn().mockResolvedValue(undefined);
+    conversations.cancelTurn = vi.fn().mockResolvedValue(undefined);
+    conversations.editMessage = vi.fn().mockResolvedValue({});
+    conversations.undoLast = vi.fn().mockResolvedValue({});
+    conversations.get = vi.fn().mockResolvedValue({ messages: [] });
   });
 
   afterEach(() => {
@@ -329,7 +320,7 @@ describe('useConversationActions', () => {
       }));
     });
 
-    it('handles stream onError AbortError without force refresh', async () => {
+    it('handles stream onError AbortError without completing the turn or force refresh', async () => {
       let onError: ((err: Error) => void) | undefined;
       vi.mocked(api.projects.notebooks.conversations.sendMessageStream).mockImplementation(
         async (_p, _n, _c, _payload, _onEvent, errCb) => {
@@ -347,8 +338,8 @@ describe('useConversationActions', () => {
         onError?.(Object.assign(new Error('aborted'), { name: 'AbortError' }));
       });
 
-      expect(dispatch).toHaveBeenCalledWith({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
-      expect(dispatch).toHaveBeenCalledWith({ type: 'COMPLETE_STREAMING_TURN' });
+      expect(dispatch).not.toHaveBeenCalledWith({ type: 'COMPLETE_STREAMING_TURN' });
+      expect(dispatch).not.toHaveBeenCalledWith({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
       expect(deps.refreshConversation).not.toHaveBeenCalled();
       expect(deps.showToast).not.toHaveBeenCalled();
       const errorDispatches = dispatch.mock.calls.filter(
@@ -521,28 +512,124 @@ describe('useConversationActions', () => {
   });
 
   describe('cancelStream', () => {
-    it('aborts controller and schedules finalization when still streaming', () => {
-      vi.useFakeTimers();
+    it('calls cancelTurn and does not abort the send SSE controller', () => {
       const controller = new AbortController();
       const abortSpy = vi.spyOn(controller, 'abort');
       const { actions, dispatch } = mountActions(
         { isStreaming: true },
-        { currentStreamController: controller },
+        {
+          currentStreamController: controller,
+          activeStreamTurnId: 'turn-1',
+          getActiveStreamTurnId: vi.fn(() => 'turn-1'),
+        },
       );
 
       act(() => {
         actions.cancelStream();
       });
 
-      expect(abortSpy).toHaveBeenCalled();
+      expect(abortSpy).not.toHaveBeenCalled();
+      expect(api.projects.notebooks.conversations.cancelTurn).toHaveBeenCalledWith(
+        PROJECT_ID, NOTEBOOK_ID, CONVERSATION_ID, 'turn-1',
+      );
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CANCELLING', payload: true });
+    });
+
+    it('calls cancelTurn without aborting when only observing', () => {
+      const observerController = new AbortController();
+      const abortSpy = vi.spyOn(observerController, 'abort');
+      const { actions, dispatch } = mountActions(
+        { isStreaming: true, streamingMode: 'observing' },
+        {
+          observerStreamController: observerController,
+          activeStreamTurnId: 'turn-2',
+          getActiveStreamTurnId: vi.fn(() => 'turn-2'),
+        },
+      );
+
+      act(() => {
+        actions.cancelStream();
+      });
+
+      expect(api.projects.notebooks.conversations.cancelTurn).toHaveBeenCalledWith(
+        PROJECT_ID, NOTEBOOK_ID, CONVERSATION_ID, 'turn-2',
+      );
+      expect(abortSpy).not.toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CANCELLING', payload: true });
+    });
+
+    it('posts cancelTurn when Stop is clicked before turn_created then the turn id arrives', () => {
+      const controller = new AbortController();
+      const abortSpy = vi.spyOn(controller, 'abort');
+      const { actions, dispatch } = mountActions(
+        { isStreaming: true },
+        {
+          currentStreamController: controller,
+          activeStreamTurnId: null,
+          getActiveStreamTurnId: vi.fn(() => null),
+        },
+      );
+
+      act(() => {
+        actions.cancelStream();
+      });
+
+      expect(api.projects.notebooks.conversations.cancelTurn).not.toHaveBeenCalled();
+      expect(abortSpy).not.toHaveBeenCalled();
       expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CANCELLING', payload: true });
 
       act(() => {
-        vi.advanceTimersByTime(500);
+        actions.onTurnIdAssigned('turn-late');
       });
 
-      expect(dispatch).toHaveBeenCalledWith({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
-      vi.useRealTimers();
+      expect(api.projects.notebooks.conversations.cancelTurn).toHaveBeenCalledWith(
+        PROJECT_ID, NOTEBOOK_ID, CONVERSATION_ID, 'turn-late',
+      );
+      expect(abortSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reattachIfStreaming', () => {
+    it('opens observer SSE when conversation is still streaming', async () => {
+      const setObserverStreamController = vi.fn();
+      const setActiveStreamTurnId = vi.fn();
+      const { actions, dispatch } = mountActions(
+        {},
+        { setObserverStreamController, setActiveStreamTurnId },
+      );
+
+      await act(async () => {
+        await actions.reattachIfStreaming({
+          activeTurn: { turnId: 'turn-1', status: 'streaming', turnIndex: 1 },
+          lock: { lockedByUserName: 'Alice' },
+          streamingPreview: { messageId: 'msg-1', content: 'partial', turnIndex: 1 },
+          assistantName: 'Claude',
+        });
+      });
+
+      expect(setActiveStreamTurnId).toHaveBeenCalledWith('turn-1');
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_STREAMING_MODE',
+        payload: { mode: 'observing', activeUser: { userId: '', userName: 'Alice' } },
+      });
+      expect(api.projects.notebooks.conversations.observeConversationEvents).toHaveBeenCalled();
+      expect(setObserverStreamController).toHaveBeenCalled();
+    });
+
+    it('does not open observer SSE while the send stream is still attached', async () => {
+      const sendController = new AbortController();
+      const { actions } = mountActions(
+        {},
+        { currentStreamController: sendController },
+      );
+
+      await act(async () => {
+        await actions.reattachIfStreaming({
+          activeTurn: { turnId: 'turn-1', status: 'streaming', turnIndex: 1 },
+        });
+      });
+
+      expect(api.projects.notebooks.conversations.observeConversationEvents).not.toHaveBeenCalled();
     });
   });
 

--- a/src/client/src/contexts/conversation/conversationRefreshHelpers.ts
+++ b/src/client/src/contexts/conversation/conversationRefreshHelpers.ts
@@ -1,0 +1,94 @@
+import type { MessageDto } from '../../types/conversation';
+import type { ConversationStreamingPreviewDto } from '../../types/notebook';
+import { userService } from '../../services/userService';
+
+export function appendStreamingPreviewMessage(
+  messages: MessageDto[],
+  preview: ConversationStreamingPreviewDto | null | undefined,
+  assistantName?: string | null,
+): MessageDto[] {
+  if (!preview) {
+    return messages;
+  }
+
+  const previewId = `streaming-${preview.messageId}`;
+  if (messages.some(m => m.id === previewId)) {
+    return messages;
+  }
+
+  return [
+    ...messages,
+    {
+      id: previewId,
+      role: 'assistant',
+      content: preview.content,
+      created: new Date().toISOString(),
+      isEdited: false,
+      streaming: true,
+      assistantName: assistantName ?? undefined,
+      turnIndex: preview.turnIndex,
+    } as MessageDto,
+  ];
+}
+
+export function buildInlineUserProfiles(messages: MessageDto[]): Record<string, { id: string; name?: string; email?: string }> {
+  const profileMap: Record<string, { id: string; name?: string; email?: string }> = {};
+  for (const m of messages) {
+    if (m.userId && (m.userName || m.userEmail)) {
+      profileMap[m.userId] = {
+        ...(profileMap[m.userId] || {}),
+        id: m.userId,
+        name: m.userName,
+        email: m.userEmail,
+      };
+    }
+  }
+  return profileMap;
+}
+
+export async function fetchMissingUserProfiles(messages: MessageDto[]): Promise<Record<string, unknown>> {
+  const idsSet = new Set<string>();
+  const profileMap: Record<string, unknown> = {};
+
+  for (const m of messages) {
+    if (m.userId) {
+      idsSet.add(m.userId);
+    }
+    if (m.userId && (m.userName || m.userEmail)) {
+      profileMap[m.userId] = {
+        ...(profileMap[m.userId] as object || {}),
+        id: m.userId,
+        name: m.userName,
+        email: m.userEmail,
+      };
+    }
+  }
+
+  try {
+    const me = await userService.getCurrentUser();
+    if (me?.id) {
+      idsSet.add(me.id);
+      profileMap[me.id] = { ...(profileMap[me.id] as object || {}), ...me };
+    }
+  } catch {
+    // best effort
+  }
+
+  const idsToFetch = Array.from(idsSet).filter(id => {
+    const cached = profileMap[id] as { name?: string; email?: string } | undefined;
+    return !cached || (!cached.name && !cached.email);
+  });
+
+  if (idsToFetch.length > 0) {
+    const profiles = await Promise.all(
+      idsToFetch.map(id => userService.getUserById(id).catch(() => null)),
+    );
+    idsToFetch.forEach((id, idx) => {
+      if (profiles[idx]) {
+        profileMap[id] = profiles[idx];
+      }
+    });
+  }
+
+  return profileMap;
+}

--- a/src/client/src/contexts/conversation/useConversationActions.ts
+++ b/src/client/src/contexts/conversation/useConversationActions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import type { MessageDto, PendingAttachment } from '../../types/conversation';
 import { api } from '../../services/api';
 import { uploadTypeToServer } from '../../utils/attachments';
@@ -16,6 +16,8 @@ interface ActionDeps {
   loadNotebookFiles: () => Promise<void>;
   currentStreamController: AbortController | null;
   setCurrentStreamController: (c: AbortController | null) => void;
+  observerStreamController: AbortController | null;
+  setObserverStreamController: (c: AbortController | null) => void;
   inflightRuntimeChecksRef: React.MutableRefObject<Set<string>>;
   runtimeReadyCacheRef: React.MutableRefObject<Set<string>>;
   assistantByName: Record<string, { name: string; model?: string; avatarUrl: string; id?: string }>;
@@ -34,9 +36,35 @@ export function useConversationActions(
     projectId, notebookId, conversationId,
     handleStreamingEvent, showToast, loadNotebookFiles,
     currentStreamController, setCurrentStreamController,
+    observerStreamController, setObserverStreamController,
     inflightRuntimeChecksRef, runtimeReadyCacheRef, assistantByName,
     activeStreamTurnId, setActiveStreamTurnId, getActiveStreamTurnId, refreshConversation,
   } = deps;
+
+  const pendingStopRef = useRef(false);
+  const stopPostedForTurnRef = useRef<string | null>(null);
+
+  const clearPendingStop = useCallback(() => {
+    pendingStopRef.current = false;
+    stopPostedForTurnRef.current = null;
+  }, []);
+
+  const requestServerStop = useCallback((turnId: string) => {
+    if (stopPostedForTurnRef.current === turnId) {
+      return;
+    }
+
+    stopPostedForTurnRef.current = turnId;
+    void api.projects.notebooks.conversations
+      .cancelTurn(projectId, notebookId, conversationId, turnId)
+      .catch(err => console.warn('Failed to request server stream cancellation:', err));
+  }, [projectId, notebookId, conversationId]);
+
+  const onTurnIdAssigned = useCallback((turnId: string) => {
+    if (pendingStopRef.current) {
+      requestServerStop(turnId);
+    }
+  }, [requestServerStop]);
 
   const sendMessage = useCallback(
     async (content: string, attachments: PendingAttachment[] = []) => {
@@ -108,6 +136,7 @@ export function useConversationActions(
       dispatch({ type: 'SET_CANCELLING', payload: false });
       dispatch({ type: 'SET_STREAMING_ERROR', payload: undefined });
       dispatch({ type: 'SET_DRAFT', payload: '' });
+      clearPendingStop();
 
       const controller = new AbortController();
       setCurrentStreamController(controller);
@@ -172,17 +201,17 @@ export function useConversationActions(
             const isIdleTimeout = error.name === 'StreamIdleTimeoutError';
 
             if (isUserCancel) {
-              console.log('Stream cancelled by user - finalizing partial content without force refresh');
-              dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
-              dispatch({ type: 'COMPLETE_STREAMING_TURN' });
-              dispatch({ type: 'SET_CANCELLING', payload: false });
+              console.log('SSE client disconnected; server run may continue');
               setCurrentStreamController(null);
-              setActiveStreamTurnId?.(null);
+              if (!pendingStopRef.current) {
+                dispatch({ type: 'SET_CANCELLING', payload: false });
+              }
               return;
             }
 
             if (isIdleTimeout) {
               console.log('Stream idle timeout - finalizing partial content without force refresh');
+              clearPendingStop();
               dispatch({ type: 'SET_STREAMING', payload: false });
               dispatch({ type: 'SET_CANCELLING', payload: false });
               dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
@@ -212,6 +241,7 @@ export function useConversationActions(
 
             console.error('Streaming error:', error);
             void reconcile();
+            clearPendingStop();
             runtimeReadyCacheRef.current.clear();
             dispatch({ type: 'SET_STREAMING', payload: false });
             dispatch({ type: 'SET_CANCELLING', payload: false });
@@ -229,6 +259,7 @@ export function useConversationActions(
             });
           },
           () => {
+            clearPendingStop();
             dispatch({ type: 'COMPLETE_STREAMING_TURN' });
             dispatch({ type: 'SET_CANCELLING', payload: false });
             setCurrentStreamController(null);
@@ -254,15 +285,16 @@ export function useConversationActions(
         );
       } catch (error: any) {
         if (error instanceof Error && (error.name === 'AbortError' || error.message.includes('aborted'))) {
-          dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
-          dispatch({ type: 'COMPLETE_STREAMING_TURN' });
-          dispatch({ type: 'SET_CANCELLING', payload: false });
           setCurrentStreamController(null);
+          if (!pendingStopRef.current) {
+            dispatch({ type: 'SET_CANCELLING', payload: false });
+          }
           return;
         }
 
         console.error('Send message failed', error);
         runtimeReadyCacheRef.current.clear();
+        clearPendingStop();
         dispatch({ type: 'SET_STREAMING', payload: false });
         dispatch({ type: 'SET_CANCELLING', payload: false });
         dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
@@ -437,27 +469,100 @@ export function useConversationActions(
     dispatch({ type: 'SET_STREAMING_MODE', payload: { mode, activeUser } });
   }, [projectId, notebookId, conversationId, dispatch]);
 
-  const cancelStream = useCallback(() => {
-    if (activeStreamTurnId) {
-      void api.projects.notebooks.conversations
-        .cancelTurn(projectId, notebookId, conversationId, activeStreamTurnId)
-        .catch(err => console.warn('Failed to request server stream cancellation:', err));
+  const reattachIfStreaming = useCallback(async (convo: {
+    activeTurn?: { turnId: string; status: string; turnIndex: number } | null;
+    lock?: { lockedByUserName: string } | null;
+    streamingPreview?: { messageId: string; content: string; turnIndex: number } | null;
+    assistantName?: string | null;
+    messages?: MessageDto[];
+  }) => {
+    if (!convo.activeTurn || convo.activeTurn.status !== 'streaming') {
+      return;
     }
-    if (currentStreamController) {
-      dispatch({ type: 'SET_CANCELLING', payload: true });
-      currentStreamController.abort();
-      setCurrentStreamController(null);
 
-      setTimeout(() => {
-        if (state.isStreaming) {
-          console.log('🔥 Forcing finalization of cancelled stream');
-          dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
-          dispatch({ type: 'COMPLETE_STREAMING_TURN' });
-          dispatch({ type: 'SET_CANCELLING', payload: false });
-        }
-      }, 500);
+    if (currentStreamController && !currentStreamController.signal.aborted) {
+      return;
     }
-  }, [activeStreamTurnId, currentStreamController, projectId, notebookId, conversationId, state.isStreaming, dispatch, setCurrentStreamController, setActiveStreamTurnId]);
+
+    if (observerStreamController && !observerStreamController.signal.aborted) {
+      return;
+    }
+
+    const activeUser = convo.lock
+      ? { userId: '', userName: convo.lock.lockedByUserName }
+      : undefined;
+
+    setActiveStreamTurnId(convo.activeTurn.turnId);
+    dispatch({
+      type: 'SET_STREAMING_MODE',
+      payload: { mode: 'observing', activeUser },
+    });
+
+    if (convo.streamingPreview) {
+      const previewId = `streaming-${convo.streamingPreview.messageId}`;
+      const knownMessages = convo.messages ?? state.messages;
+      const hasPreview = knownMessages.some(m => m.id === previewId);
+      if (!hasPreview) {
+        const placeholder: MessageDto = {
+          id: previewId,
+          role: 'assistant',
+          content: convo.streamingPreview.content,
+          created: new Date().toISOString(),
+          isEdited: false,
+          streaming: true,
+          assistantName: convo.assistantName || state.selectedAssistant || undefined,
+          turnIndex: convo.streamingPreview.turnIndex,
+        } as MessageDto;
+        dispatch({ type: 'ADD_MESSAGE', payload: placeholder });
+      }
+    }
+
+    const controller = new AbortController();
+    setObserverStreamController(controller);
+
+    void api.projects.notebooks.conversations.observeConversationEvents(
+      projectId,
+      notebookId,
+      conversationId,
+      handleStreamingEvent,
+      (error) => {
+        if (error.name === 'AbortError') {
+          return;
+        }
+        console.error('Observer stream error:', error);
+        dispatch({ type: 'SET_STREAMING_ERROR', payload: error.message || 'Observer stream failed' });
+      },
+      () => {
+        setObserverStreamController(null);
+        setActiveStreamTurnId(null);
+        dispatch({ type: 'SET_CANCELLING', payload: false });
+        clearPendingStop();
+      },
+      controller.signal,
+    );
+  }, [
+    observerStreamController,
+    projectId,
+    notebookId,
+    conversationId,
+    handleStreamingEvent,
+    dispatch,
+    setActiveStreamTurnId,
+    setObserverStreamController,
+    state.messages,
+    state.selectedAssistant,
+    currentStreamController,
+  ]);
+
+  const cancelStream = useCallback(() => {
+    dispatch({ type: 'SET_CANCELLING', payload: true });
+    pendingStopRef.current = true;
+
+    const turnId = getActiveStreamTurnId() ?? activeStreamTurnId;
+    if (turnId) {
+      requestServerStop(turnId);
+    }
+  }, [activeStreamTurnId, getActiveStreamTurnId, requestServerStop, dispatch]);
 
   const undoLastTurn = useCallback(async () => {
     if (state._isUndoing) {
@@ -533,6 +638,9 @@ export function useConversationActions(
     startEditingAssistant,
     cancelEditingAssistant,
     setStreamingMode,
+    reattachIfStreaming,
+    onTurnIdAssigned,
+    clearPendingStop,
     cancelStream,
     undoLastTurn,
     setSelectedAssistant,

--- a/src/client/src/contexts/conversation/useStreamingEventHandler.ts
+++ b/src/client/src/contexts/conversation/useStreamingEventHandler.ts
@@ -12,6 +12,7 @@ interface StreamingEventDeps {
   setCurrentStreamController: (c: AbortController | null) => void;
   setActiveStreamTurnId?: (turnId: string | null) => void;
   refreshConversation?: (options?: { force?: boolean }) => Promise<void>;
+  onStreamTerminal?: () => void;
 }
 
 export function useStreamingEventHandler(
@@ -83,6 +84,7 @@ export function useStreamingEventHandler(
 
       case 'complete':
         {
+          deps.onStreamTerminal?.();
           const streamingMsg = state.messages.find(m =>
             m.role.toLowerCase() === 'assistant' && m.id.startsWith('streaming-')
           );
@@ -124,6 +126,7 @@ export function useStreamingEventHandler(
         break;
 
       case 'pending_client_tool':
+        deps.onStreamTerminal?.();
         dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
         dispatch({ type: 'COMPLETE_STREAMING_TURN' });
         dispatch({ type: 'SET_STREAMING', payload: false });
@@ -138,6 +141,7 @@ export function useStreamingEventHandler(
 
       case 'cancelled':
         console.log('🔥 Stream was cancelled, preserving partial content');
+        deps.onStreamTerminal?.();
         dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
         dispatch({ type: 'COMPLETE_STREAMING_TURN' });
         break;
@@ -261,6 +265,7 @@ export function useStreamingEventHandler(
           // See GuideAntsApi/Services/Conversations/StreamingErrorEnvelope.cs.
           const errorCode = event.data?.code;
 
+          deps.onStreamTerminal?.();
           dispatch({ type: 'SET_STREAMING_ERROR', payload: displayMessage });
           dispatch({ type: 'SET_STREAMING', payload: false });
           dispatch({ type: 'SET_CANCELLING', payload: false });
@@ -331,5 +336,5 @@ export function useStreamingEventHandler(
         }
         break;
     }
-  }, [loadNotebookFiles, showToast, projectId, notebookId, conversationId]);
+  }, [loadNotebookFiles, showToast, projectId, notebookId, conversationId, setCurrentStreamController, deps, state.messages, state.currentTurn, dispatch]);
 }

--- a/src/client/src/services/__tests__/api.projects.conversations.test.ts
+++ b/src/client/src/services/__tests__/api.projects.conversations.test.ts
@@ -399,4 +399,35 @@ describe('api.projects.notebooks.conversations (table-driven)', () => {
       }
     });
   });
+
+  describe('observeConversationEvents', () => {
+    it('parses observer SSE events and calls onComplete on terminal event', async () => {
+      const onEvent = vi.fn();
+      const onComplete = vi.fn();
+      mockFetch.mockResolvedValue(sseResponse([
+        'event: token\n',
+        'data: {"role":"assistant","contentDelta":"Hi"}\n',
+        '\n',
+        'event: complete\n',
+        'data: {}\n',
+        '\n',
+      ]));
+
+      await api.projects.notebooks.conversations.observeConversationEvents(
+        projectId,
+        notebookId,
+        convoId,
+        onEvent,
+        vi.fn(),
+        onComplete,
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/conversations/${convoId}/events`),
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'token' }));
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/client/src/services/api.ts
+++ b/src/client/src/services/api.ts
@@ -1214,6 +1214,107 @@ export const api = {
                         `/projects/${projectId}/notebooks/${notebookId}/conversations/${convoId}/turns/${turnId}/cancel`,
                         { method: 'POST' }
                     ),
+                observeConversationEvents: async (
+                    projectId: string,
+                    notebookId: string,
+                    convoId: string,
+                    onEvent: (event: { type: string; data: any }) => void,
+                    onError: (error: Error) => void,
+                    onComplete: () => void,
+                    abortSignal?: AbortSignal,
+                ) => {
+                    const response = await fetchWithAuth(
+                        `${API_BASE_URL}/projects/${projectId}/notebooks/${notebookId}/conversations/${convoId}/events`,
+                        {
+                            method: 'GET',
+                            headers: {
+                                Accept: 'text/event-stream',
+                            },
+                            signal: abortSignal,
+                        },
+                    );
+
+                    if (!response.ok) {
+                        const errorBody = await response.json().catch(() => null);
+                        const err: any = new Error(`HTTP ${response.status}: ${response.statusText}`);
+                        err.status = response.status;
+                        err.body = errorBody;
+                        throw err;
+                    }
+
+                    if (!response.body) {
+                        throw new Error('No response body for observer streaming');
+                    }
+
+                    const reader = response.body.getReader();
+                    const decoder = new TextDecoder();
+                    let buffer = '';
+                    let currentEventType = '';
+                    let sawTerminalEvent = false;
+
+                    try {
+                        while (true) {
+                            if (abortSignal?.aborted) {
+                                throw new DOMException('Operation was aborted', 'AbortError');
+                            }
+
+                            const { done, value } = await reader.read();
+                            if (done) break;
+
+                            buffer += decoder.decode(value, { stream: true });
+                            const lines = buffer.split('\n');
+                            buffer = lines.pop() || '';
+
+                            for (const line of lines) {
+                                if (abortSignal?.aborted) {
+                                    throw new DOMException('Operation was aborted', 'AbortError');
+                                }
+
+                                if (line.startsWith('event: ')) {
+                                    currentEventType = line.slice(7);
+                                } else if (line.startsWith('data: ')) {
+                                    const eventData = line.slice(6);
+                                    if (eventData === '[DONE]') {
+                                        sawTerminalEvent = true;
+                                        onComplete();
+                                        return;
+                                    }
+
+                                    try {
+                                        const parsed = JSON.parse(eventData);
+                                        const eventType = currentEventType || 'data';
+                                        if (CONVERSATION_STREAM_TERMINAL_EVENT_TYPES.has(eventType)) {
+                                            sawTerminalEvent = true;
+                                        }
+                                        onEvent({ type: eventType, data: parsed });
+                                    } catch (err) {
+                                        console.error('Failed to parse observer SSE data:', err);
+                                    }
+                                } else if (line === '') {
+                                    currentEventType = '';
+                                }
+                            }
+                        }
+
+                        if (!sawTerminalEvent) {
+                            onError(new Error('The observer stream ended without a terminal event.'));
+                            return;
+                        }
+
+                        onComplete();
+                    } catch (err) {
+                        if (err instanceof DOMException && err.name === 'AbortError') {
+                            return;
+                        }
+                        onError(err as Error);
+                    } finally {
+                        try {
+                            reader.releaseLock();
+                        } catch {
+                            // cancel() may already have released the lock
+                        }
+                    }
+                },
                 sendMessageStream: async (
                     projectId: string,
                     notebookId: string,

--- a/src/client/src/types/notebook.ts
+++ b/src/client/src/types/notebook.ts
@@ -297,7 +297,21 @@ export interface ConversationTurnStatusDto {
     terminalizedAt?: string | null;
 }
 
+export interface ConversationLockStatusDto {
+    lockedByUserName: string;
+    lockedAt: string;
+}
+
+export interface ConversationStreamingPreviewDto {
+    messageId: string;
+    content: string;
+    toolCallsJson?: string | null;
+    turnIndex: number;
+}
+
 export interface NotebookConversationWithMessagesDto extends NotebookConversationDto {
   messages: MessageDto[];
   activeTurn?: ConversationTurnStatusDto | null;
+  lock?: ConversationLockStatusDto | null;
+  streamingPreview?: ConversationStreamingPreviewDto | null;
 }

--- a/src/server/AntRunner.Chat/AntRunner.Chat.OpenAI/OpenAiResponsesClient.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.OpenAI/OpenAiResponsesClient.cs
@@ -15,27 +15,34 @@ namespace AntRunner.Chat.OpenAI;
 
 public sealed class OpenAiResponsesClient : IChatCompletionClient
 {
-    private readonly OpenAIClient _client;
+    private readonly OpenAiResponsesStreamingTransport _transport;
     private readonly ILogger<OpenAiResponsesClient> _logger;
+    private readonly string? _defaultDeploymentId;
 
     public bool SupportsToolChoiceNone => false;
 
-    public OpenAiResponsesClient(OpenAIClient client, ILogger<OpenAiResponsesClient>? logger = null)
+    public OpenAiResponsesClient(
+        HttpClient httpClient,
+        AzureOpenAiConfig config,
+        ILogger<OpenAiResponsesClient>? logger = null)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _transport = new OpenAiResponsesStreamingTransport(httpClient, config);
         _logger = logger ?? NullLogger<OpenAiResponsesClient>.Instance;
+        _defaultDeploymentId = config.DeploymentId;
     }
 
     public async Task<ChatCompletionResponse> GetCompletionAsync(
         ChatCompletionRequest request,
         CancellationToken cancellationToken = default)
     {
-        var responseRequest = OpenAiResponsesMapper.ToResponseRequest(request);
-        var response = await _client.ResponsesEndpoint.CreateModelResponseAsync(
+        var responseRequest = OpenAiResponsesMapper.ToResponseRequestWithDefault(
+            request,
+            _defaultDeploymentId);
+        var response = await _transport.CreateAsync(
             responseRequest,
-            _ => Task.CompletedTask,
+            eventHandler: null,
             cancellationToken);
-        return OpenAiResponsesMapper.FromResponseWithLogger(response, _logger);
+        return OpenAiResponsesMapper.FromTerminalResponse(response, _logger);
     }
 
     public async Task<ChatCompletionResponse> StreamCompletionAsync(
@@ -43,22 +50,20 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
         Action<ChatCompletionChunk> onChunk,
         CancellationToken cancellationToken = default)
     {
-        var responseRequest = OpenAiResponsesMapper.ToResponseRequest(request);
+        var responseRequest = OpenAiResponsesMapper.ToResponseRequestWithDefault(
+            request,
+            _defaultDeploymentId);
         var streamHandler = new ResponsesStreamHandler(onChunk);
-        var response = await _client.ResponsesEndpoint.CreateModelResponseAsync(
+        var response = await _transport.CreateAsync(
             responseRequest,
             streamHandler.HandleEventAsync,
             cancellationToken);
-        return OpenAiResponsesMapper.FromResponseWithLogger(response, _logger);
+        return OpenAiResponsesMapper.FromTerminalResponse(response, _logger);
     }
 
     private sealed class ResponsesStreamHandler
     {
         private readonly Action<ChatCompletionChunk>? _onChunk;
-        private int _lastTextLength;
-        private int _lastRefusalLength;
-        private int _lastReasoningSummaryLength;
-        private int _lastReasoningContentLength;
         private string? _lastContentType;
         private bool _hasEmittedContent;
 
@@ -67,40 +72,40 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
             _onChunk = onChunk;
         }
 
-        public Task HandleEventAsync(string @event, IServerSentEvent sseEvent)
+        public Task HandleEventAsync(string @event, JsonElement eventData)
         {
             if (_onChunk == null)
             {
                 return Task.CompletedTask;
             }
 
-            // During streaming, the library sends individual content items (TextContent, ReasoningContent, etc.)
-            // as the IServerSentEvent, not the entire Message. The Delta property contains accumulated text.
-            switch (sseEvent)
+            switch (@event)
             {
-                case ResponseTextContent textContent:
-                    EmitDelta("text", textContent.Delta, ref _lastTextLength);
+                case "response.output_text.delta":
+                    EmitDelta("text", ReadDelta(eventData));
                     break;
-                case ResponseRefusalContent refusalContent:
-                    EmitDelta("refusal", refusalContent.Delta, ref _lastRefusalLength);
+                case "response.refusal.delta":
+                    EmitDelta("refusal", ReadDelta(eventData));
                     break;
-                case ResponseReasoningSummary reasoningSummary:
-                    EmitDelta("reasoning_summary", reasoningSummary.Delta ?? reasoningSummary.Text, ref _lastReasoningSummaryLength, "thinking");
+                case "response.reasoning_summary_text.delta":
+                    EmitDelta("reasoning_summary", ReadDelta(eventData), "thinking");
                     break;
-                case ResponseReasoningContent reasoningContent:
-                    EmitDelta("reasoning_content", reasoningContent.Delta ?? reasoningContent.Text, ref _lastReasoningContentLength, "thinking");
+                case "response.reasoning_text.delta":
+                    EmitDelta("reasoning_content", ReadDelta(eventData), "thinking");
                     break;
-                // FunctionToolCall deltas contain argument chunks, not emitted during streaming
             }
 
             return Task.CompletedTask;
         }
 
-        private void EmitDelta(string contentType, string? accumulatedDelta, ref int lastLength, string? finishReason = null)
+        private static string? ReadDelta(JsonElement eventData) =>
+            eventData.TryGetProperty("delta", out var delta) && delta.ValueKind == JsonValueKind.String
+                ? delta.GetString()
+                : null;
+
+        private void EmitDelta(string contentType, string? delta, string? finishReason = null)
         {
-            // The library accumulates deltas by appending each new piece to the Delta property.
-            // We need to emit only the new portion since the last emission.
-            if (string.IsNullOrEmpty(accumulatedDelta))
+            if (string.IsNullOrEmpty(delta))
             {
                 return;
             }
@@ -112,29 +117,10 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
                 _onChunk?.Invoke(new ChatCompletionChunk([new ChatChoiceDelta(separatorDelta, finishReason)]));
             }
 
-            // Calculate what's new since last time
-            if (accumulatedDelta.Length < lastLength)
-            {
-                // New content item of same type started; emit paragraph break, then reset.
-                if (lastLength > 0)
-                {
-                    var separatorDelta = new ChatDelta(ChatRole.Assistant, "\n\n");
-                    _onChunk?.Invoke(new ChatCompletionChunk([new ChatChoiceDelta(separatorDelta, finishReason)]));
-                }
-                lastLength = 0;
-            }
-            if (accumulatedDelta.Length <= lastLength)
-            {
-                return;
-            }
-
-            var newContent = accumulatedDelta[lastLength..];
-            lastLength = accumulatedDelta.Length;
-
             _lastContentType = contentType;
             _hasEmittedContent = true;
 
-            var chatDelta = new ChatDelta(ChatRole.Assistant, newContent);
+            var chatDelta = new ChatDelta(ChatRole.Assistant, delta);
             _onChunk?.Invoke(new ChatCompletionChunk([new ChatChoiceDelta(chatDelta, finishReason)]));
         }
 
@@ -142,45 +128,89 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
 
     private static class OpenAiResponsesMapper
     {
-        internal static CreateResponseRequest ToResponseRequest(ChatCompletionRequest request)
+        internal static JsonObject ToResponseRequest(ChatCompletionRequest request) =>
+            ToResponseRequestCore(request, defaultDeploymentId: null);
+
+        internal static JsonObject ToResponseRequestWithDefault(
+            ChatCompletionRequest request,
+            string? defaultDeploymentId) =>
+            ToResponseRequestCore(request, defaultDeploymentId);
+
+        private static JsonObject ToResponseRequestCore(
+            ChatCompletionRequest request,
+            string? defaultDeploymentId)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var inputItems = new List<IResponseItem>();
+            var inputItems = new JsonArray();
             foreach (var message in request.Messages)
             {
                 if (message.Role == ChatRole.Tool)
                 {
-                    inputItems.Add(ToToolCallOutput(message));
+                    inputItems.Add(ToJsonToolCallOutput(message));
                     continue;
                 }
 
-                inputItems.Add(ToResponseMessage(message));
+                inputItems.Add(ToJsonMessage(message));
 
                 if (message.ToolCalls is { Count: > 0 })
                 {
                     foreach (var toolCall in message.ToolCalls)
                     {
-                        inputItems.Add(ToToolCall(toolCall));
+                        inputItems.Add(ToJsonToolCall(toolCall));
                     }
                 }
             }
 
-            var tools = request.Tools?.Select(ToOpenAiTool).ToList();
-            var reasoning = MapReasoning(request.Model, request.ReasoningEffort);
-            var (temperature, topP) = ResolveOpenAiSampling(request);
+            var model = request.Model ?? defaultDeploymentId;
+            if (string.IsNullOrWhiteSpace(model))
+            {
+                throw new InvalidOperationException(
+                    "OpenAI Responses requests require a model deployment ID.");
+            }
 
-            var responseRequest = new CreateResponseRequest(
-                input: inputItems,
-                model: request.Model,
-                temperature: temperature,
-                topP: topP,
-                reasoning: reasoning,
-                tools: tools,
-                truncation: Truncation.Disabled);
+            var reasoning = MapReasoning(model, request.ReasoningEffort);
+            var (temperature, topP) = ResolveOpenAiSampling(request);
+            var responseRequest = new JsonObject
+            {
+                ["input"] = inputItems,
+                ["model"] = model,
+                ["store"] = false,
+                ["truncation"] = "disabled"
+            };
+
+            if (temperature.HasValue)
+            {
+                responseRequest["temperature"] = temperature.Value;
+            }
+
+            if (topP.HasValue)
+            {
+                responseRequest["top_p"] = topP.Value;
+            }
+
+            if (reasoning != null)
+            {
+                responseRequest["reasoning"] = new JsonObject
+                {
+                    ["effort"] = reasoning.Effort.ToString().ToLowerInvariant(),
+                    ["summary"] = "detailed"
+                };
+            }
+
+            if (request.Tools is { Count: > 0 })
+            {
+                var tools = new JsonArray();
+                foreach (var tool in request.Tools)
+                {
+                    tools.Add(ToJsonTool(tool));
+                }
+
+                responseRequest["tools"] = tools;
+            }
 
             return responseRequest;
         }
@@ -216,7 +246,8 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
             if (unprojectedKeys is { Count: > 0 })
             {
                 throw new InvalidOperationException(
-                    $"Unable to project sampling parameter(s) [{string.Join(", ", unprojectedKeys)}] to OpenAI Responses request fields.");
+                    $"Unable to project sampling parameter(s) [{string.Join(", ", unprojectedKeys)}] " +
+                    "to OpenAI Responses request fields.");
             }
 
             return (temperature, topP);
@@ -230,6 +261,60 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
         internal static ChatCompletionResponse FromResponseWithLogger(Response response, ILogger logger)
         {
             return FromResponseCore(response, logger ?? NullLogger<OpenAiResponsesClient>.Instance);
+        }
+
+        internal static ChatCompletionResponse FromTerminalResponse(JsonElement response, ILogger logger)
+        {
+            if (response.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException(
+                    "Responses API response.completed payload must contain a JSON object.");
+            }
+
+            var content = new List<ChatContent>();
+            var toolCalls = new List<ChatToolCall>();
+            var reasoningSummaries = new List<string>();
+
+            if (!response.TryGetProperty("output", out var output) ||
+                output.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidOperationException(
+                    "Responses API response.completed payload did not contain an output array.");
+            }
+
+            foreach (var item in output.EnumerateArray())
+            {
+                var type = ReadOptionalString(item, "type");
+                switch (type)
+                {
+                    case "message" when string.Equals(
+                        ReadOptionalString(item, "role"),
+                        "assistant",
+                        StringComparison.Ordinal):
+                        AppendJsonMessageContent(item, content, reasoningSummaries, logger);
+                        break;
+                    case "function_call":
+                        toolCalls.Add(FromJsonToolCall(item));
+                        break;
+                    case "reasoning":
+                        AppendJsonReasoningItem(item, reasoningSummaries);
+                        break;
+                    case "function_call_output":
+                        logger.LogWarning("OpenAI Responses returned tool outputs in the output list.");
+                        break;
+                    default:
+                        logger.LogWarning("Unsupported OpenAI response item type: {ResponseItemType}", type);
+                        break;
+                }
+            }
+
+            var thinkingBlocks = BuildThinkingBlocks(reasoningSummaries);
+            var assistantMessage = BuildAssistantMessage(content, toolCalls, thinkingBlocks);
+            var finishReason = toolCalls.Count > 0 ? "tool_calls" : "stop";
+
+            return new ChatCompletionResponse(
+                [new ChatChoice(assistantMessage, finishReason)],
+                MapJsonUsage(response));
         }
 
         private static ChatCompletionResponse FromResponseCore(Response response, ILogger logger)
@@ -274,49 +359,322 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
                 MapUsage(response.Usage));
         }
 
-        private static Message ToResponseMessage(ChatMessage message)
+        private static void AppendJsonMessageContent(
+            JsonElement message,
+            List<ChatContent> output,
+            List<string> reasoningSummaries,
+            ILogger logger)
         {
-            var role = MapRole(message.Role);
-            var content = ToResponseContent(message.Content, message.Role);
-            return new Message(role, content);
+            if (!message.TryGetProperty("content", out var contents) ||
+                contents.ValueKind != JsonValueKind.Array)
+            {
+                return;
+            }
+
+            foreach (var content in contents.EnumerateArray())
+            {
+                var type = ReadOptionalString(content, "type");
+                switch (type)
+                {
+                    case "output_text":
+                        AppendTextContent(output, ReadOptionalString(content, "text"), null);
+                        break;
+                    case "refusal":
+                        AppendTextContent(output, ReadOptionalString(content, "refusal"), null);
+                        break;
+                    case "reasoning_text":
+                        AppendReasoningText(reasoningSummaries, ReadOptionalString(content, "text"));
+                        break;
+                    case "output_image":
+                        AppendJsonImageContent(content, output, logger);
+                        break;
+                    default:
+                        logger.LogWarning(
+                            "Unsupported OpenAI response content type: {ResponseContentType}",
+                            type);
+                        break;
+                }
+            }
         }
 
-        private static IResponseItem ToToolCall(ChatToolCall toolCall)
+        private static void AppendJsonImageContent(
+            JsonElement content,
+            List<ChatContent> output,
+            ILogger logger)
         {
-            var arguments = ParseArguments(toolCall.Function.Arguments);
-            return new FunctionToolCall(toolCall.Id, toolCall.Function.Name, arguments);
+            var imageUrl = ReadOptionalString(content, "image_url");
+            if (!string.IsNullOrWhiteSpace(imageUrl))
+            {
+                output.Add(new ChatContent(new ChatImageUrl(imageUrl)));
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(ReadOptionalString(content, "file_id")))
+            {
+                logger.LogWarning("OpenAI Responses returned image content with FileId only.");
+            }
         }
 
-        private static IResponseItem ToToolCallOutput(ChatMessage message)
+        private static ChatToolCall FromJsonToolCall(JsonElement item)
+        {
+            var id = ReadOptionalString(item, "call_id");
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                id = ReadOptionalString(item, "id");
+            }
+
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new InvalidOperationException(
+                    "Responses API function_call output did not include call_id or id.");
+            }
+
+            var name = ReadOptionalString(item, "name");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new InvalidOperationException(
+                    "Responses API function_call output did not include a function name.");
+            }
+
+            if (!item.TryGetProperty("arguments", out var arguments))
+            {
+                throw new InvalidOperationException(
+                    "Responses API function_call output did not include arguments.");
+            }
+
+            var parsedArguments = ParseJsonToolArguments(arguments);
+            return new ChatToolCall
+            {
+                Id = id,
+                Type = "function",
+                Function = new ChatToolCallFunction
+                {
+                    Name = name,
+                    Arguments = parsedArguments
+                }
+            };
+        }
+
+        private static JsonElement ParseJsonToolArguments(JsonElement arguments)
+        {
+            if (arguments.ValueKind == JsonValueKind.Object)
+            {
+                return arguments.Clone();
+            }
+
+            if (arguments.ValueKind != JsonValueKind.String)
+            {
+                throw new InvalidOperationException(
+                    "Responses API function_call arguments must be a JSON string or object.");
+            }
+
+            var argumentsJson = arguments.GetString();
+            if (string.IsNullOrWhiteSpace(argumentsJson))
+            {
+                throw new InvalidOperationException(
+                    "Responses API function_call arguments were empty.");
+            }
+
+            using var document = JsonDocument.Parse(argumentsJson);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException(
+                    "Responses API function_call arguments must contain a JSON object.");
+            }
+
+            return document.RootElement.Clone();
+        }
+
+        private static void AppendJsonReasoningItem(
+            JsonElement item,
+            List<string> reasoningSummaries)
+        {
+            if (AppendJsonTextArray(item, "summary", reasoningSummaries))
+            {
+                return;
+            }
+
+            AppendJsonTextArray(item, "content", reasoningSummaries);
+        }
+
+        private static bool AppendJsonTextArray(
+            JsonElement item,
+            string propertyName,
+            List<string> output)
+        {
+            if (!item.TryGetProperty(propertyName, out var values) ||
+                values.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            foreach (var value in values.EnumerateArray())
+            {
+                AppendReasoningText(output, ReadOptionalString(value, "text"));
+            }
+
+            return values.GetArrayLength() > 0;
+        }
+
+        private static void AppendReasoningText(List<string> output, string? text)
+        {
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                output.Add(text);
+            }
+        }
+
+        private static ChatCompletionUsage? MapJsonUsage(JsonElement response)
+        {
+            if (!response.TryGetProperty("usage", out var usage) ||
+                usage.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+
+            if (usage.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException(
+                    "Responses API usage value must be an object or null.");
+            }
+
+            return new ChatCompletionUsage
+            {
+                PromptTokens = ReadOptionalInt32(usage, "input_tokens"),
+                CompletionTokens = ReadOptionalInt32(usage, "output_tokens"),
+                TotalTokens = ReadOptionalInt32(usage, "total_tokens"),
+                PromptTokensDetails = MapJsonInputTokenDetails(usage)
+            };
+        }
+
+        private static ChatPromptTokensDetails? MapJsonInputTokenDetails(JsonElement usage)
+        {
+            JsonElement details;
+            if (!usage.TryGetProperty("input_tokens_details", out details) &&
+                !usage.TryGetProperty("input_token_details", out details))
+            {
+                return null;
+            }
+
+            if (details.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            return new ChatPromptTokensDetails
+            {
+                CachedTokens = ReadOptionalInt32(details, "cached_tokens")
+            };
+        }
+
+        private static int ReadOptionalInt32(JsonElement element, string propertyName) =>
+            element.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.Number &&
+            property.TryGetInt32(out var value)
+                ? value
+                : 0;
+
+        private static string? ReadOptionalString(JsonElement element, string propertyName) =>
+            element.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.String
+                ? property.GetString()
+                : null;
+
+        private static JsonObject ToJsonMessage(ChatMessage message)
+        {
+            var contentType = message.Role == ChatRole.Assistant ? "output_text" : "input_text";
+            var contents = new JsonArray();
+            foreach (var content in message.Content)
+            {
+                if (content.ImageUrl != null)
+                {
+                    contents.Add(new JsonObject
+                    {
+                        ["type"] = "input_image",
+                        ["image_url"] = content.ImageUrl.Url,
+                        ["detail"] = "auto"
+                    });
+                    continue;
+                }
+
+                contents.Add(new JsonObject
+                {
+                    ["type"] = contentType,
+                    ["text"] = content.Text ?? string.Empty
+                });
+            }
+
+            return new JsonObject
+            {
+                ["role"] = ToJsonRole(message.Role),
+                ["content"] = contents
+            };
+        }
+
+        private static JsonObject ToJsonToolCall(ChatToolCall toolCall)
+        {
+            if (string.IsNullOrWhiteSpace(toolCall.Id))
+            {
+                throw new InvalidOperationException("Assistant tool calls must include an ID.");
+            }
+
+            if (string.IsNullOrWhiteSpace(toolCall.Function.Name))
+            {
+                throw new InvalidOperationException("Assistant tool calls must include a function name.");
+            }
+
+            var arguments = toolCall.Function.Arguments.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null
+                ? "{}"
+                : toolCall.Function.Arguments.GetRawText();
+
+            return new JsonObject
+            {
+                ["type"] = "function_call",
+                ["call_id"] = toolCall.Id,
+                ["name"] = toolCall.Function.Name,
+                ["arguments"] = arguments
+            };
+        }
+
+        private static JsonObject ToJsonToolCallOutput(ChatMessage message)
         {
             if (string.IsNullOrWhiteSpace(message.ToolCallId))
             {
                 throw new InvalidOperationException("Tool response messages must include ToolCallId.");
             }
 
-            var output = message.GetText();
-            return new FunctionToolCallOutput(message.ToolCallId, output);
+            return new JsonObject
+            {
+                ["type"] = "function_call_output",
+                ["call_id"] = message.ToolCallId,
+                ["output"] = message.GetText()
+            };
         }
 
-        private static IReadOnlyList<IResponseContent> ToResponseContent(IReadOnlyList<ChatContent> contents, ChatRole role)
+        private static JsonObject ToJsonTool(ChatToolDefinition tool)
         {
-            var list = new List<IResponseContent>();
-            var contentType = role == ChatRole.Assistant
-                ? ResponseContentType.OutputText
-                : ResponseContentType.InputText;
-
-            foreach (var content in contents)
+            if (tool.Function == null)
             {
-                if (content.ImageUrl != null)
-                {
-                    list.Add(new ResponseImageContent(content.ImageUrl.Url, null, ImageDetail.Auto));
-                    continue;
-                }
-
-                list.Add(new ResponseTextContent(content.Text ?? string.Empty, contentType));
+                throw new InvalidOperationException("Function tool definition is required.");
             }
 
-            return list;
+            var function = tool.Function;
+            var json = new JsonObject
+            {
+                ["type"] = "function",
+                ["name"] = function.Name
+            };
+            if (!string.IsNullOrWhiteSpace(function.Description))
+            {
+                json["description"] = function.Description;
+            }
+
+            if (function.Parameters != null)
+            {
+                json["parameters"] = JsonNode.Parse(function.Parameters.ToJsonString());
+            }
+
+            return json;
         }
 
         private static void AppendMessageContent(
@@ -355,7 +713,9 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
                         }
                         break;
                     default:
-                        logger.LogWarning("Unsupported OpenAI response content: {ResponseContentType}", content.GetType().Name);
+                        logger.LogWarning(
+                            "Unsupported OpenAI response content: {ResponseContentType}",
+                            content.GetType().Name);
                         break;
                 }
             }
@@ -453,17 +813,6 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
             };
         }
 
-        private static JsonNode ParseArguments(JsonElement arguments)
-        {
-            if (arguments.ValueKind == JsonValueKind.Undefined || arguments.ValueKind == JsonValueKind.Null)
-            {
-                return JsonNode.Parse("{}")!;
-            }
-
-            var json = arguments.GetRawText();
-            return JsonNode.Parse(json) ?? JsonNode.Parse("{}")!;
-        }
-
         private static ChatCompletionUsage? MapUsage(TokenUsage? usage)
         {
             if (usage == null)
@@ -482,19 +831,6 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
             };
         }
 
-        private static Tool ToOpenAiTool(ChatToolDefinition tool)
-        {
-            if (tool.Function == null)
-            {
-                throw new InvalidOperationException("Function tool definition is required.");
-            }
-
-            var function = tool.Function;
-            JsonNode? parameters = function.Parameters;
-            var openAiFunction = new Function(function.Name, function.Description, parameters, null);
-            return new Tool(openAiFunction);
-        }
-
         private static Reasoning? MapReasoning(string? model, string? effort)
         {
             var mapped = OpenAiReasoningSupport.MapReasoningEffort(model, effort);
@@ -508,14 +844,14 @@ public sealed class OpenAiResponsesClient : IChatCompletionClient
                 global::OpenAI.ReasoningSummary.Detailed);
         }
 
-        private static Role MapRole(ChatRole role) => role switch
+        private static string ToJsonRole(ChatRole role) => role switch
         {
-            ChatRole.System => Role.System,
-            ChatRole.Developer => Role.Developer,
-            ChatRole.User => Role.User,
-            ChatRole.Assistant => Role.Assistant,
-            ChatRole.Tool => Role.Tool,
-            _ => Role.User
+            ChatRole.System => "system",
+            ChatRole.Developer => "developer",
+            ChatRole.User => "user",
+            ChatRole.Assistant => "assistant",
+            ChatRole.Tool => "tool",
+            _ => throw new InvalidOperationException($"Unsupported chat role '{role}'.")
         };
     }
 }

--- a/src/server/AntRunner.Chat/AntRunner.Chat.OpenAI/OpenAiResponsesClientFactory.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.OpenAI/OpenAiResponsesClientFactory.cs
@@ -1,8 +1,6 @@
-using System.Collections.Concurrent;
 using AntRunner.Chat.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using OpenAI;
 
 namespace AntRunner.Chat.OpenAI;
 
@@ -12,8 +10,6 @@ public sealed class OpenAiResponsesClientFactory : IChatCompletionClientFactory
     private readonly Func<AzureOpenAiConfig>? _configAccessor;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<OpenAiResponsesClient> _clientLogger;
-    private readonly ConcurrentDictionary<string, OpenAIClient> _clientCache = new();
-    private string? _activeSignature;
 
     public OpenAiResponsesClientFactory(
         IHttpClientFactory httpClientFactory,
@@ -32,33 +28,13 @@ public sealed class OpenAiResponsesClientFactory : IChatCompletionClientFactory
 
     public IChatCompletionClient CreateClient(string? deploymentId, HttpClient? httpClient = null)
     {
-        var client = GetOrCreateOpenAiClient(deploymentId, httpClient);
-        return new OpenAiResponsesClient(client, _clientLogger);
-    }
-
-    private OpenAIClient GetOrCreateOpenAiClient(string? deploymentId, HttpClient? overrideClient)
-    {
         var config = GetCurrentConfig();
-        EnsureCacheSignature(config);
-
-        if (overrideClient != null)
+        var effectiveConfig = config with
         {
-            return CreateClientInstance(config, deploymentId, overrideClient);
-        }
-
-        var key = $"{BuildSignature(config)}:{deploymentId ?? string.Empty}";
-        return _clientCache.GetOrAdd(key, _ =>
-        {
-            var client = _httpClientFactory.CreateClient();
-            return CreateClientInstance(config, deploymentId, client);
-        });
-    }
-
-    private OpenAIClient CreateClientInstance(AzureOpenAiConfig config, string? deploymentId, HttpClient httpClient)
-    {
-        var auth = new OpenAIAuthentication(config.ApiKey);
-        var settings = OpenAiClientSettingsFactory.Create(config, deploymentId);
-        return new OpenAIClient(auth, settings, httpClient);
+            DeploymentId = deploymentId ?? config.DeploymentId
+        };
+        var effectiveHttpClient = httpClient ?? _httpClientFactory.CreateClient();
+        return new OpenAiResponsesClient(effectiveHttpClient, effectiveConfig, _clientLogger);
     }
 
     private AzureOpenAiConfig GetCurrentConfig()
@@ -66,22 +42,5 @@ public sealed class OpenAiResponsesClientFactory : IChatCompletionClientFactory
         return _configAccessor?.Invoke()
             ?? _config
             ?? throw new InvalidOperationException("OpenAI configuration is required.");
-    }
-
-    private void EnsureCacheSignature(AzureOpenAiConfig config)
-    {
-        var signature = BuildSignature(config);
-        if (string.Equals(signature, _activeSignature, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        _clientCache.Clear();
-        _activeSignature = signature;
-    }
-
-    private static string BuildSignature(AzureOpenAiConfig config)
-    {
-        return $"{config.ApiKey}:{config.ResourceName}:{config.ApiVersion}:{config.DeploymentId}";
     }
 }

--- a/src/server/AntRunner.Chat/AntRunner.Chat.OpenAI/OpenAiResponsesStreamingTransport.cs
+++ b/src/server/AntRunner.Chat/AntRunner.Chat.OpenAI/OpenAiResponsesStreamingTransport.cs
@@ -1,0 +1,231 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace AntRunner.Chat.OpenAI;
+
+/// <summary>
+/// Sends stateless Responses API requests and treats the terminal SSE event as authoritative.
+/// GuideAnts owns conversation state, so this transport never retrieves or chains provider responses.
+/// </summary>
+internal sealed class OpenAiResponsesStreamingTransport
+{
+    private readonly HttpClient _httpClient;
+    private readonly AzureOpenAiConfig _config;
+
+    public OpenAiResponsesStreamingTransport(HttpClient httpClient, AzureOpenAiConfig config)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+    }
+
+    public async Task<JsonElement> CreateAsync(
+        JsonObject request,
+        Func<string, JsonElement, Task>? eventHandler,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, BuildResponsesUri());
+        AddAuthentication(requestMessage);
+        requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+        requestMessage.Content = CreateRequestContent(request);
+
+        using var response = await _httpClient.SendAsync(
+            requestMessage,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new HttpRequestException(
+                $"Responses API POST failed with HTTP {(int)response.StatusCode} ({response.StatusCode}). " +
+                $"Response body: {responseBody}",
+                null,
+                response.StatusCode);
+        }
+
+        await using var responseStream = await response.Content
+            .ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        using var reader = new StreamReader(responseStream);
+
+        string? eventName = null;
+        var data = new StringBuilder();
+        JsonElement? terminalResponse = null;
+
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
+        {
+            if (line.Length == 0)
+            {
+                terminalResponse = await ProcessEventAsync(
+                    eventName,
+                    data,
+                    terminalResponse,
+                    eventHandler).ConfigureAwait(false);
+                eventName = null;
+                data.Clear();
+                continue;
+            }
+
+            if (line.StartsWith(':'))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("event:", StringComparison.Ordinal))
+            {
+                eventName = line["event:".Length..].TrimStart();
+                continue;
+            }
+
+            if (line.StartsWith("data:", StringComparison.Ordinal))
+            {
+                if (data.Length > 0)
+                {
+                    data.Append('\n');
+                }
+
+                data.Append(line["data:".Length..].TrimStart());
+            }
+        }
+
+        if (data.Length > 0)
+        {
+            terminalResponse = await ProcessEventAsync(
+                eventName,
+                data,
+                terminalResponse,
+                eventHandler).ConfigureAwait(false);
+        }
+
+        return terminalResponse
+            ?? throw new InvalidOperationException(
+                "Responses API stream ended without a terminal response.completed event.");
+    }
+
+    private static StringContent CreateRequestContent(JsonObject request)
+    {
+        var payloadObject = JsonNode.Parse(request.ToJsonString())?.AsObject()
+            ?? throw new InvalidOperationException("Unable to clone the Responses API request.");
+
+        // GuideAnts replays its own SQL transcript. Provider-side response persistence and chaining
+        // are deliberately disabled, while streaming is required for live progress and tool calls.
+        payloadObject["store"] = false;
+        payloadObject["stream"] = true;
+        payloadObject.Remove("previous_response_id");
+
+        return new StringContent(
+            payloadObject.ToJsonString(),
+            Encoding.UTF8,
+            new MediaTypeHeaderValue("application/json"));
+    }
+
+    private Uri BuildResponsesUri()
+    {
+        if (string.IsNullOrWhiteSpace(_config.ResourceName))
+        {
+            return new Uri("https://api.openai.com/v1/responses", UriKind.Absolute);
+        }
+
+        if (string.IsNullOrWhiteSpace(_config.ApiVersion))
+        {
+            throw new InvalidOperationException(
+                "Azure OpenAI Responses configuration requires an API version.");
+        }
+
+        var resourceName = _config.ResourceName.Trim();
+        if (resourceName.Contains('/') || resourceName.Contains('\\'))
+        {
+            throw new InvalidOperationException(
+                "Azure OpenAI ResourceName must be the resource name, not a URL.");
+        }
+
+        var apiVersion = Uri.EscapeDataString(_config.ApiVersion.Trim());
+        return new Uri(
+            $"https://{resourceName}.openai.azure.com/openai/responses?api-version={apiVersion}",
+            UriKind.Absolute);
+    }
+
+    private void AddAuthentication(HttpRequestMessage request)
+    {
+        if (string.IsNullOrWhiteSpace(_config.ApiKey))
+        {
+            throw new InvalidOperationException("OpenAI Responses configuration requires an API key.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_config.ResourceName))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.ApiKey);
+            return;
+        }
+
+        request.Headers.TryAddWithoutValidation("api-key", _config.ApiKey);
+    }
+
+    private static async Task<JsonElement?> ProcessEventAsync(
+        string? eventName,
+        StringBuilder data,
+        JsonElement? terminalResponse,
+        Func<string, JsonElement, Task>? eventHandler)
+    {
+        if (data.Length == 0 || string.Equals(data.ToString(), "[DONE]", StringComparison.Ordinal))
+        {
+            return terminalResponse;
+        }
+
+        using var document = JsonDocument.Parse(data.ToString());
+        var eventData = document.RootElement;
+        var resolvedEventName = !string.IsNullOrWhiteSpace(eventName)
+            ? eventName
+            : ReadOptionalString(eventData, "type");
+
+        if (string.IsNullOrWhiteSpace(resolvedEventName))
+        {
+            throw new InvalidOperationException("Responses API SSE event did not include an event type.");
+        }
+
+        if (eventHandler != null)
+        {
+            await eventHandler(resolvedEventName, eventData).ConfigureAwait(false);
+        }
+
+        switch (resolvedEventName)
+        {
+            case "response.completed":
+                return ReadRequiredResponse(eventData).Clone();
+
+            case "response.failed":
+            case "response.incomplete":
+                throw new InvalidOperationException(
+                    $"Responses API returned terminal event '{resolvedEventName}': {eventData.GetRawText()}");
+
+            case "error":
+                throw new InvalidOperationException(
+                    $"Responses API stream returned an error event: {eventData.GetRawText()}");
+
+            default:
+                return terminalResponse;
+        }
+    }
+
+    private static JsonElement ReadRequiredResponse(JsonElement eventData)
+    {
+        if (eventData.TryGetProperty("response", out var response) &&
+            response.ValueKind == JsonValueKind.Object)
+        {
+            return response;
+        }
+
+        throw new InvalidOperationException(
+            "Responses API terminal event did not contain a response object.");
+    }
+
+    private static string? ReadOptionalString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var property) &&
+        property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+}

--- a/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationAssistantSwitchingTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationAssistantSwitchingTests.cs
@@ -67,7 +67,13 @@ public class NotebookConversationAssistantSwitchingTests
         public Task EditMessageAsync(Guid messageId, string newContent) => throw new NotImplementedException();
         public Task<bool> CancelTurnStreamAsync(Guid conversationId, Guid turnId) => Task.FromResult(false);
 
-
+        public async IAsyncEnumerable<StreamingEvent> ObserveConversationEventsAsync(
+            Guid conversationId,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
 
         public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(
             Guid conversationId, 

--- a/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationStreamingEndpointsTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationStreamingEndpointsTests.cs
@@ -45,8 +45,14 @@ public class NotebookConversationStreamingEndpointsTests
         public Task EditMessageAsync(Guid messageId, string newContent) => throw new NotImplementedException();
         public Task<bool> CancelTurnStreamAsync(Guid conversationId, Guid turnId) => Task.FromResult(false);
 
+        public async IAsyncEnumerable<StreamingEvent> ObserveConversationEventsAsync(
+            Guid conversationId,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
 
-        
         public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             yield return new StreamingEvent("token", JsonSerializer.Serialize(new { role = "assistant", contentDelta = "Hel" }));
@@ -102,6 +108,15 @@ public class NotebookConversationStreamingEndpointsTests
         public Task DeleteConversationAsync(Guid conversationId) => throw new NotImplementedException();
         public Task EditMessageAsync(Guid messageId, string newContent) => throw new NotImplementedException();
         public Task<bool> CancelTurnStreamAsync(Guid conversationId, Guid turnId) => Task.FromResult(false);
+
+        public async IAsyncEnumerable<StreamingEvent> ObserveConversationEventsAsync(
+            Guid conversationId,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
         public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await Task.Yield();

--- a/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationStreamingToolCallsTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationStreamingToolCallsTests.cs
@@ -44,8 +44,14 @@ public class NotebookConversationStreamingToolCallsTests
         public Task EditMessageAsync(Guid messageId, string newContent) => throw new NotImplementedException();
         public Task<bool> CancelTurnStreamAsync(Guid conversationId, Guid turnId) => Task.FromResult(false);
 
+        public async IAsyncEnumerable<StreamingEvent> ObserveConversationEventsAsync(
+            Guid conversationId,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
 
-        
         public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             // Simulate the complete flow with tool calls
@@ -327,6 +333,15 @@ public class NotebookConversationStreamingToolCallsTests
         public Task DeleteConversationAsync(Guid conversationId) => throw new NotImplementedException();
         public Task EditMessageAsync(Guid messageId, string newContent) => throw new NotImplementedException();
         public Task<bool> CancelTurnStreamAsync(Guid conversationId, Guid turnId) => Task.FromResult(false);
+
+        public async IAsyncEnumerable<StreamingEvent> ObserveConversationEventsAsync(
+            Guid conversationId,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
         public Task UndoLastForConversationAsync(Guid conversationId) => throw new NotImplementedException();
         public Task UndoForConversationAsync(Guid conversationId, Guid messageId) => throw new NotImplementedException();
         public Task<PagedUserConversationsDto> GetUserConversationsAsync(UserConversationsQuery query)

--- a/src/server/GuideAntsApi.IntegrationTests/Services/Conversations/ConversationServiceIntegrationTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Services/Conversations/ConversationServiceIntegrationTests.cs
@@ -12,6 +12,7 @@ using GuideAntsApi.Models.Conversations;
 using GuideAntsApi.Services.Components;
 using GuideAntsApi.Services.Conversations;
 using GuideAntsApi.Services.Conversations.Mapping;
+using GuideAntsApi.Services.Conversations.Streaming;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using DataModelChatRole = GuideAntsApi.DataModel.Models.ChatRole;
@@ -57,6 +58,26 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
             .Select(t => t.Status)
             .SingleAsync();
         finalStatus.Should().Be(expectedStatus);
+    }
+
+    private static async Task WaitForLockReleasedAsync(
+        ApplicationDbContext db,
+        Guid conversationId,
+        TimeSpan? timeout = null)
+    {
+        var waitTimeout = timeout ?? TimeSpan.FromSeconds(10);
+        var deadline = DateTime.UtcNow + waitTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!await db.ConversationLocks.AnyAsync(l => l.ConversationId == conversationId))
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        (await db.ConversationLocks.AnyAsync(l => l.ConversationId == conversationId)).Should().BeFalse();
     }
 
     [ClassInitialize]
@@ -334,6 +355,128 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
         catch (IOException) when (cancellationToken.IsCancellationRequested)
         {
             // The test host aborts the response body when the client cancels mid-stream.
+        }
+
+        return events;
+    }
+
+    private static async Task<Guid> GetActiveTurnIdAsync(ApplicationDbContext db, Guid conversationId) =>
+        (await db.ConversationTurns
+            .AsNoTracking()
+            .Where(t => t.NotebookConversationId == conversationId)
+            .SingleAsync()).Id;
+
+    private async Task RequestTurnCancelAsync(Guid turnId)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(8);
+        while (DateTime.UtcNow < deadline)
+        {
+            using var scope = SharedFactory!.Services.CreateScope();
+            var registry = scope.ServiceProvider.GetRequiredService<ConversationStreamRunRegistry>();
+            if (registry.RequestCancel(turnId))
+            {
+                return;
+            }
+
+            await Task.Delay(50);
+        }
+
+        Assert.Fail($"Turn {turnId} was not active for cancellation");
+    }
+
+    private async Task CancelTurnViaApiAsync(
+        Guid projectId,
+        Guid notebookId,
+        Guid conversationId,
+        Guid turnId)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(8);
+        while (DateTime.UtcNow < deadline)
+        {
+            using (var scope = SharedFactory!.Services.CreateScope())
+            {
+                var registry = scope.ServiceProvider.GetRequiredService<ConversationStreamRunRegistry>();
+                if (!registry.IsActive(turnId))
+                {
+                    await Task.Delay(50);
+                    continue;
+                }
+            }
+
+            var resp = await Client.PostAsync(
+                $"/api/projects/{projectId}/notebooks/{notebookId}/conversations/{conversationId}/turns/{turnId}/cancel",
+                null);
+            if (resp.StatusCode == HttpStatusCode.NotFound)
+            {
+                await Task.Delay(50);
+                continue;
+            }
+
+            resp.EnsureSuccessStatusCode();
+            return;
+        }
+
+        Assert.Fail($"Turn {turnId} was not active for cancellation");
+    }
+
+    private async Task<HttpStatusCode> SendConversationStreamStatusAsync(
+        Guid projectId,
+        Guid notebookId,
+        Guid conversationId,
+        object requestBody)
+    {
+        using var req = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/api/projects/{projectId}/notebooks/{notebookId}/conversations/{conversationId}/messages")
+        {
+            Content = JsonContent.Create(requestBody)
+        };
+        req.Headers.Accept.Clear();
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        using var resp = await Client.SendAsync(req);
+        return resp.StatusCode;
+    }
+
+    private async Task<List<(string EventType, string Payload)>> ObserveConversationEventsCollectAsync(
+        Guid projectId,
+        Guid notebookId,
+        Guid conversationId,
+        CancellationToken cancellationToken)
+    {
+        using var req = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/api/projects/{projectId}/notebooks/{notebookId}/conversations/{conversationId}/events");
+        req.Headers.Accept.Clear();
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        using var resp = await Client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        resp.EnsureSuccessStatusCode();
+
+        var events = new List<(string EventType, string Payload)>();
+        await using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        string? currentEvent = null;
+        while (!reader.EndOfStream)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var line = await reader.ReadLineAsync(cancellationToken);
+            if (line == null)
+            {
+                break;
+            }
+
+            if (line.StartsWith("event:", StringComparison.Ordinal))
+            {
+                currentEvent = line["event:".Length..].Trim();
+                continue;
+            }
+
+            if (line.StartsWith("data:", StringComparison.Ordinal) && currentEvent != null)
+            {
+                events.Add((currentEvent, line["data:".Length..].Trim()));
+            }
         }
 
         return events;
@@ -856,11 +999,30 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
             // expected when the HTTP stream is aborted
         }
 
+        Guid turnId;
+        using (var midScope = SharedFactory!.Services.CreateScope())
+        {
+            var midDb = midScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var registry = midScope.ServiceProvider.GetRequiredService<ConversationStreamRunRegistry>();
+            turnId = await GetActiveTurnIdAsync(midDb, conversationId);
+
+            (await midDb.ConversationTurns
+                .AsNoTracking()
+                .Where(t => t.Id == turnId)
+                .Select(t => t.Status)
+                .SingleAsync()).Should().Be("streaming");
+            (await midDb.ConversationLocks.AnyAsync(l => l.ConversationId == conversationId)).Should().BeTrue();
+            registry.IsActive(turnId).Should().BeTrue();
+        }
+
+        await RequestTurnCancelAsync(turnId);
+
         using (var verifyScope = SharedFactory!.Services.CreateScope())
         {
             var db2 = verifyScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
             await WaitForTurnStatusAsync(db2, conversationId, "cancelled");
+            await WaitForLockReleasedAsync(db2, conversationId);
 
             var turn = await db2.ConversationTurns.SingleAsync(t => t.NotebookConversationId == conversationId);
 
@@ -893,6 +1055,7 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
         using var pruneCts = new CancellationTokenSource();
         FakeChatCompletionBehavior.Instance.Reset();
         FakeChatCompletionBehavior.Instance.Scenario = FakeChatScenario.ToolCallsCancelBeforeExecution;
+        Guid pruneTurnId = Guid.Empty;
         FakeChatCompletionBehavior.Instance.OnToolCallsReturning = () => pruneCts.Cancel();
 
         try
@@ -906,8 +1069,21 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
         }
         catch (OperationCanceledException)
         {
-            // expected when tool execution is cancelled before results are persisted
+            // expected when the HTTP stream is aborted
         }
+
+        using (var pruneMidScope = SharedFactory!.Services.CreateScope())
+        {
+            var pruneMidDb = pruneMidScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            pruneTurnId = await GetActiveTurnIdAsync(pruneMidDb, pruneConversationId);
+            (await pruneMidDb.ConversationTurns
+                .AsNoTracking()
+                .Where(t => t.Id == pruneTurnId)
+                .Select(t => t.Status)
+                .SingleAsync()).Should().Be("streaming");
+        }
+
+        await CancelTurnViaApiAsync(projectId, notebookId, pruneConversationId, pruneTurnId);
 
         using (var pruneVerifyScope = SharedFactory!.Services.CreateScope())
         {
@@ -999,7 +1175,7 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
         FakeChatCompletionBehavior.Instance.FinalAssistantText = "should not be persisted";
 
         using var cts = new CancellationTokenSource();
-        cts.CancelAfter(TimeSpan.FromMilliseconds(80));
+        cts.CancelAfter(TimeSpan.FromMilliseconds(120));
         try
         {
             await SendConversationStreamUntilCancelledAsync(
@@ -1014,10 +1190,20 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
             // expected when the HTTP stream is aborted
         }
 
+        Guid turnId;
+        using (var midScope = SharedFactory!.Services.CreateScope())
+        {
+            var midDb = midScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            turnId = await GetActiveTurnIdAsync(midDb, conversationId);
+        }
+
+        await RequestTurnCancelAsync(turnId);
+
         using var verifyScope = SharedFactory!.Services.CreateScope();
         var db2 = verifyScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
         await WaitForTurnStatusAsync(db2, conversationId, "cancelled");
+        await WaitForLockReleasedAsync(db2, conversationId);
 
         var turn = await db2.ConversationTurns.SingleAsync(t => t.NotebookConversationId == conversationId);
         turn.ChatRunOutputJson.Should().NotBeNullOrWhiteSpace();
@@ -1324,7 +1510,15 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
 
         sawHeartbeat.Should().BeTrue("thinking-only stream should checkpoint before terminalization");
 
+        Guid turnId;
+        using (var midScope = SharedFactory!.Services.CreateScope())
+        {
+            var midDb = midScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            turnId = await GetActiveTurnIdAsync(midDb, conversationId);
+        }
+
         await cts.CancelAsync();
+        await RequestTurnCancelAsync(turnId);
         await streamTask;
 
         using var verifyScope = SharedFactory!.Services.CreateScope();
@@ -1337,6 +1531,224 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
         assistant.ThinkingBlocksJson.Should().NotBeNullOrWhiteSpace();
         assistant.ThinkingBlocksJson.Should().Contain("word1");
         assistant.Content.Should().NotBe("should not be reached before cancel");
+    }
+
+    [TestMethod]
+    public async Task SendMessageStream_SseDisconnect_keeps_worker_locked_until_explicit_cancel_and_reattach_observe()
+    {
+        Guid projectId;
+        Guid notebookId;
+        Guid conversationId;
+        using (var scope = SharedFactory!.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            (projectId, notebookId) = await SeedProjectNotebookAsync(db);
+            conversationId = await SeedConversationAsync(db, notebookId, "SSE disconnect reattach");
+        }
+
+        FakeChatCompletionBehavior.Instance.Reset();
+        FakeChatCompletionBehavior.Instance.Scenario = FakeChatScenario.SlowCancellableStream;
+        FakeChatCompletionBehavior.Instance.ChunkDelayMs = 400;
+        FakeChatCompletionBehavior.Instance.SlowStreamText = string.Join(
+            ' ',
+            Enumerable.Range(1, 80).Select(i => $"word{i}"));
+
+        using var sendCts = new CancellationTokenSource();
+        sendCts.CancelAfter(TimeSpan.FromMilliseconds(400));
+
+        var sendTask = Task.Run(async () =>
+        {
+            try
+            {
+                await SendConversationStreamUntilCancelledAsync(
+                    projectId,
+                    notebookId,
+                    conversationId,
+                    new { instructions = "Disconnect then observe", assistantName = "assistant" },
+                    sendCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // expected when the primary SSE client disconnects
+            }
+        });
+
+        Guid turnId = Guid.Empty;
+        var sawPartial = false;
+        var partialDeadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < partialDeadline)
+        {
+            using var pollScope = SharedFactory!.Services.CreateScope();
+            var pollDb = pollScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var assistant = await pollDb.NotebookConversationMessages
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m =>
+                    m.NotebookConversationId == conversationId && m.Role == DataModelChatRole.Assistant);
+            if (assistant is { Content: { Length: > 0 } })
+            {
+                sawPartial = true;
+                turnId = await GetActiveTurnIdAsync(pollDb, conversationId);
+                break;
+            }
+
+            await Task.Delay(50);
+        }
+
+        sawPartial.Should().BeTrue("worker should persist partial content while SSE is active");
+
+        var streamingConfirmed = false;
+        var streamingDeadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < streamingDeadline)
+        {
+            using var pollScope = SharedFactory!.Services.CreateScope();
+            var pollDb = pollScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var registry = pollScope.ServiceProvider.GetRequiredService<ConversationStreamRunRegistry>();
+            var status = await pollDb.ConversationTurns
+                .AsNoTracking()
+                .Where(t => t.Id == turnId)
+                .Select(t => t.Status)
+                .SingleAsync();
+            if (status == "streaming" && registry.IsActive(turnId))
+            {
+                streamingConfirmed = true;
+                break;
+            }
+
+            await Task.Delay(25);
+        }
+
+        streamingConfirmed.Should().BeTrue("turn should remain streaming after SSE disconnect");
+
+        _ = sendTask;
+
+        (await SendConversationStreamStatusAsync(
+            projectId,
+            notebookId,
+            conversationId,
+            new { instructions = "Should be blocked", assistantName = "assistant" }))
+            .Should().Be(HttpStatusCode.Conflict);
+
+        using (var previewScope = SharedFactory!.Services.CreateScope())
+        {
+            var service = ResolveService(previewScope);
+            var dto = await service.GetConversationWithMessagesAsync(conversationId);
+            dto!.ActiveTurn.Should().NotBeNull();
+            dto.ActiveTurn!.Status.Should().Be("streaming");
+            dto.Lock.Should().NotBeNull();
+            dto.StreamingPreview.Should().NotBeNull();
+            dto.StreamingPreview!.Content.Should().NotBeEmpty();
+        }
+
+        using (var undoScope = SharedFactory!.Services.CreateScope())
+        {
+            var undoSvc = ResolveService(undoScope);
+            var act = () => undoSvc.UndoLastForConversationAsync(conversationId);
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("*locked*");
+        }
+
+        using var observeCts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var observedEvents = new System.Collections.Concurrent.ConcurrentBag<(string EventType, string Payload)>();
+        var observeTask = Task.Run(async () =>
+        {
+            using var req = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"/api/projects/{projectId}/notebooks/{notebookId}/conversations/{conversationId}/events");
+            req.Headers.Accept.Clear();
+            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+            using var resp = await Client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, observeCts.Token);
+            resp.EnsureSuccessStatusCode();
+
+            await using var stream = await resp.Content.ReadAsStreamAsync(observeCts.Token);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+
+            string? currentEvent = null;
+            while (!observeCts.Token.IsCancellationRequested)
+            {
+                var line = await reader.ReadLineAsync(observeCts.Token);
+                if (line == null)
+                {
+                    break;
+                }
+
+                if (line.StartsWith("event:", StringComparison.Ordinal))
+                {
+                    currentEvent = line["event:".Length..].Trim();
+                    continue;
+                }
+
+                if (line.StartsWith("data:", StringComparison.Ordinal) && currentEvent != null)
+                {
+                    observedEvents.Add((currentEvent, line["data:".Length..].Trim()));
+                }
+            }
+        });
+
+        await RequestTurnCancelAsync(turnId);
+
+        var observeDeadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < observeDeadline)
+        {
+            if (observedEvents.Any(e =>
+                    e.EventType == StreamingEventTypes.Token
+                    || e.EventType == StreamingEventTypes.AssistantMessage
+                    || e.EventType == StreamingEventTypes.Complete
+                    || e.EventType == StreamingEventTypes.Cancelled))
+            {
+                break;
+            }
+
+            await Task.Delay(50);
+        }
+
+        observeCts.Cancel();
+        try
+        {
+            await observeTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // expected when ending the observer subscription
+        }
+
+        observedEvents.Should().Contain(e =>
+            e.EventType == StreamingEventTypes.Token
+            || e.EventType == StreamingEventTypes.AssistantMessage
+            || e.EventType == StreamingEventTypes.Complete
+            || e.EventType == StreamingEventTypes.Cancelled,
+            "GET /events should receive live hub events after SSE disconnect");
+
+        using (var verifyScope = SharedFactory!.Services.CreateScope())
+        {
+            var verifyDb = verifyScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var registry = verifyScope.ServiceProvider.GetRequiredService<ConversationStreamRunRegistry>();
+
+            await WaitForTurnStatusAsync(verifyDb, conversationId, "cancelled");
+            await WaitForLockReleasedAsync(verifyDb, conversationId);
+            registry.IsActive(turnId).Should().BeFalse();
+        }
+    }
+
+    [TestMethod]
+    public async Task ObserveEvents_unknown_conversation_returns_404()
+    {
+        Guid projectId;
+        Guid notebookId;
+        using (var scope = SharedFactory!.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            (projectId, notebookId) = await SeedProjectNotebookAsync(db);
+        }
+
+        using var req = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/api/projects/{projectId}/notebooks/{notebookId}/conversations/{Guid.NewGuid()}/events");
+        req.Headers.Accept.Clear();
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        using var resp = await Client.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [TestMethod]

--- a/src/server/GuideAntsApi.IntegrationTests/Services/Conversations/ConversationServiceIntegrationTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Services/Conversations/ConversationServiceIntegrationTests.cs
@@ -1647,7 +1647,7 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
                 .WithMessage("*locked*");
         }
 
-        using var observeCts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        using var observeCts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
         var observedEvents = new System.Collections.Concurrent.ConcurrentBag<(string EventType, string Payload)>();
         var observeTask = Task.Run(async () =>
         {
@@ -1684,6 +1684,36 @@ public sealed class ConversationServiceIntegrationTests : BaseEndpointTest
                 }
             }
         });
+
+        var connectedDeadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < connectedDeadline)
+        {
+            if (observedEvents.Any(e => e.EventType == "connection_established"))
+            {
+                break;
+            }
+
+            await Task.Delay(25);
+        }
+
+        observedEvents.Should().Contain(
+            e => e.EventType == "connection_established",
+            "observer SSE must be subscribed before Stop so it can receive live hub events");
+
+        var liveDeadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < liveDeadline)
+        {
+            if (observedEvents.Any(e =>
+                    e.EventType == StreamingEventTypes.Token
+                    || e.EventType == StreamingEventTypes.AssistantMessage
+                    || e.EventType == StreamingEventTypes.Complete
+                    || e.EventType == StreamingEventTypes.Cancelled))
+            {
+                break;
+            }
+
+            await Task.Delay(50);
+        }
 
         await RequestTurnCancelAsync(turnId);
 

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiDesiredStateBuilderTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiDesiredStateBuilderTests.cs
@@ -1,12 +1,16 @@
 using FluentAssertions;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Models.Settings;
 using GuideAntsApi.Services.Bootstrap;
 using GuideAntsApi.Services.Routing;
 using GuideAntsApi.Settings;
 using GuideAntsApi.Tests.TestUtils;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using System.Text.Json.Nodes;
 
 namespace GuideAntsApi.Tests.Services.Bootstrap;
 
@@ -192,6 +196,59 @@ public sealed class LocalAiDesiredStateBuilderTests
     }
 
     [TestMethod]
+    public async Task BuildPlanJsonAsync_ApplicationSettingsChatDefaults_WritesEnabledLlamaRouterAlias()
+    {
+        const string defaultModelId = "qwen3.6-35b-a3b-mtp-local";
+        const string routerAlias = "Qwen3.6-35B-A3B-MTP-GGUF";
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["LlamaCpp:BaseUrl"] = "http://localhost:8080/llama-cpp",
+            })
+            .Build();
+
+        var dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"chatdefaults-plan-{Guid.NewGuid():N}")
+            .Options;
+        await using var db = new ApplicationDbContext(dbOptions);
+        db.Models.Add(new Model
+        {
+            ModelId = defaultModelId,
+            DisplayName = "Qwen 3.6 35B",
+            Provider = "llama-cpp",
+            IsActive = true,
+            Created = DateTime.UtcNow,
+            RuntimeConfigJson = $$"""{"routerModelId":"{{routerAlias}}","runtimeProfileId":"qwen3_6"}""",
+        });
+        await db.SaveChangesAsync();
+
+        var settings = CreateBundleSettingsService();
+        Mock.Get(settings)
+            .Setup(s => s.GetSectionAsync("ChatDefaults", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SettingsSectionDto(
+                "ChatDefaults",
+                1,
+                "v1",
+                DateTime.UtcNow,
+                new JsonObject
+                {
+                    ["DefaultModelId"] = defaultModelId,
+                    ["OverrideAllChatModels"] = true,
+                },
+                new Dictionary<string, bool>()));
+
+        var builder = new LocalAiDesiredStateBuilder(
+            configuration,
+            new ServiceScopeFactoryStub(settings, dbOptions),
+            new FakeServiceModeResolver());
+
+        var planJson = await builder.BuildPlanJsonAsync();
+
+        planJson.Should().Contain("\"llama\":{\"enabled\":true,\"routerAlias\":\"" + routerAlias + "\"}");
+    }
+
+    [TestMethod]
     public async Task BuildPlanJsonAsync_ServiceModesReadFails_DoesNotInventIdlePolicy()
     {
         var configuration = new ConfigurationBuilder().Build();
@@ -216,6 +273,9 @@ public sealed class LocalAiDesiredStateBuilderTests
     {
         var settings = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
         settings
+            .Setup(s => s.GetSectionAsync("ChatDefaults", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SettingsSectionDto?)null);
+        settings
             .Setup(s => s.GetImageGenerationBundleDefinitionAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string bundleId, CancellationToken _) => new ImageGenerationBundleDefinitionDto(
                 bundleId,
@@ -232,21 +292,35 @@ public sealed class LocalAiDesiredStateBuilderTests
     private sealed class ServiceScopeFactoryStub : IServiceScopeFactory
     {
         private readonly IApplicationSettingsService? _settingsService;
+        private readonly DbContextOptions<ApplicationDbContext>? _dbOptions;
 
-        public ServiceScopeFactoryStub(IApplicationSettingsService? settingsService = null) =>
+        public ServiceScopeFactoryStub(
+            IApplicationSettingsService? settingsService = null,
+            DbContextOptions<ApplicationDbContext>? dbOptions = null)
+        {
             _settingsService = settingsService;
+            _dbOptions = dbOptions;
+        }
 
-        public IServiceScope CreateScope() => new ServiceScopeStub(_settingsService);
+        public IServiceScope CreateScope() => new ServiceScopeStub(_settingsService, _dbOptions);
     }
 
     private sealed class ServiceScopeStub : IServiceScope
     {
-        public ServiceScopeStub(IApplicationSettingsService? settingsService)
+        public ServiceScopeStub(
+            IApplicationSettingsService? settingsService,
+            DbContextOptions<ApplicationDbContext>? dbOptions = null)
         {
             var services = new ServiceCollection();
             if (settingsService is not null)
             {
                 services.AddSingleton(settingsService);
+            }
+
+            if (dbOptions is not null)
+            {
+                services.AddSingleton(dbOptions);
+                services.AddScoped<ApplicationDbContext>();
             }
 
             ServiceProvider = services.BuildServiceProvider();

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStartupWarmupServiceTests.cs
@@ -483,6 +483,64 @@ public sealed class LocalAiStartupWarmupServiceTests
         orchestration.VerifyAll();
     }
 
+    [TestMethod]
+    public async Task SyncDesiredAndApplyAsync_WaitForCompletion_ClearsWarmupInProgress()
+    {
+        var orchestration = new Mock<ILocalAiWarmupOrchestrationClient>(MockBehavior.Strict);
+        orchestration
+            .Setup(c => c.ApplyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WarmupApplyResult(
+                Ok: true,
+                Noop: false,
+                Continue: false,
+                Started: true,
+                DesiredRevision: 2,
+                AppliedRevision: 0,
+                ApplyStatus: "applying",
+                Changed: true));
+        orchestration
+            .Setup(c => c.GetStatusAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WarmupStatusDocument(
+                SchemaVersion: 1,
+                DesiredRevision: 2,
+                AppliedRevision: 2,
+                InProgressRevision: null,
+                ApplyStatus: "applied",
+                ApplyError: null,
+                DesiredSha256: string.Empty,
+                WrittenAt: string.Empty,
+                Services: new Dictionary<string, WarmupServiceStatus>()));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["LlamaCpp:BaseUrl"] = "http://localhost:8080/llama-cpp",
+            })
+            .Build();
+
+        var modeResolver = new FakeServiceModeResolver();
+        var (settingsMock, _) = CreateSettingsMock();
+        var builder = new LocalAiDesiredStateBuilder(
+            configuration,
+            new ServiceScopeFactoryStub(settingsMock.Object),
+            modeResolver);
+
+        var service = new LocalAiStartupWarmupService(
+            configuration,
+            new ServiceScopeFactoryStub(settingsMock.Object),
+            builder,
+            orchestration.Object,
+            CreateAlignedVerifier(),
+            modeResolver,
+            new LocalAiStackHostResolver(configuration),
+            NullLogger<LocalAiStartupWarmupService>.Instance);
+
+        await service.SyncDesiredAndApplyAsync(waitForCompletion: true);
+
+        service.IsWarmupInProgress.Should().BeFalse();
+        orchestration.VerifyAll();
+    }
+
     private static ILocalAiRuntimeAlignmentVerifier CreateAlignedVerifier()
     {
         var mock = new Mock<ILocalAiRuntimeAlignmentVerifier>(MockBehavior.Strict);
@@ -598,6 +656,9 @@ public sealed class LocalAiStartupWarmupServiceTests
             StringComparer.Ordinal);
 
         var settingsMock = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+        settingsMock
+            .Setup(s => s.GetSectionAsync("ChatDefaults", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SettingsSectionDto?)null);
         foreach (var (serviceId, _) in modesByService)
         {
             settingsMock

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiWarmupOrchestrationClientTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiWarmupOrchestrationClientTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using GuideAntsApi.Services.Bootstrap;
+
+namespace GuideAntsApi.Tests.Services.Bootstrap;
+
+[TestClass]
+public sealed class LocalAiWarmupOrchestrationClientTests
+{
+    [TestMethod]
+    public void MergeStackStatuses_IndependentRevisionCounters_UsesMaxAppliedRevision()
+    {
+        var stackOne = new WarmupStatusDocument(
+            SchemaVersion: 1,
+            DesiredRevision: 2,
+            AppliedRevision: 2,
+            InProgressRevision: null,
+            ApplyStatus: "applied",
+            ApplyError: null,
+            DesiredSha256: string.Empty,
+            WrittenAt: string.Empty,
+            Services: new Dictionary<string, WarmupServiceStatus>());
+
+        var stackTwo = new WarmupStatusDocument(
+            SchemaVersion: 1,
+            DesiredRevision: 1,
+            AppliedRevision: 1,
+            InProgressRevision: null,
+            ApplyStatus: "applied",
+            ApplyError: null,
+            DesiredSha256: string.Empty,
+            WrittenAt: string.Empty,
+            Services: new Dictionary<string, WarmupServiceStatus>());
+
+        var merged = LocalAiWarmupOrchestrationClient.MergeStackStatuses(
+            [stackOne, stackTwo],
+            new Dictionary<string, WarmupServiceStatus>());
+
+        merged.DesiredRevision.Should().Be(2);
+        merged.AppliedRevision.Should().Be(2);
+        merged.ApplyStatus.Should().Be("applied");
+        merged.DesiredRevision.Should().BeLessThanOrEqualTo(merged.AppliedRevision);
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationStreamRunRegistryTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationStreamRunRegistryTests.cs
@@ -14,7 +14,7 @@ public sealed class ConversationStreamRunRegistryTests
 
         registry.IsActive(turnId).Should().BeFalse();
 
-        _ = registry.Register(turnId, CancellationToken.None);
+        using var cts = registry.Register(turnId);
         registry.IsActive(turnId).Should().BeTrue();
 
         registry.Unregister(turnId);
@@ -26,10 +26,22 @@ public sealed class ConversationStreamRunRegistryTests
     {
         var registry = new ConversationStreamRunRegistry();
         var turnId = Guid.NewGuid();
-        var token = registry.Register(turnId, CancellationToken.None);
+        using var cts = registry.Register(turnId);
 
-        token.IsCancellationRequested.Should().BeFalse();
+        cts.Token.IsCancellationRequested.Should().BeFalse();
         registry.RequestCancel(turnId).Should().BeTrue();
-        token.IsCancellationRequested.Should().BeTrue();
+        cts.Token.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Register_is_not_linked_to_http_abort_token()
+    {
+        var registry = new ConversationStreamRunRegistry();
+        var turnId = Guid.NewGuid();
+        using var httpCts = new CancellationTokenSource();
+        using var workerCts = registry.Register(turnId);
+
+        httpCts.Cancel();
+        workerCts.Token.IsCancellationRequested.Should().BeFalse();
     }
 }

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationTurnRecoveryServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationTurnRecoveryServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class ConversationTurnRecoveryServiceTests
     {
         var (options, turnId, _) = await SeedStaleStreamingTurnAsync();
         var registry = new ConversationStreamRunRegistry();
-        _ = registry.Register(turnId, CancellationToken.None);
+        _ = registry.Register(turnId);
 
         var service = CreateService(options, registry);
         await service.RecoverStaleTurnsAsync(CancellationToken.None);

--- a/src/server/GuideAntsApi.Tests/Services/OpenAiReasoningSupportTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/OpenAiReasoningSupportTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.Json.Nodes;
 using AntRunner.Chat.Abstractions;
 using AntRunner.Chat.OpenAI;
 using FluentAssertions;
@@ -56,7 +57,8 @@ public sealed class OpenAiReasoningSupportTests
             "ToResponseRequest",
             request);
 
-        GetPropertyValue(mapped, "Reasoning").Should().BeNull();
+        mapped.Should().BeOfType<JsonObject>();
+        ((JsonObject)mapped).ContainsKey("reasoning").Should().BeFalse();
     }
 
     [TestMethod]
@@ -73,7 +75,8 @@ public sealed class OpenAiReasoningSupportTests
             "ToResponseRequest",
             request);
 
-        GetPropertyValue(mapped, "Reasoning").Should().NotBeNull();
+        mapped.Should().BeOfType<JsonObject>();
+        ((JsonObject)mapped)["reasoning"].Should().NotBeNull();
     }
 
     private static object InvokeMapperMethod(

--- a/src/server/GuideAntsApi.Tests/Services/Providers/OpenAiResponsesClientDeepTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Providers/OpenAiResponsesClientDeepTests.cs
@@ -9,13 +9,8 @@ namespace GuideAntsApi.Tests.Services.Providers;
 
 /// <summary>
 /// Deterministic HTTP-handler coverage for <see cref="AntRunner.Chat.OpenAI.OpenAiResponsesClient"/> driven
-/// through the real OpenAI-DotNet Responses transport.
-/// <para>
-/// The OpenAI-DotNet Responses endpoint always streams (a callback is always supplied) and then calls
-/// <c>WaitForStatusChangeAsync</c>, which polls <c>GET /responses/{id}</c> once and returns THAT body as the
-/// authoritative response. So tests answer the streaming POST with SSE (used for deltas + establishing the
-/// response id) and answer the poll GET with the final JSON response that drives mapping.
-/// </para>
+/// through the stateless Responses streaming transport. The terminal <c>response.completed</c> SSE event is
+/// authoritative; a provider response retrieval request is never made.
 /// </summary>
 [TestClass]
 public sealed class OpenAiResponsesClientDeepTests
@@ -63,18 +58,20 @@ public sealed class OpenAiResponsesClientDeepTests
         "{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"gpt-4o\",\"output\":[" +
         outputItemsJson + "],\"usage\":" + (usageJson ?? DefaultUsageJson) + "}";
 
-    /// <summary>
-    /// POST (stream) -> SSE that just establishes the response id; GET (poll) -> final JSON response.
-    /// </summary>
     private static Func<HttpRequestMessage, HttpResponseMessage> Responder(
         string outputItemsJson,
         string? usageJson = null,
         string? streamSse = null)
     {
-        var getJson = CompletedResponseJson(outputItemsJson, usageJson);
-        var sse = streamSse ?? CreatedSse;
+        var completedJson = CompletedResponseJson(outputItemsJson, usageJson);
+        var terminalSse =
+            "event: response.completed\n" +
+            "data: {\"type\":\"response.completed\",\"response\":" + completedJson + "}\n\n";
+        var sse = (streamSse ?? CreatedSse) + terminalSse;
         return request => request.Method == HttpMethod.Get
-            ? ChatHttpResponses.Json(getJson)
+            ? ChatHttpResponses.Json(
+                """{"error":{"message":"response retrieval is forbidden"}}""",
+                HttpStatusCode.NotFound)
             : ChatHttpResponses.Sse(sse);
     }
 
@@ -95,8 +92,11 @@ public sealed class OpenAiResponsesClientDeepTests
         using var body = JsonDocument.Parse(postRequest.Body);
         body.RootElement.GetProperty("model").GetString().Should().Be("gpt-4o");
         body.RootElement.GetProperty("stream").GetBoolean().Should().BeTrue();
+        body.RootElement.GetProperty("store").GetBoolean().Should().BeFalse();
+        body.RootElement.TryGetProperty("previous_response_id", out _).Should().BeFalse();
         body.RootElement.GetProperty("truncation").GetString().Should().Be("disabled");
         body.RootElement.GetProperty("input").GetArrayLength().Should().Be(2);
+        handler.RequestCount.Should().Be(1);
 
         response.FirstChoice!.Message.GetText().Should().Be("Hello world");
         response.FirstChoice.FinishReason.Should().Be("stop");
@@ -137,6 +137,7 @@ public sealed class OpenAiResponsesClientDeepTests
         toolCall.Id.Should().Be("call_1");
         toolCall.Function.Name.Should().Be("lookup_weather");
         toolCall.Function.Arguments.GetRawText().Should().Contain("Boston");
+        handler.RequestCount.Should().Be(1);
     }
 
     [TestMethod]
@@ -298,9 +299,49 @@ public sealed class OpenAiResponsesClientDeepTests
     }
 
     [TestMethod]
+    public async Task GetCompletionAsync_StreamWithoutTerminalEvent_ThrowsWithoutRetrieval()
+    {
+        var handler = new CapturingHandler(_ => ChatHttpResponses.Sse(CreatedSse));
+        using var httpClient = new HttpClient(handler);
+        var client = CreateClient(handler, httpClient);
+
+        Func<Task> act = () => client.GetCompletionAsync(TextRequest());
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*without a terminal response.completed event*");
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task GetCompletionAsync_AzureUsesResourceEndpointAndApiKeyHeader()
+    {
+        var handler = new CapturingHandler(Responder(AssistantTextItem("ok")));
+        using var httpClient = new HttpClient(handler);
+        var config = new AzureOpenAiConfig
+        {
+            ApiKey = "azure-test-key",
+            ResourceName = "test-resource",
+            ApiVersion = "2025-04-01-preview",
+            DeploymentId = "gpt-4o"
+        };
+        var client = new OpenAiResponsesClientFactory(
+                new StaticHttpClientFactory(httpClient),
+                config)
+            .CreateClient(null, httpClient);
+
+        await client.GetCompletionAsync(TextRequest());
+
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.Uri!.ToString().Should().Be(
+            "https://test-resource.openai.azure.com/openai/responses?api-version=2025-04-01-preview");
+        request.Headers.Authorization.Should().BeNull();
+        request.Headers.TryGetValues("api-key", out var values).Should().BeTrue();
+        values.Should().ContainSingle().Which.Should().Be("azure-test-key");
+    }
+
+    [TestMethod]
     public async Task StreamCompletionAsync_EmitsTextDeltasAndMapsFinalResponse()
     {
-        // The client's EmitDelta computes the new suffix from accumulated delta values, so deltas grow.
         var sse =
             CreatedSse +
             "event: response.output_item.added\n" +
@@ -314,7 +355,7 @@ public sealed class OpenAiResponsesClientDeepTests
             "\"content_index\":0,\"delta\":\"Hel\"}\n\n" +
             "event: response.output_text.delta\n" +
             "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"output_index\":0," +
-            "\"content_index\":0,\"delta\":\"Hello\"}\n\n" +
+            "\"content_index\":0,\"delta\":\"lo\"}\n\n" +
             "event: response.output_text.done\n" +
             "data: {\"type\":\"response.output_text.done\",\"item_id\":\"msg_1\",\"output_index\":0," +
             "\"content_index\":0,\"text\":\"Hello\"}\n\n";
@@ -336,12 +377,13 @@ public sealed class OpenAiResponsesClientDeepTests
                 }
             });
 
-        // The streaming handler emits incremental text deltas as they arrive over SSE; the first
-        // emitted delta is the leading fragment. The authoritative final text/usage come from the poll.
+        // Streaming deltas are emitted directly; the terminal event supplies final text and usage.
         deltas.Should().NotBeEmpty();
         deltas[0].Should().Be("Hel");
+        deltas[1].Should().Be("lo");
         response.FirstChoice!.Message.GetText().Should().Be("Hello");
         response.FirstChoice.FinishReason.Should().Be("stop");
         response.Usage!.TotalTokens.Should().Be(5);
+        handler.RequestCount.Should().Be(1);
     }
 }

--- a/src/server/GuideAntsApi.Tests/Services/Providers/OpenAiResponsesClientDeepTests2.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Providers/OpenAiResponsesClientDeepTests2.cs
@@ -45,16 +45,24 @@ public sealed class OpenAiResponsesClientDeepTests2
     private static string CompletedResponseJson(string outputItemsJson, string? usageJson = null)
     {
         var usagePart = usageJson == "null" ? "null" : (usageJson ?? DefaultUsageJson);
-        return "{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"gpt-4o\",\"output\":[" +
+        return "{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\"," +
+            "\"model\":\"gpt-4o\",\"output\":[" +
             outputItemsJson + "],\"usage\":" + usagePart + "}";
     }
 
-    private static Func<HttpRequestMessage, HttpResponseMessage> Responder(string outputItemsJson, string? usageJson = null)
+    private static Func<HttpRequestMessage, HttpResponseMessage> Responder(
+        string outputItemsJson,
+        string? usageJson = null)
     {
-        var getJson = CompletedResponseJson(outputItemsJson, usageJson);
+        var completedJson = CompletedResponseJson(outputItemsJson, usageJson);
+        var terminalSse =
+            "event: response.completed\n" +
+            "data: {\"type\":\"response.completed\",\"response\":" + completedJson + "}\n\n";
         return request => request.Method == HttpMethod.Get
-            ? ChatHttpResponses.Json(getJson)
-            : ChatHttpResponses.Sse(CreatedSse);
+            ? ChatHttpResponses.Json(
+                """{"error":{"message":"response retrieval is forbidden"}}""",
+                System.Net.HttpStatusCode.NotFound)
+            : ChatHttpResponses.Sse(CreatedSse + terminalSse);
     }
 
     [TestMethod]
@@ -154,7 +162,8 @@ public sealed class OpenAiResponsesClientDeepTests2
     public async Task GetCompletionAsync_ReasoningItemWithContent_MapsThinkingBlock()
     {
         var reasoningItem =
-            "{\"type\":\"reasoning\",\"id\":\"rs_2\",\"content\":[{\"type\":\"reasoning_text\",\"text\":\"deep reasoning\"}]}";
+            "{\"type\":\"reasoning\",\"id\":\"rs_2\",\"content\":[" +
+            "{\"type\":\"reasoning_text\",\"text\":\"deep reasoning\"}]}";
         var outputItems = reasoningItem + "," + AssistantTextItem("final");
         var handler = new CapturingHandler(Responder(outputItems));
         using var httpClient = new HttpClient(handler);

--- a/src/server/GuideAntsApi.Tests/TestUtils/ConversationTestServices.cs
+++ b/src/server/GuideAntsApi.Tests/TestUtils/ConversationTestServices.cs
@@ -101,10 +101,12 @@ internal static class ConversationTestServices
             scopeFactory,
             Mock.Of<ILogger<ConversationStreamEngine>>(),
             notebookFileSyncService);
+        var streamRunRegistry = new ConversationStreamRunRegistry();
         var undoService = new ConversationUndoService(
             lockService,
             hub,
             streamPolicy,
+            streamRunRegistry,
             scopeFactory,
             Mock.Of<ILogger<ConversationUndoService>>());
 
@@ -120,7 +122,8 @@ internal static class ConversationTestServices
             undoService,
             streamPolicy,
             streamEngine,
-            new ConversationStreamRunRegistry(),
+            streamRunRegistry,
+            hub,
             logger ?? Mock.Of<ILogger<ConversationService>>(),
             toolOAuthService);
     }
@@ -180,6 +183,7 @@ internal static class ConversationTestServices
             undoLockService,
             Mock.Of<IConversationBroadcastHub>(),
             privateStreamPolicy,
+            new ConversationStreamRunRegistry(),
             scopeFactory,
             Mock.Of<ILogger<ConversationUndoService>>());
 
@@ -196,6 +200,7 @@ internal static class ConversationTestServices
             attachmentService,
             streamPolicy,
             streamEngine,
+            new ConversationStreamRunRegistry(),
             configuration);
     }
 }

--- a/src/server/GuideAntsApi/Endpoints/NotebookConversationsEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/NotebookConversationsEndpoints.cs
@@ -100,6 +100,45 @@ public static class NotebookConversationsEndpoints
         .Produces(StatusCodes.Status204NoContent)
         .Produces(StatusCodes.Status404NotFound);
 
+        // GET observer SSE (subscribe-only; does not start a turn or acquire a lock)
+        group.MapGet("/{convoId:guid}/events", async (
+            HttpContext ctx,
+            [FromServices] IConversationService service,
+            Guid convoId) =>
+        {
+            var accept = ctx.Request.Headers.Accept.ToString();
+            if (!accept.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase))
+            {
+                return Results.BadRequest(new { error = "Accept header must include text/event-stream" });
+            }
+
+            var existing = await service.GetConversationByIdAsync(convoId);
+            if (existing == null)
+            {
+                return Results.NotFound(new { error = "Conversation not found" });
+            }
+
+            try
+            {
+                await ctx.Response.WriteSseStreamWithKeepAliveAsync(
+                    service.ObserveConversationEventsAsync(convoId, ctx.RequestAborted),
+                    ctx.RequestAborted);
+            }
+            catch (KeyNotFoundException)
+            {
+                if (!ctx.Response.HasStarted)
+                {
+                    ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+                    await ctx.Response.WriteAsJsonAsync(new { error = "Conversation not found" });
+                }
+            }
+
+            return Results.Empty;
+        })
+        .RequireAuthorization("RequireContributor")
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status404NotFound);
+
         // POST send message (requires SSE via Accept: text/event-stream)
         group.MapPost("/{convoId:guid}/messages", async (
             HttpContext ctx, 

--- a/src/server/GuideAntsApi/Models/Conversations/ConversationDto.cs
+++ b/src/server/GuideAntsApi/Models/Conversations/ConversationDto.cs
@@ -49,21 +49,33 @@ public record ToolCallFunctionDto(
 
 public record ConversationDto(Guid NotebookId, DateTime Created, IReadOnlyList<MessageDto> Messages);
 
-public record NotebookConversationWithMessagesDto(
-    Guid Id,
-    string Title, 
-    string? AssistantName,
-    DateTime Created,
-    DateTime? LastActivity,
-    IReadOnlyList<MessageDto> Messages,
-    ConversationTurnStatusDto? ActiveTurn = null);
-
 public record ConversationTurnStatusDto(
     Guid TurnId,
     int TurnIndex,
     string Status,
     string? TerminationCode,
     DateTime? TerminalizedAt);
+
+public record ConversationLockStatusDto(
+    string LockedByUserName,
+    DateTime LockedAt);
+
+public record ConversationStreamingPreviewDto(
+    Guid MessageId,
+    string Content,
+    string? ToolCallsJson,
+    int TurnIndex);
+
+public record NotebookConversationWithMessagesDto(
+    Guid Id,
+    string Title,
+    string? AssistantName,
+    DateTime Created,
+    DateTime? LastActivity,
+    IReadOnlyList<MessageDto> Messages,
+    ConversationTurnStatusDto? ActiveTurn = null,
+    ConversationLockStatusDto? Lock = null,
+    ConversationStreamingPreviewDto? StreamingPreview = null);
 
 public class SendMessageRequest
 {
@@ -74,10 +86,10 @@ public class SendMessageRequest
 
     // NEW: Optional list of notebook file attachments to include with this message
     public List<AttachmentDto>? Attachments { get; set; }
-    
+
     // NEW: Optional external OAuth tokens for accessing external APIs
     public Dictionary<string, string>? ExternalAuthTokens { get; set; }
-    
+
     // NEW: Optional client-provided context message (from page initialization callback)
     public string? ClientContext { get; set; }
 
@@ -108,10 +120,10 @@ public enum ContentUploadType
     TextFile,
     SandboxFile,
     Folder
-} 
+}
 
 public record AttachmentDto(
     Guid? NotebookFileId,
     ContentUploadType UploadType,
     string? RelativePath = null
-); 
+);

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiDesiredStateBuilder.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiDesiredStateBuilder.cs
@@ -246,13 +246,17 @@ public sealed class LocalAiDesiredStateBuilder : ILocalAiDesiredStateBuilder
             return null;
         }
 
-        var defaultModelId = (_configuration["ChatDefaults:DefaultModelId"] ?? string.Empty).Trim();
+        using var scope = _scopeFactory.CreateScope();
+        var settingsService = scope.ServiceProvider.GetRequiredService<IApplicationSettingsService>();
+        var chatDefaultsSection = await settingsService
+            .GetSectionAsync("ChatDefaults", cancellationToken)
+            .ConfigureAwait(false);
+        var defaultModelId = ChatDefaultsSnapshot.FromSection(chatDefaultsSection).DefaultModelId?.Trim();
         if (string.IsNullOrWhiteSpace(defaultModelId))
         {
             return null;
         }
 
-        using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         var row = await db.Models
             .AsNoTracking()

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiRuntimeWatchdogHostedService.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiRuntimeWatchdogHostedService.cs
@@ -1,5 +1,6 @@
 using GuideAntsApi.Configuration;
 using GuideAntsApi.Services.LlamaCpp;
+using GuideAntsApi.Settings;
 using Microsoft.EntityFrameworkCore;
 
 namespace GuideAntsApi.Services.Bootstrap;
@@ -102,35 +103,10 @@ public sealed class LocalAiRuntimeWatchdogHostedService : BackgroundService
 
     private async Task<bool> IsConfiguredDefaultLlamaLoadedAsync(CancellationToken cancellationToken)
     {
-        var defaultModelId = (_configuration["ChatDefaults:DefaultModelId"] ?? string.Empty).Trim();
-        if (string.IsNullOrWhiteSpace(defaultModelId))
-        {
-            return true;
-        }
-
         using var scope = _scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<GuideAntsApi.DataModel.ApplicationDbContext>();
-        var row = await db.Models
-            .AsNoTracking()
-            .Where(m => m.ModelId == defaultModelId)
-            .Select(m => new { m.Provider, m.RuntimeConfigJson, m.IsActive })
-            .FirstOrDefaultAsync(cancellationToken)
+        var routerAlias = await ResolveConfiguredDefaultRouterAliasAsync(scope, cancellationToken)
             .ConfigureAwait(false);
-
-        if (row is null
-            || !row.IsActive
-            || !string.Equals(row.Provider, "llama-cpp", StringComparison.OrdinalIgnoreCase)
-            || string.IsNullOrWhiteSpace(row.RuntimeConfigJson))
-        {
-            return true;
-        }
-
-        string routerAlias;
-        try
-        {
-            routerAlias = LocalRuntimeConfigurationParser.ParseRequired(defaultModelId, row.RuntimeConfigJson).RouterModelId;
-        }
-        catch
+        if (routerAlias is null)
         {
             return true;
         }
@@ -154,35 +130,10 @@ public sealed class LocalAiRuntimeWatchdogHostedService : BackgroundService
 
     private async Task<bool> IsConfiguredDefaultLlamaFailedAsync(CancellationToken cancellationToken)
     {
-        var defaultModelId = (_configuration["ChatDefaults:DefaultModelId"] ?? string.Empty).Trim();
-        if (string.IsNullOrWhiteSpace(defaultModelId))
-        {
-            return false;
-        }
-
         using var scope = _scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<GuideAntsApi.DataModel.ApplicationDbContext>();
-        var row = await db.Models
-            .AsNoTracking()
-            .Where(m => m.ModelId == defaultModelId)
-            .Select(m => new { m.Provider, m.RuntimeConfigJson, m.IsActive })
-            .FirstOrDefaultAsync(cancellationToken)
+        var routerAlias = await ResolveConfiguredDefaultRouterAliasAsync(scope, cancellationToken)
             .ConfigureAwait(false);
-
-        if (row is null
-            || !row.IsActive
-            || !string.Equals(row.Provider, "llama-cpp", StringComparison.OrdinalIgnoreCase)
-            || string.IsNullOrWhiteSpace(row.RuntimeConfigJson))
-        {
-            return false;
-        }
-
-        string routerAlias;
-        try
-        {
-            routerAlias = LocalRuntimeConfigurationParser.ParseRequired(defaultModelId, row.RuntimeConfigJson).RouterModelId;
-        }
-        catch
+        if (routerAlias is null)
         {
             return false;
         }
@@ -201,6 +152,46 @@ public sealed class LocalAiRuntimeWatchdogHostedService : BackgroundService
         return models.Data.Any(m =>
             string.Equals(m.Id, routerAlias, StringComparison.Ordinal)
             && IsRouterModelFailed(m));
+    }
+
+    private static async Task<string?> ResolveConfiguredDefaultRouterAliasAsync(
+        IServiceScope scope,
+        CancellationToken cancellationToken)
+    {
+        var settingsService = scope.ServiceProvider.GetRequiredService<IApplicationSettingsService>();
+        var chatDefaultsSection = await settingsService
+            .GetSectionAsync("ChatDefaults", cancellationToken)
+            .ConfigureAwait(false);
+        var defaultModelId = ChatDefaultsSnapshot.FromSection(chatDefaultsSection).DefaultModelId?.Trim();
+        if (string.IsNullOrWhiteSpace(defaultModelId))
+        {
+            return null;
+        }
+
+        var db = scope.ServiceProvider.GetRequiredService<GuideAntsApi.DataModel.ApplicationDbContext>();
+        var row = await db.Models
+            .AsNoTracking()
+            .Where(m => m.ModelId == defaultModelId)
+            .Select(m => new { m.Provider, m.RuntimeConfigJson, m.IsActive })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (row is null
+            || !row.IsActive
+            || !string.Equals(row.Provider, "llama-cpp", StringComparison.OrdinalIgnoreCase)
+            || string.IsNullOrWhiteSpace(row.RuntimeConfigJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            return LocalRuntimeConfigurationParser.ParseRequired(defaultModelId, row.RuntimeConfigJson).RouterModelId;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static bool IsRouterModelLoaded(LlamaModelData model)

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiWarmupOrchestrationClient.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiWarmupOrchestrationClient.cs
@@ -202,7 +202,7 @@ public sealed class LocalAiWarmupOrchestrationClient : ILocalAiWarmupOrchestrati
             Services: services);
     }
 
-    private static WarmupStatusDocument MergeStackStatuses(
+    internal static WarmupStatusDocument MergeStackStatuses(
         IReadOnlyList<WarmupStatusDocument> stackStatuses,
         Dictionary<string, WarmupServiceStatus> mergedServices)
     {
@@ -252,11 +252,10 @@ public sealed class LocalAiWarmupOrchestrationClient : ILocalAiWarmupOrchestrati
                 : "idle";
         }
 
-        var allApplied = stackStatuses.All(static s => s.DesiredRevision <= s.AppliedRevision);
         return new WarmupStatusDocument(
             SchemaVersion: 1,
             DesiredRevision: stackStatuses.Max(static s => s.DesiredRevision),
-            AppliedRevision: allApplied ? stackStatuses.Min(static s => s.AppliedRevision) : stackStatuses.Max(static s => s.AppliedRevision),
+            AppliedRevision: stackStatuses.Max(static s => s.AppliedRevision),
             InProgressRevision: stackStatuses.Select(static s => s.InProgressRevision).FirstOrDefault(static r => r.HasValue),
             ApplyStatus: applyStatus,
             ApplyError: applyError,

--- a/src/server/GuideAntsApi/Services/Conversations/Commands/ConversationUndoService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Commands/ConversationUndoService.cs
@@ -31,6 +31,7 @@ public sealed class ConversationUndoService : IConversationUndoService
     private readonly IDistributedConversationLock _distributedLock;
     private readonly IConversationBroadcastHub _broadcastHub;
     private readonly PrivateConversationStreamPolicy _privateStreamPolicy;
+    private readonly ConversationStreamRunRegistry _streamRunRegistry;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<ConversationUndoService> _logger;
 
@@ -38,12 +39,14 @@ public sealed class ConversationUndoService : IConversationUndoService
         IDistributedConversationLock distributedLock,
         IConversationBroadcastHub broadcastHub,
         PrivateConversationStreamPolicy privateStreamPolicy,
+        ConversationStreamRunRegistry streamRunRegistry,
         IServiceScopeFactory scopeFactory,
         ILogger<ConversationUndoService> logger)
     {
         _distributedLock = distributedLock;
         _broadcastHub = broadcastHub;
         _privateStreamPolicy = privateStreamPolicy;
+        _streamRunRegistry = streamRunRegistry;
         _scopeFactory = scopeFactory;
         _logger = logger;
     }
@@ -154,6 +157,12 @@ public sealed class ConversationUndoService : IConversationUndoService
 
         if (lockResult.Status != LockAcquisitionStatus.Acquired)
         {
+            var streamingTurnId = await GetActiveStreamingTurnIdAsync(conversationId);
+            if (streamingTurnId != null && _streamRunRegistry.IsActive(streamingTurnId.Value))
+            {
+                throw new InvalidOperationException($"Conversation is locked by {lockResult.LockedByUserName}");
+            }
+
             if (_privateStreamPolicy.GetConversationGate(conversationId) is { CurrentCount: 0 })
             {
                 throw new InvalidOperationException($"Conversation is locked by {lockResult.LockedByUserName}");
@@ -188,6 +197,18 @@ public sealed class ConversationUndoService : IConversationUndoService
         }
 
         return streamGate;
+    }
+
+    private async Task<Guid?> GetActiveStreamingTurnIdAsync(Guid conversationId)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return await db.ConversationTurns
+            .AsNoTracking()
+            .Where(t => t.NotebookConversationId == conversationId && t.Status == "streaming")
+            .OrderByDescending(t => t.TurnIndex)
+            .Select(t => (Guid?)t.Id)
+            .FirstOrDefaultAsync();
     }
 
     private async Task ReleaseUndoLockAsync(Guid conversationId, SemaphoreSlim streamGate)

--- a/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
@@ -5,6 +5,7 @@ using GuideAntsApi.DataModel;
 using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Models.Conversations;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using GuideAntsApi.Services.Auth;
 using GuideAntsApi.Services.Routing;
 using GuideAntsApi.Services.Conversations.Attachments;
@@ -31,6 +32,7 @@ public class ConversationService : IConversationService
     private readonly PrivateConversationStreamPolicy _streamPolicy;
     private readonly IConversationStreamEngine _streamEngine;
     private readonly ConversationStreamRunRegistry _streamRunRegistry;
+    private readonly IConversationBroadcastHub _broadcastHub;
     private readonly IToolOAuthService? _toolOAuthService;
     private readonly ILogger<ConversationService> _logger;
 
@@ -47,6 +49,7 @@ public class ConversationService : IConversationService
         PrivateConversationStreamPolicy streamPolicy,
         IConversationStreamEngine streamEngine,
         ConversationStreamRunRegistry streamRunRegistry,
+        IConversationBroadcastHub broadcastHub,
         ILogger<ConversationService> logger,
         IToolOAuthService? toolOAuthService = null)
     {
@@ -62,6 +65,7 @@ public class ConversationService : IConversationService
         _streamPolicy = streamPolicy;
         _streamEngine = streamEngine;
         _streamRunRegistry = streamRunRegistry;
+        _broadcastHub = broadcastHub;
         _logger = logger;
         _toolOAuthService = toolOAuthService;
     }
@@ -142,6 +146,25 @@ public class ConversationService : IConversationService
             ? Task.FromResult(true)
             : Task.FromResult(false);
 
+    public async IAsyncEnumerable<StreamingEvent> ObserveConversationEventsAsync(
+        Guid conversationId,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var conversation = await _queryService.GetConversationByIdAsync(conversationId);
+        if (conversation == null)
+        {
+            throw new KeyNotFoundException($"Conversation {conversationId} was not found.");
+        }
+
+        await foreach (var ev in _broadcastHub.SubscribeToConversationAsync(
+            conversationId,
+            Guid.NewGuid().ToString("N"),
+            cancellationToken))
+        {
+            yield return ev;
+        }
+    }
+
     private async IAsyncEnumerable<StreamingEvent> SendMessageStreamCoreAsync(
         Guid conversationId,
         SendMessageRequest request,
@@ -151,6 +174,8 @@ public class ConversationService : IConversationService
         var lockHandle = await _streamPolicy.TryAcquireStreamAsync(conversationId, user, CancellationToken.None);
 
         ConversationStreamRunContext runContext;
+        CancellationTokenSource? workerCts = null;
+        var registeredTurnId = Guid.Empty;
         try
         {
             var setupCt = CancellationToken.None;
@@ -165,10 +190,13 @@ public class ConversationService : IConversationService
                     conversationId);
             }
 
+            registeredTurnId = loaded.DbTurn.Id;
+            workerCts = _streamRunRegistry.Register(registeredTurnId);
+
             await _streamPolicy.OnTurnCreatedAsync(
                 conversationId,
                 new StreamTurnCreatedInfo(
-                    loaded.DbTurn!.Id,
+                    loaded.DbTurn.Id,
                     loaded.TurnIndex,
                     request.Instructions,
                     loaded.AssistantName,
@@ -182,21 +210,32 @@ public class ConversationService : IConversationService
         }
         catch
         {
+            if (workerCts != null)
+            {
+                _streamRunRegistry.Unregister(registeredTurnId);
+            }
+
             await lockHandle.ReleaseAsync(CancellationToken.None);
             throw;
         }
 
-        var streamToken = _streamRunRegistry.Register(runContext.DbTurn.Id, cancellationToken);
-        try
-        {
-            await foreach (var ev in _streamEngine.RunStreamAsync(runContext, lockHandle, streamToken))
+        yield return new StreamingEvent(
+            StreamingEventTypes.TurnCreated,
+            JsonSerializer.Serialize(new { turnId = registeredTurnId }, new JsonSerializerOptions
             {
-                yield return ev;
-            }
-        }
-        finally
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            }));
+
+        Action onWorkerCompleted = () => _streamRunRegistry.Unregister(registeredTurnId);
+
+        await foreach (var ev in _streamEngine.RunStreamAsync(
+            runContext,
+            lockHandle,
+            cancellationToken,
+            workerCts.Token,
+            onWorkerCompleted))
         {
-            _streamRunRegistry.Unregister(runContext.DbTurn.Id);
+            yield return ev;
         }
     }
 

--- a/src/server/GuideAntsApi/Services/Conversations/IConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/IConversationService.cs
@@ -28,6 +28,13 @@ public interface IConversationService
     /// Requests cancellation of an in-process stream for the given turn.
     /// </summary>
     Task<bool> CancelTurnStreamAsync(Guid conversationId, Guid turnId);
+
+    /// <summary>
+    /// Subscribe-only SSE stream for live conversation events (observers / reattach).
+    /// </summary>
+    IAsyncEnumerable<StreamingEvent> ObserveConversationEventsAsync(
+        Guid conversationId,
+        CancellationToken cancellationToken = default);
     
     // User conversations across all projects
     Task<PagedUserConversationsDto> GetUserConversationsAsync(UserConversationsQuery query);

--- a/src/server/GuideAntsApi/Services/Conversations/PublishedConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/PublishedConversationService.cs
@@ -37,6 +37,7 @@ public class PublishedConversationService : IPublishedConversationService
     private readonly IAttachmentContentService _attachmentContentService;
     private readonly PublishedConversationStreamPolicy _streamPolicy;
     private readonly IConversationStreamEngine _streamEngine;
+    private readonly ConversationStreamRunRegistry _streamRunRegistry;
 
     public PublishedConversationService(
         IServiceScopeFactory scopeFactory,
@@ -51,6 +52,7 @@ public class PublishedConversationService : IPublishedConversationService
         IAttachmentContentService attachmentContentService,
         PublishedConversationStreamPolicy streamPolicy,
         IConversationStreamEngine streamEngine,
+        ConversationStreamRunRegistry streamRunRegistry,
         IConfiguration? configuration = null)
     {
         _scopeFactory = scopeFactory;
@@ -65,6 +67,7 @@ public class PublishedConversationService : IPublishedConversationService
         _attachmentContentService = attachmentContentService;
         _streamPolicy = streamPolicy;
         _streamEngine = streamEngine;
+        _streamRunRegistry = streamRunRegistry;
         _configuration = configuration;
     }
 
@@ -181,7 +184,7 @@ public class PublishedConversationService : IPublishedConversationService
         };
 
         var lockHandle = await _streamPolicy.TryAcquireStreamAsync(conversationId, user, cancellationToken);
-        await foreach (var ev in _streamEngine.RunStreamAsync(runContext, lockHandle, cancellationToken))
+        await foreach (var ev in RunRegisteredStreamAsync(runContext, lockHandle, cancellationToken))
         {
             yield return ev;
         }
@@ -330,7 +333,25 @@ public class PublishedConversationService : IPublishedConversationService
         };
 
         var lockHandle = await _streamPolicy.TryAcquireStreamAsync(conversationId, user, cancellationToken);
-        await foreach (var ev in _streamEngine.RunStreamAsync(runContext, lockHandle, cancellationToken))
+        await foreach (var ev in RunRegisteredStreamAsync(runContext, lockHandle, cancellationToken))
+        {
+            yield return ev;
+        }
+    }
+
+    private async IAsyncEnumerable<StreamingEvent> RunRegisteredStreamAsync(
+        ConversationStreamRunContext runContext,
+        IStreamLockHandle lockHandle,
+        [EnumeratorCancellation] CancellationToken sseCt)
+    {
+        var turnId = runContext.DbTurn.Id;
+        var workerCts = _streamRunRegistry.Register(turnId);
+        await foreach (var ev in _streamEngine.RunStreamAsync(
+            runContext,
+            lockHandle,
+            sseCt,
+            workerCts.Token,
+            () => _streamRunRegistry.Unregister(turnId)))
         {
             yield return ev;
         }

--- a/src/server/GuideAntsApi/Services/Conversations/Queries/ConversationQueryService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Queries/ConversationQueryService.cs
@@ -1,5 +1,6 @@
 using AntRunner.Chat.Abstractions;
 using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Models.Conversations;
 using GuideAntsApi.Services.Auth;
 using GuideAntsApi.Services.Conversations.Mapping;
@@ -261,6 +262,37 @@ public class ConversationQueryService : IConversationQueryService
                 latestTurn.TerminationCode,
                 latestTurn.TerminalizedAt);
 
+        ConversationLockStatusDto? lockStatus = null;
+        var activeLock = await db.ConversationLocks
+            .AsNoTracking()
+            .Where(l => l.ConversationId == conversationId && l.ExpiresAt > DateTime.UtcNow)
+            .FirstOrDefaultAsync();
+        if (activeLock != null)
+        {
+            lockStatus = new ConversationLockStatusDto(activeLock.LockedByUserName, activeLock.LockedAt);
+        }
+
+        ConversationStreamingPreviewDto? streamingPreview = null;
+        if (latestTurn != null && string.Equals(latestTurn.Status, "streaming", StringComparison.OrdinalIgnoreCase))
+        {
+            var streamingStub = await db.NotebookConversationMessages
+                .AsNoTracking()
+                .Where(m => m.NotebookConversationId == conversationId
+                    && m.TurnIndex == latestTurn.TurnIndex
+                    && m.IsStreaming == true
+                    && m.Role == DataModelChatRole.Assistant)
+                .OrderByDescending(m => m.MessageSequence)
+                .FirstOrDefaultAsync();
+            if (streamingStub != null)
+            {
+                streamingPreview = new ConversationStreamingPreviewDto(
+                    streamingStub.Id,
+                    streamingStub.Content,
+                    streamingStub.ToolCalls,
+                    streamingStub.TurnIndex);
+            }
+        }
+
         return new NotebookConversationWithMessagesDto(
             conversationData.Id,
             conversationData.Title ?? "Untitled",
@@ -268,7 +300,9 @@ public class ConversationQueryService : IConversationQueryService
             conversationData.Created,
             conversationData.LastActivity,
             filteredMessageDtos,
-            activeTurn
+            activeTurn,
+            lockStatus,
+            streamingPreview
         );
     }
 

--- a/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamEngine.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamEngine.cs
@@ -170,21 +170,19 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
 
             void TryWrite(StreamingEvent ev)
             {
+                if ((ev.EventType == StreamingEventTypes.ExternalToolCall && policy.SupportsExternalToolResume)
+                    || ev.EventType == StreamingEventTypes.PendingClientTool)
+                {
+                    // Resume clients acquire a new lock as soon as they see these events.
+                    releaseStreamLockAsync().GetAwaiter().GetResult();
+                }
+
                 if (!hubWork.Writer.TryWrite(() => policy.BroadcastEventAsync(context.ConversationId, ev, CancellationToken.None)))
                 {
                     _logger.LogWarning(
                         "Dropped hub event {EventType} for {ConversationId}",
                         ev.EventType,
                         context.ConversationId);
-                }
-
-                if (ev.EventType == StreamingEventTypes.ExternalToolCall && policy.SupportsExternalToolResume)
-                {
-                    _ = releaseStreamLockAsync();
-                }
-                else if (ev.EventType == StreamingEventTypes.PendingClientTool)
-                {
-                    _ = releaseStreamLockAsync();
                 }
 
                 if (sseCt.IsCancellationRequested)
@@ -582,13 +580,26 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
             {
                 try
                 {
-                    if (streamingSucceeded)
+                    hubWork.Writer.TryComplete();
+                    try
                     {
-                        await policy.OnCompleteAsync(context.ConversationId, CancellationToken.None);
-                        TryWrite(new StreamingEvent(StreamingEventTypes.Complete, "{}"));
+                        await hubPump.ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Hub broadcast pump failed for {ConversationId}", context.ConversationId);
                     }
 
                     await releaseStreamLockAsync();
+
+                    if (streamingSucceeded)
+                    {
+                        await policy.OnCompleteAsync(context.ConversationId, CancellationToken.None);
+                        if (!sseCt.IsCancellationRequested)
+                        {
+                            writer.TryWrite(new StreamingEvent(StreamingEventTypes.Complete, "{}"));
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -596,16 +607,6 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
                 }
 
                 throttler?.Dispose();
-                hubWork.Writer.TryComplete();
-                try
-                {
-                    await hubPump.ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Hub broadcast pump failed for {ConversationId}", context.ConversationId);
-                }
-
                 writer.TryComplete();
                 onWorkerCompleted?.Invoke();
             }

--- a/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamEngine.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamEngine.cs
@@ -50,31 +50,22 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
     public async IAsyncEnumerable<StreamingEvent> RunStreamAsync(
         ConversationStreamRunContext context,
         IStreamLockHandle lockHandle,
-        [EnumeratorCancellation] CancellationToken externalCt)
+        [EnumeratorCancellation] CancellationToken sseCt,
+        CancellationToken workerCt,
+        Action? onWorkerCompleted = null)
     {
         var policy = context.Policy;
         var channel = CreateChannel();
-
-        await policy.OnStreamingStartedAsync(
-            context.ConversationId,
-            new StreamStreamingStartedInfo(context.AssistantName, context.TurnIndex),
-            CancellationToken.None);
-
-        StartBackgroundRun(context, channel.Writer, externalCt);
-
-        var streamingSucceeded = false;
-        var sawPendingClientTool = false;
-        var sawFailureEvent = false;
-        var distributedLockReleased = false;
+        var lockReleased = 0;
 
         async Task ReleaseStreamLockIfHeldAsync()
         {
-            if (distributedLockReleased)
+            if (Interlocked.CompareExchange(ref lockReleased, 1, 0) != 0)
             {
                 return;
             }
 
-            distributedLockReleased = await lockHandle.ReleaseAsync(CancellationToken.None);
+            var distributedLockReleased = await lockHandle.ReleaseAsync(CancellationToken.None);
             if (lockHandle.ConversationLockEventSent && distributedLockReleased)
             {
                 try
@@ -88,44 +79,22 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
             }
         }
 
-        try
-        {
-            await foreach (var ev in channel.Reader.ReadAllAsync(externalCt))
-            {
-                if (ev.EventType == StreamingEventTypes.ExternalToolCall && policy.SupportsExternalToolResume)
-                {
-                    // guideants-chat resumes on external_tool_call (before pending_client_tool). Release
-                    // here so a parallel tool-calls/results?resume=true can acquire the lock.
-                    await ReleaseStreamLockIfHeldAsync();
-                }
-                else if (ev.EventType == StreamingEventTypes.PendingClientTool)
-                {
-                    sawPendingClientTool = true;
-                    // Belt-and-suspenders for clients that wait for pending_client_tool.
-                    await ReleaseStreamLockIfHeldAsync();
-                }
-                else if (ev.EventType == StreamingEventTypes.Cancelled || ev.EventType == StreamingEventTypes.Error)
-                {
-                    sawFailureEvent = true;
-                }
+        await policy.OnStreamingStartedAsync(
+            context.ConversationId,
+            new StreamStreamingStartedInfo(context.AssistantName, context.TurnIndex),
+            CancellationToken.None);
 
-                await policy.BroadcastEventAsync(context.ConversationId, ev, externalCt);
-                yield return ev;
-            }
+        StartBackgroundRun(
+            context,
+            channel.Writer,
+            sseCt,
+            workerCt,
+            ReleaseStreamLockIfHeldAsync,
+            onWorkerCompleted);
 
-            // The background run owns terminal turn status (completed / cancelled / pending). A clean
-            // channel drain with no terminal event therefore means a successful turn.
-            streamingSucceeded = !sawPendingClientTool && !sawFailureEvent;
-        }
-        finally
+        await foreach (var ev in channel.Reader.ReadAllAsync(sseCt))
         {
-            await ReleaseStreamLockIfHeldAsync();
-        }
-
-        if (streamingSucceeded && (distributedLockReleased || !lockHandle.ConversationLockEventSent))
-        {
-            await policy.OnCompleteAsync(context.ConversationId, CancellationToken.None);
-            yield return new StreamingEvent(StreamingEventTypes.Complete, "{}");
+            yield return ev;
         }
     }
 
@@ -140,13 +109,36 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
     private void StartBackgroundRun(
         ConversationStreamRunContext context,
         ChannelWriter<StreamingEvent> writer,
-        CancellationToken externalCt)
+        CancellationToken sseCt,
+        CancellationToken workerCt,
+        Func<Task> releaseStreamLockAsync,
+        Action? onWorkerCompleted)
     {
         _ = Task.Run(async () =>
         {
             var policy = context.Policy;
             var noneCt = CancellationToken.None;
+            var streamingSucceeded = false;
             SemaphoreSlim? throttler = policy.UsesProgressThrottling ? new SemaphoreSlim(50, 50) : null;
+            var hubWork = Channel.CreateUnbounded<Func<Task>>(new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false
+            });
+            var hubPump = Task.Run(async () =>
+            {
+                await foreach (var work in hubWork.Reader.ReadAllAsync())
+                {
+                    try
+                    {
+                        await work().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to broadcast stream event for {ConversationId}", context.ConversationId);
+                    }
+                }
+            });
 
             Guid? currentAssistantMessageId = null;
             var currentAssistantContent = new StringBuilder();
@@ -178,14 +170,31 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
 
             void TryWrite(StreamingEvent ev)
             {
-                if (ConversationStreamEventWriter.IsTerminal(ev.EventType))
+                if (!hubWork.Writer.TryWrite(() => policy.BroadcastEventAsync(context.ConversationId, ev, CancellationToken.None)))
                 {
-                    ConversationStreamEventWriter.WriteTerminal(writer, ev, TimeSpan.FromSeconds(2));
+                    _logger.LogWarning(
+                        "Dropped hub event {EventType} for {ConversationId}",
+                        ev.EventType,
+                        context.ConversationId);
+                }
+
+                if (ev.EventType == StreamingEventTypes.ExternalToolCall && policy.SupportsExternalToolResume)
+                {
+                    _ = releaseStreamLockAsync();
+                }
+                else if (ev.EventType == StreamingEventTypes.PendingClientTool)
+                {
+                    _ = releaseStreamLockAsync();
+                }
+
+                if (sseCt.IsCancellationRequested)
+                {
                     return;
                 }
 
-                if (externalCt.IsCancellationRequested)
+                if (ConversationStreamEventWriter.IsTerminal(ev.EventType))
                 {
+                    ConversationStreamEventWriter.WriteTerminal(writer, ev, TimeSpan.FromSeconds(2));
                     return;
                 }
 
@@ -218,7 +227,7 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
 
             StreamingMessageProgressEventHandler onProgress = (_, e) =>
             {
-                if (externalCt.IsCancellationRequested)
+                if (workerCt.IsCancellationRequested)
                 {
                     return;
                 }
@@ -274,22 +283,15 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
 
                         if (!isThinking && !policy.SupportsExternalToolResume)
                         {
-                            _ = Task.Run(async () =>
+                            if (!hubWork.Writer.TryWrite(() => policy.BroadcastStreamingProgressAsync(
+                                    context.ConversationId,
+                                    context.User,
+                                    currentAssistantContent.Length,
+                                    progressCheckpoint.FlushCounter,
+                                    CancellationToken.None)))
                             {
-                                try
-                                {
-                                    await policy.BroadcastStreamingProgressAsync(
-                                        context.ConversationId,
-                                        context.User,
-                                        currentAssistantContent.Length,
-                                        progressCheckpoint.FlushCounter,
-                                        CancellationToken.None);
-                                }
-                                catch (Exception ex)
-                                {
-                                    _logger.LogWarning(ex, "Failed to broadcast streaming progress");
-                                }
-                            });
+                                _logger.LogWarning("Dropped streaming progress broadcast for {ConversationId}", context.ConversationId);
+                            }
                         }
                     }
                     catch
@@ -312,7 +314,7 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
 
             MessageAddedEventHandler onMessageAdded = (_, e) =>
             {
-                if (externalCt.IsCancellationRequested || string.IsNullOrEmpty(e.Role))
+                if (workerCt.IsCancellationRequested || string.IsNullOrEmpty(e.Role))
                 {
                     return;
                 }
@@ -349,7 +351,7 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
 
             try
             {
-                externalCt.ThrowIfCancellationRequested();
+                workerCt.ThrowIfCancellationRequested();
                 var httpClient = _httpClientFactory.CreateClient();
                 ChatRunOutput? output;
 
@@ -398,7 +400,7 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
                         },
                         resumeWithoutNewUserMessage: context.ResumeWithoutNewUserMessage,
                         ctx: invocationContext,
-                        token: externalCt,
+                        token: workerCt,
                         isAgentInvocation: false);
                 }
                 else
@@ -427,7 +429,7 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
                                 // Activity metadata is best-effort; never interrupt tool execution.
                             }
                         },
-                        cancellationToken: externalCt);
+                        cancellationToken: workerCt);
                 }
 
                 if (output?.Status != null
@@ -476,6 +478,7 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
 
                 await RegisterAndQueueNotebookSyncIfNeededAsync(context, output);
                 await PersistTraceSegmentAsync("completed", ct: noneCt);
+                streamingSucceeded = true;
             }
             catch (OperationCanceledException ex)
             {
@@ -577,10 +580,36 @@ public sealed class ConversationStreamEngine : IConversationStreamEngine
             }
             finally
             {
+                try
+                {
+                    if (streamingSucceeded)
+                    {
+                        await policy.OnCompleteAsync(context.ConversationId, CancellationToken.None);
+                        TryWrite(new StreamingEvent(StreamingEventTypes.Complete, "{}"));
+                    }
+
+                    await releaseStreamLockAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to finalize stream lifecycle for {ConversationId}", context.ConversationId);
+                }
+
                 throttler?.Dispose();
-                writer.Complete();
+                hubWork.Writer.TryComplete();
+                try
+                {
+                    await hubPump.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Hub broadcast pump failed for {ConversationId}", context.ConversationId);
+                }
+
+                writer.TryComplete();
+                onWorkerCompleted?.Invoke();
             }
-        }, externalCt);
+        }, CancellationToken.None);
     }
 
     private void HandleAssistantMessageAdded(

--- a/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamRunRegistry.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Streaming/ConversationStreamRunRegistry.cs
@@ -9,11 +9,15 @@ public sealed class ConversationStreamRunRegistry
 {
     private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _activeRuns = new();
 
-    public CancellationToken Register(Guid turnId, CancellationToken externalToken)
+    /// <summary>
+    /// Registers an in-process worker for <paramref name="turnId"/>.
+    /// The returned CTS is not linked to the HTTP SSE client; only explicit Stop cancels it.
+    /// </summary>
+    public CancellationTokenSource Register(Guid turnId)
     {
-        var linked = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
-        _activeRuns[turnId] = linked;
-        return linked.Token;
+        var cts = new CancellationTokenSource();
+        _activeRuns[turnId] = cts;
+        return cts;
     }
 
     public void Unregister(Guid turnId)

--- a/src/server/GuideAntsApi/Services/Conversations/Streaming/IConversationStreamEngine.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Streaming/IConversationStreamEngine.cs
@@ -34,8 +34,13 @@ public interface IConversationStreamEngine
     /// completion event. The same orchestration serves both private and published conversations; the
     /// supplied <paramref name="lockHandle"/> is a no-op for paths that do not lock.
     /// </summary>
+    /// <param name="sseCt">Cancels when the primary SSE client disconnects; does not stop the worker.</param>
+    /// <param name="workerCt">Cancels the background worker (explicit Stop).</param>
+    /// <param name="onWorkerCompleted">Invoked when the background worker finishes (success, cancel, or error).</param>
     IAsyncEnumerable<StreamingEvent> RunStreamAsync(
         ConversationStreamRunContext context,
         IStreamLockHandle lockHandle,
-        CancellationToken externalCt);
+        CancellationToken sseCt,
+        CancellationToken workerCt,
+        Action? onWorkerCompleted = null);
 }

--- a/src/server/GuideAntsApi/Services/SandboxWireApi/SandboxWireConversationService.cs
+++ b/src/server/GuideAntsApi/Services/SandboxWireApi/SandboxWireConversationService.cs
@@ -38,6 +38,7 @@ public sealed class SandboxWireConversationService : ISandboxWireConversationSer
     private readonly IConversationHistoryBuilder _historyBuilder;
     private readonly PublishedConversationStreamPolicy _streamPolicy;
     private readonly IConversationStreamEngine _streamEngine;
+    private readonly ConversationStreamRunRegistry _streamRunRegistry;
     private readonly IConversationPersistence _persistence;
     private readonly IAttachmentContentService _attachmentContentService;
     private readonly IConfiguration? _configuration;
@@ -49,6 +50,7 @@ public sealed class SandboxWireConversationService : ISandboxWireConversationSer
         IConversationHistoryBuilder historyBuilder,
         PublishedConversationStreamPolicy streamPolicy,
         IConversationStreamEngine streamEngine,
+        ConversationStreamRunRegistry streamRunRegistry,
         IConversationPersistence persistence,
         IAttachmentContentService attachmentContentService,
         IConfiguration? configuration = null)
@@ -59,6 +61,7 @@ public sealed class SandboxWireConversationService : ISandboxWireConversationSer
         _historyBuilder = historyBuilder;
         _streamPolicy = streamPolicy;
         _streamEngine = streamEngine;
+        _streamRunRegistry = streamRunRegistry;
         _persistence = persistence;
         _attachmentContentService = attachmentContentService;
         _configuration = configuration;
@@ -208,7 +211,14 @@ public sealed class SandboxWireConversationService : ISandboxWireConversationSer
         };
 
         var lockHandle = await _streamPolicy.TryAcquireStreamAsync(conversationId, user, ct);
-        await foreach (var ev in _streamEngine.RunStreamAsync(runContext, lockHandle, ct))
+        var turnId = runContext.DbTurn.Id;
+        var workerCts = _streamRunRegistry.Register(turnId);
+        await foreach (var ev in _streamEngine.RunStreamAsync(
+            runContext,
+            lockHandle,
+            ct,
+            workerCts.Token,
+            () => _streamRunRegistry.Unregister(turnId)))
         {
             yield return ev;
         }


### PR DESCRIPTION
Make Stop cancel the run explicitly.

SSE abort is not Stop: register the worker before turn_created, reattach senders and observers, and cancel only via cancelTurn. Treat Responses terminal SSE as authoritative and read ChatDefaults from application settings for local warmup.