### PR TITLE
Fix: allow API startup when LlamaCpp uses discard loopback :9

### DIFF
--- a/src/server/GuideAntsApi.Tests/Configuration/RuntimeConfigurationPlaceholdersTests.cs
+++ b/src/server/GuideAntsApi.Tests/Configuration/RuntimeConfigurationPlaceholdersTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using GuideAntsApi.Configuration;
+
+namespace GuideAntsApi.Tests.Configuration;
+
+[TestClass]
+public sealed class RuntimeConfigurationPlaceholdersTests
+{
+    [TestMethod]
+    public void IsDiscardLoopbackUrl_LoopbackPort9_IsTrue()
+    {
+        RuntimeConfigurationPlaceholders.IsDiscardLoopbackUrl("http://127.0.0.1:9").Should().BeTrue();
+        RuntimeConfigurationPlaceholders.IsDiscardLoopbackUrl("http://127.0.0.1:9/llama-cpp").Should().BeTrue();
+        RuntimeConfigurationPlaceholders.IsDiscardLoopbackUrl("http://localhost:9").Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void HasUsableUrl_LoopbackPort9_IsFalse()
+    {
+        RuntimeConfigurationPlaceholders.HasUsableUrl("http://127.0.0.1:9/llama-cpp").Should().BeFalse();
+        RuntimeConfigurationPlaceholders.HasUsableUrl("http://localhost:9").Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void HasUsableUrl_RealStackHost_IsTrue()
+    {
+        RuntimeConfigurationPlaceholders.HasUsableUrl("http://guideants-ai:80/llama-cpp").Should().BeTrue();
+        RuntimeConfigurationPlaceholders.HasUsableUrl("http://127.0.0.1:8110/llama-cpp").Should().BeTrue();
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStackHostUrlsTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiStackHostUrlsTests.cs
@@ -1,0 +1,112 @@
+using FluentAssertions;
+using GuideAntsApi.Services.Bootstrap;
+using GuideAntsApi.Services.LlamaCpp;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GuideAntsApi.Tests.Services.Bootstrap;
+
+[TestClass]
+public sealed class LocalAiStackHostUrlsTests
+{
+    [TestMethod]
+    public void NormalizeStackBaseUrl_DiscardLoopback_ReturnsNull()
+    {
+        LocalAiStackHostUrls.NormalizeStackBaseUrl("http://127.0.0.1:9/llama-cpp").Should().BeNull();
+        LocalAiStackHostUrls.NormalizeStackBaseUrl("http://localhost:9").Should().BeNull();
+    }
+
+    [TestMethod]
+    public void TryDeriveAdminBaseUriFromLlamaCppUrl_DiscardLoopback_ReturnsNull()
+    {
+        LocalAiStackHostUrls.TryDeriveAdminBaseUriFromLlamaCppUrl("http://127.0.0.1:9/llama-cpp")
+            .Should().BeNull();
+    }
+
+    [TestMethod]
+    public void DeriveAdminBaseUriFromLlamaCppUrl_DiscardLoopback_Throws()
+    {
+        var derive = () => LocalAiStackHostUrls.DeriveAdminBaseUriFromLlamaCppUrl(
+            "http://127.0.0.1:9/llama-cpp");
+
+        derive.Should().Throw<ArgumentException>().WithParameterName("llamaCppBaseUrl");
+    }
+
+    [TestMethod]
+    public void TryDeriveAdminBaseUriFromLlamaCppUrl_UsableUrl_DerivesLlamaAdmin()
+    {
+        var uri = LocalAiStackHostUrls.TryDeriveAdminBaseUriFromLlamaCppUrl("http://guideants-ai:80/llama-cpp");
+
+        uri.Should().NotBeNull();
+        uri!.AbsoluteUri.Should().Be("http://guideants-ai/llama-admin/");
+    }
+
+    [TestMethod]
+    public void ApplyLlamaRuntimeAdminBaseAddress_DiscardLoopback_LeavesBaseAddressUnset()
+    {
+        using var client = new HttpClient();
+
+        var apply = () => LocalAiStackHostUrls.ApplyLlamaRuntimeAdminBaseAddress(
+            client,
+            "http://127.0.0.1:9/llama-cpp");
+
+        apply.Should().NotThrow();
+        client.BaseAddress.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ApplyLlamaRuntimeAdminBaseAddress_UsableUrl_SetsLlamaAdminBaseAddress()
+    {
+        using var client = new HttpClient();
+
+        LocalAiStackHostUrls.ApplyLlamaRuntimeAdminBaseAddress(client, "http://guideants-ai:80/llama-cpp");
+
+        client.BaseAddress.Should().NotBeNull();
+        client.BaseAddress!.AbsoluteUri.Should().Be("http://guideants-ai/llama-admin/");
+    }
+
+    [TestMethod]
+    public void StackHostResolver_SlimDiscardUrls_HasNoConfiguredStack()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["LlamaCpp:BaseUrl"] = "http://127.0.0.1:9/llama-cpp",
+                ["LocalServiceHosts:SpeechTranscriptionBaseUrl"] = "http://127.0.0.1:9",
+                ["LocalServiceHosts:SpeechSynthesisBaseUrl"] = "http://127.0.0.1:9",
+                ["LocalServiceHosts:ImageGenerationBaseUrl"] = "http://127.0.0.1:9",
+                ["LocalServiceHosts:EmbeddingsBaseUrl"] = "http://127.0.0.1:9",
+            })
+            .Build();
+
+        var resolver = new LocalAiStackHostResolver(configuration);
+
+        resolver.HasAnyConfiguredStack().Should().BeFalse();
+        resolver.GetAllConfiguredStackBases().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void LlamaRuntimeAdminClient_DiscardLoopback_CanBeResolvedFromDi()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["LlamaCpp:BaseUrl"] = "http://127.0.0.1:9/llama-cpp",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient<ILlamaRuntimeAdminClient, LlamaRuntimeAdminClient>(client =>
+        {
+            var baseUrl = configuration["LlamaCpp:BaseUrl"]
+                ?? throw new InvalidOperationException("LlamaCpp:BaseUrl is required.");
+            LocalAiStackHostUrls.ApplyLlamaRuntimeAdminBaseAddress(client, baseUrl);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var resolve = () => provider.GetRequiredService<ILlamaRuntimeAdminClient>();
+
+        resolve.Should().NotThrow();
+    }
+}

--- a/src/server/GuideAntsApi/Configuration/StartupConfiguration.cs
+++ b/src/server/GuideAntsApi/Configuration/StartupConfiguration.cs
@@ -189,7 +189,7 @@ public static class StartupConfiguration
             var config = configuration.GetSection("LlamaCpp");
             var baseUrl = config["BaseUrl"]
                 ?? throw new InvalidOperationException("LlamaCpp:BaseUrl is required.");
-            client.BaseAddress = LocalAiStackHostUrls.DeriveAdminBaseUriFromLlamaCppUrl(baseUrl);
+            LocalAiStackHostUrls.ApplyLlamaRuntimeAdminBaseAddress(client, baseUrl);
             client.Timeout = TimeSpan.FromHours(4);
         });
         services.Configure<LlamaInferenceTimeoutRecoveryOptions>(

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStackHostUrls.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiStackHostUrls.cs
@@ -59,7 +59,28 @@ internal static class LocalAiStackHostUrls
         return builder.Uri;
     }
 
+    public static Uri? TryDeriveAdminBaseUriFromLlamaCppUrl(string? llamaCppBaseUrl)
+    {
+        var normalized = NormalizeStackBaseUrl(llamaCppBaseUrl);
+        return normalized is null ? null : DeriveAdminBaseUri(normalized);
+    }
+
     public static Uri DeriveAdminBaseUriFromLlamaCppUrl(string llamaCppBaseUrl) =>
-        DeriveAdminBaseUri(NormalizeStackBaseUrl(llamaCppBaseUrl)
-            ?? throw new ArgumentException("LlamaCpp base URL is not usable.", nameof(llamaCppBaseUrl)));
+        TryDeriveAdminBaseUriFromLlamaCppUrl(llamaCppBaseUrl)
+            ?? throw new ArgumentException("LlamaCpp base URL is not usable.", nameof(llamaCppBaseUrl));
+
+    /// <summary>
+    /// Binds llama-admin on the typed HttpClient when <paramref name="llamaCppBaseUrl"/> is a real
+    /// stack host. Loopback port 9 is the operator sentinel for "not in use"; leave BaseAddress
+    /// unset so client construction cannot fail API startup.
+    /// </summary>
+    public static void ApplyLlamaRuntimeAdminBaseAddress(HttpClient client, string llamaCppBaseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        var adminBase = TryDeriveAdminBaseUriFromLlamaCppUrl(llamaCppBaseUrl);
+        if (adminBase is not null)
+        {
+            client.BaseAddress = adminBase;
+        }
+    }
 }


### PR DESCRIPTION
Loopback port 9 means local llama is not in use. Do not fail typed admin client construction while deriving ga-admin from that sentinel.