### PR TITLE
Lazy-load host mount trees and harden notebook sync / local-model lifecycle edges

### DIFF
--- a/docs/host-folder-mounts.md
+++ b/docs/host-folder-mounts.md
@@ -167,6 +167,15 @@ primary security invariant — never bypass it with fallback logic.
 - Mounted contents are **not recursively indexed** by default (both sync paths
   skip reparse-point descent).
 
+### Folder tree browsing
+
+The folder tree shows a **depth-3 first page** of each linked mount (cached;
+default TTL 120s via `FileStorage:LinkedMountTreeCacheSeconds`). Expanding a
+folder under the mount lazy-loads **one directory level** through
+`GET .../host-mounts/listing?path=...`. Polling the tree must not re-walk the
+host while the cache is warm. Deeper content is never a hard ceiling — only an
+unexpanded page.
+
 ### Layout invariant
 
 Mapped folders appear as `{notebookRoot}/{leafName}`. Any `External/` (or

--- a/docs/local-ai-lifecycle/ARCHITECTURE.md
+++ b/docs/local-ai-lifecycle/ARCHITECTURE.md
@@ -6,6 +6,13 @@
 service is enabled, which model or bundle is selected, and when the resulting
 plan must be applied.
 
+For local chat, the **active quant / GGUF set for a router alias** is owned by
+API installation provenance (`LocalModelInstallations` and the install /
+change-quant flows that write it). Router INI, loaded `--model` args,
+llama-admin journals, and files under the model store are apply outputs only.
+They must never be treated as a second source of which quant is selected —
+including during incident debugging.
+
 `ga-admin` is a mechanical executor. Engines are mechanical workers. Neither
 may infer policy from environment defaults, model folders, marker files,
 previous status, or container startup.

--- a/docs/local-ai-lifecycle/TESTING.md
+++ b/docs/local-ai-lifecycle/TESTING.md
@@ -11,6 +11,14 @@ The contract is protected at three layers:
   generation and skips bundle projection.
 - `LocalAiDesiredStateBuilderTests` proves ServiceModes produce explicit JSON
   lifecycle state and missing local selections fail.
+- `LocalAiDesiredStateBuilderTests` proves ApplicationSettings `ChatDefaults`
+  (not `IConfiguration`) drives the startup llama router alias when a local
+  catalog row exists.
+- `LocalAiWarmupOrchestrationClientTests` proves dual-stack status merge uses
+  `max(appliedRevision)` so independent revision counters do not block warmup
+  completion.
+- `LocalAiStartupWarmupServiceTests` proves `waitForCompletion: true` clears
+  `IsWarmupInProgress` once merged apply status reaches `applied`.
 - `LocalServiceModeSelectionReaderTests` proves selection reads do not mutate
   ServiceModes.
 - `LocalAiLifecycleAuthorityContractTests` scans runtime/configuration sources

--- a/docs/project-root-host-folder-mounts.md
+++ b/docs/project-root-host-folder-mounts.md
@@ -142,20 +142,39 @@ Mount nodes carry metadata:
 - Unique deterministic IDs (SHA256 of mount ID + path) for stable
   expand/collapse state in the UI
 
-**Shared scanner.** `HostMountDirectoryScanner` is a static helper extracted from
-`NotebookFileService.BuildLinkedMountFileDtosAsync`. Both the notebook and
-project trees use the same budgeted directory scan with identical constraints:
+**Shared scanner.** `HostMountDirectoryScanner` is shared by notebook and project
+trees. The initial tree load is a **first page**, not a hard ceiling:
 
 | Parameter | Default | Config key |
 |---|---|---|
-| Max files | 5,000 | `FileStorage:LinkedMountTreeMaxFiles` |
-| Max depth | 3 | `FileStorage:LinkedMountTreeMaxDepth` |
+| Max files (per scan/list) | 5,000 | `FileStorage:LinkedMountTreeMaxFiles` |
+| Initial max depth | 3 | `FileStorage:LinkedMountTreeMaxDepth` |
 | Scan timeout | 2,500 ms | `FileStorage:LinkedMountTreeScanBudgetMs` |
+| Shallow + listing cache TTL | 120 s | `FileStorage:LinkedMountTreeCacheSeconds` |
+| Project overlay cache TTL | 120 s | `FileStorage:ProjectMountTreeCacheSeconds` |
 
-The scanner filters out temporary script files (`{hash}_script.sh/ps1/py`) and
+**Browse model (R1–R4):**
+
+1. **Initial window** — eager scan to depth 3 from the mount root, including
+   **directory stubs** (folders appear even when they have no files in-window).
+2. **Lazy load** — expanding a folder under a mount fetches **one directory
+   level** via `GET .../host-mounts/listing?path=...` (immediate files + child
+   folder stubs). Deeper levels require further expands.
+3. **Cache** — shallow root pages and per-path listings are cached. Polling
+   `.../tree` must not re-walk the host when the cache is warm. Invalidate on
+   mount reconcile/remove, API mutations under the mount, and explicit refresh.
+4. **Sync** — mount interiors are still not recursively indexed into
+   `NotebookFile`; browse APIs only.
+
+The scanner filters temporary script files (`{hash}_script.sh/ps1/py`) and
 `__pycache__/` directories. Notebook-specific filters (`Resources/`,
 `.guideants/`) are applied in `NotebookFileService` after scanning, not in the
 shared scanner.
+
+**Acceptance:** Playwright scenario
+`walkthroughs/scenarios/notebook/host-mount-lazy-tree.spec.ts` proves expand
+below depth 3 against the notebook’s **existing** linked host mount (default path
+`samples/skills/audiocpp skills`). Unit tests are supporting only.
 
 **DTO additions.** `FolderTreeDto` gained four optional fields:
 

--- a/docs/release-notes-v0.10.md
+++ b/docs/release-notes-v0.10.md
@@ -1,0 +1,45 @@
+# GuideAnts v0.10
+
+**Streaming that survives disconnects** — Stop is explicit, long thinking turns stay alive, and cancel/timeout keeps the tokens you already saw. OpenAI/Azure **Responses** is a stateless transport owned by GuideAnts (no provider-side conversation chaining). GuideAntsApi is now the sole authority for local AI warmup. AI / support images republished to GHCR for this cut.
+
+## Get started
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Windows/macOS) or Docker Engine 24+ with Compose (Linux). Windows needs WSL2.
+2. Download **`guideants-installer-v0.10.zip`** from this release.
+3. Unzip and run:
+   - **Windows:** double-click `guideants.cmd`
+   - **Linux / macOS:** `chmod +x guideants.sh && ./guideants.sh`
+4. Choose database layout, AI backend, and optional services when prompted.
+5. Open **http://localhost:5107/** — first account becomes Admin.
+
+Existing installs: relaunch the installer; if `:main` moved past your pins, accept the update prompt to pick up this channel. Volumes are kept.
+
+## Highlights
+
+### Conversation streaming
+- Closing or dropping the SSE connection is **not** Stop. The worker stays registered, senders and observers can reattach, and only **Stop** (`cancelTurn`) cancels the run
+- If you accidently navigate you can come back and the stream is there
+- If a scheduled job is running you can observe the conversation as it happens
+- Thinking deltas are checkpointed, keep-alive streams no longer abort on `NotSupportedException`, and stale-turn recovery does not clobber an in-process run
+- Silent or truncated streams are detected on the client (idle timeout, missing terminal events); the server always delivers a terminal event even when the channel is backpressured
+- Cancel, idle timeout, and token-limit stops persist thinking blocks and accumulated usage (no zero-token usage rows). Empty assistant shells are hidden from conversation history
+- Force-refresh no longer wipes local cancel/idle content, while idle-timeout failures still surface in the UI
+
+### OpenAI Responses API
+- Replaced the SDK Responses streaming client with a GuideAnts HTTP transport
+- Requests are stateless: `store: false`, no `previous_response_id`. GuideAnts sends its own SQL transcript; the provider does not chain responses
+- Live text and thinking come from SSE deltas; the final message, tool calls, and usage come from `response.completed`
+
+### Local AI warmup
+- **GuideAntsApi owns warmup policy.** Desired load/unload is an explicit JSON plan derived from `ServiceModes`, not an INI file or container autoload
+- `ga-admin` validates and executes that plan only: no engine-inventory backfill, no startup autoload
+- Split stacks (chat on one host, embeddings/ASR/TTS on another) get a complete per-host plan so each box loads only what it owns
+
+### Images
+- AI / support images republished to GHCR (`:main`, `:latest`, and `:v0.10`) for this cut: cpu, cuda13, rocm, slim, vulkan, plus PlantUML, MSSQL FTS, and SearXNG
+- Web API images (`guideants-webapi-ui-slim`, `guideants-webapi-ui-mssql`) published to GHCR `:main` from this commit
+
+## Notes
+
+- Apple Silicon: prefer the **slim** AI backend (`linux/amd64` under emulation).
+- Operator details: `docs/release-runbook.md`, `docs/local-ai-lifecycle/`, `installer/README.md`, `deploy/azure/README.md`.

--- a/docs/release-notes-v0.9.15.md
+++ b/docs/release-notes-v0.9.15.md
@@ -1,0 +1,41 @@
+# GuideAnts v0.9.15
+
+Patch release: faster, safer skill/MCP sandbox venv apply, OpenRouter/Hugging Face thinking controls, setup-wizard API key fixes, and Azure deploy venv migration cleanup. AI / support images republished to GHCR for this cut.
+
+## Get started
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Windows/macOS) or Docker Engine 24+ with Compose (Linux). Windows needs WSL2.
+2. Download **`guideants-installer-v0.9.15.zip`** from this release.
+3. Unzip and run:
+   - **Windows:** double-click `guideants.cmd`
+   - **Linux / macOS:** `chmod +x guideants.sh && ./guideants.sh`
+4. Choose database layout, AI backend, and optional services when prompted.
+5. Open **http://localhost:5107/** — first account becomes Admin.
+
+Existing installs: relaunch the installer; if `:main` moved past your pins, accept the update prompt to pick up this channel. Volumes are kept.
+
+## Highlights
+
+### Script execution / sandboxes
+- **Surgical scoped apply:** global/startup reconcile is apt-only; scoped apply updates one guide venv (`pip` + install scripts) instead of walking every scope on startup
+- **Durable scoped venvs:** packages persist across restarts; repeat apply skips when already satisfied
+- **Pip reconcile fixes:** reinstall when desired packages are missing even if the applied-state hash matched; prune/list only the scoped venv’s own site-packages so base-runtime inheritance is not torn down every run
+
+### Models & providers
+- **OpenRouter and Hugging Face rows** own `ThinkingControlJson` and `RequestFieldsWhenToolsPresentJson` (e.g. `chat_template_kwargs.enable_thinking`, extra body fields such as `parallel_tool_calls`)
+- Guide reasoning choice now reaches the request instead of being silently overridden by the row default
+
+### Setup wizard
+- Fix API key handling in step 4 on first run for OpenAI, OpenRouter, Hugging Face, and Gemini flows
+
+### Azure deploy
+- Reset / migrate scoped script venvs when the Azure Files mount layout changes (mfsymlinks), without blocking deploy or mutating SQL config unexpectedly
+- Deploy scripts and slim entrypoint updated for the new venv lifecycle
+
+### Images
+- AI / support images republished to GHCR (`:main`, `:latest`, and `:v0.9.15`) for this cut
+
+## Notes
+
+- Apple Silicon: prefer the **slim** AI backend (`linux/amd64` under emulation).
+- Operator details: `docs/release-runbook.md`, `installer/README.md`, `deploy/azure/README.md`.

--- a/docs/release-notes-v0.9.18.md
+++ b/docs/release-notes-v0.9.18.md
@@ -1,0 +1,43 @@
+# GuideAnts v0.9.18
+
+**Muse Glimmer support** — curated install for Muse Glimmer 30B (vision + 131k context + DFlash companion weights), plus notebook folder UX, richer PDF/OCR sandboxes, and connection/routing fixes. AI / support images republished to GHCR for this cut.
+
+## Get started
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Windows/macOS) or Docker Engine 24+ with Compose (Linux). Windows needs WSL2.
+2. Download **`guideants-installer-v0.9.18.zip`** from this release.
+3. Unzip and run:
+   - **Windows:** double-click `guideants.cmd`
+   - **Linux / macOS:** `chmod +x guideants.sh && ./guideants.sh`
+4. Choose database layout, AI backend, and optional services when prompted.
+5. Open **http://localhost:5107/** — first account becomes Admin.
+
+Existing installs: relaunch the installer; if `:main` moved past your pins, accept the update prompt to pick up this channel. Volumes are kept.
+
+## Highlights
+
+### Muse Glimmer
+- **Muse Glimmer 30B** (`unsloth/Muse-Glimmer-30B-GGUF`) in the curated llama catalog: vision mmproj, 131k context, Meta-recommended sampling defaults, and reasoning tiers via system-prompt directive
+- **Companion artifacts:** optional HF files beyond model + mmproj (e.g. DFlash `dflash-kquant.gguf`), with install progress and DB provenance
+- **Chat behavior lives on the catalog entry:** curated installs write sampling/reasoning defaults straight to the model row; Runtime Profiles are retired
+- AI images rebuilt against a newer llama.cpp (needed for the `muse-glimmer` arch); ROCm ASR/TTS backend env corrected
+
+### Notebook & samples
+- Copy path for files and folders; multi-select folders (Shift/Ctrl) with bulk delete
+- Sample guide for Notion MCP
+
+### Script sandboxes
+- Apt/pip additions for PDF and OCR workflows: `tesseract-ocr`, `ghostscript`, `poppler-utils`, `ocrmypdf`, `pypdf`, `openpyxl`, plus dependency pin hotfixes
+
+### Fixes
+- Microsoft Foundry Connections no longer overwrite the stored API key when editing only the Resource field
+- Unmatched SPA routes show a NotFound page (auto-home after 30s) instead of a blank screen
+
+### Images
+- AI / support images republished to GHCR (`:main`, `:latest`, and `:v0.9.18`) for this cut
+
+## Notes
+
+- Apple Silicon: prefer the **slim** AI backend (`linux/amd64` under emulation).
+- Glimmer needs the republished AI images from this release (newer llama.cpp).
+- Operator details: `docs/release-runbook.md`, `installer/README.md`, `deploy/azure/README.md`.

--- a/docs/release-notes-v0.9.19.md
+++ b/docs/release-notes-v0.9.19.md
@@ -1,0 +1,40 @@
+# GuideAnts v0.9.19
+
+**Qwen 3.8 27B** — curated install for Unsloth’s dense 27B vision model (262k context, hybrid thinking, in-GGUF draft-mtp), plus catalog-edit recovery when llama.cpp rejects a preset, clearer ReadWeb errors, and CWD-relative copy paths. AI / support images republished to GHCR for this cut.
+
+## Get started
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Windows/macOS) or Docker Engine 24+ with Compose (Linux). Windows needs WSL2.
+2. Download **`guideants-installer-v0.9.19.zip`** from this release.
+3. Unzip and run:
+   - **Windows:** double-click `guideants.cmd`
+   - **Linux / macOS:** `chmod +x guideants.sh && ./guideants.sh`
+4. Choose database layout, AI backend, and optional services when prompted.
+5. Open **http://localhost:5107/** — first account becomes Admin.
+
+Existing installs: relaunch the installer; if `:main` moved past your pins, accept the update prompt to pick up this channel. Volumes are kept.
+
+## Highlights
+
+### Qwen 3.8 27B
+- **Qwen 3.8 27B** (`unsloth/Qwen3.8-27B-GGUF`) in the curated llama catalog: vision mmproj, 262k native context, in-GGUF draft-mtp, and hybrid thinking with `reasoning_effort` (default **xhigh**)
+- Sampling defaults on the catalog row (temperature 1.0 / top_p 0.95 / top_k 20); Unsloth 4-bit typical **17–19GB** RAM+VRAM (`UD-Q4_K_XL`)
+- Needs the republished AI images from this release (older llama.cpp crashes on `draft-mtp` / `reasoning-preserve`)
+
+### Local model catalog
+- Saving a router preset no longer 502s after llama-server rejects unknown keys; unrecognized options are stripped on respawn so the editor can recover
+- `no-mmproj` is rewritten to `mmproj-auto=false`
+
+### ReadWeb & notebook
+- ReadWeb failures report the actual status (401 / 403 / 404 / 429 / 5xx / timeout) instead of a generic error
+- GitHub hosts are not auto-excluded; excluded-host blocks are honored before fetch
+- Copy-path and attachment paths are CWD-relative so pasted paths work in chat tools
+
+### Images
+- AI / support images republished to GHCR (`:main`, `:latest`, and `:v0.9.19`) for this cut
+
+## Notes
+
+- Apple Silicon: prefer the **slim** AI backend (`linux/amd64` under emulation).
+- Qwen 3.8 27B needs the republished AI images from this release (newer llama.cpp).
+- Operator details: `docs/release-runbook.md`, `installer/README.md`, `deploy/azure/README.md`.

--- a/src/.cursor/rules/local-ai-lifecycle-authority.mdc
+++ b/src/.cursor/rules/local-ai-lifecycle-authority.mdc
@@ -7,6 +7,11 @@ alwaysApply: true
 
 - `GuideAntsApi` alone decides enabled/disabled state and model/bundle selection.
 - `ServiceModes` is authoritative for auxiliary service routing and selections.
+- For local chat models, **active quant / artifact selection for an alias** is
+  owned by API installation provenance (`LocalModelInstallations` and the
+  change-quant / install flows that write it). Router INI, loaded `--model`
+  args, llama-admin journals, and files under the model store are apply
+  outputs only — never a second source of “which quant is selected.”
 - `ga-admin` only validates and executes a complete plan explicitly submitted by
   the API. It must start empty/idle and must not load engines on boot.
 - Engine folders, inventory endpoints, status, and marker files are diagnostic
@@ -26,3 +31,33 @@ alwaysApply: true
 
 Read `docs/local-ai-lifecycle/ARCHITECTURE.md` before changing local AI startup,
 routing, warmup, model selection, engine admin, or compose behavior.
+
+## Debugging and incident investigation (same severity as design)
+
+“Only diagnosing” is not an exception. Inspecting the AI container to learn
+what is selected is the same failure mode as autoloading from inventory.
+
+When API provenance and runtime behavior disagree:
+
+1. **Investigation root is GuideAntsApi only.** Start with
+   `LocalModelInstallations` / settings APIs / GuideAntsApi logs /
+   `LocalAiRuntimeAlignmentVerifier` and the API apply path that projects
+   selection to the executor.
+2. Executor evidence (e.g. a log line that a process loaded path X) may be
+   cited as a **one-line symptom**. It must not become a spelunking session
+   inside the executor.
+3. **Forbidden without the user explicitly authorizing it in that message:**
+   - `docker exec` into `guideants-ai` (or any llama/ga-admin engine host)
+     to decide or explain selection
+   - Reading or grepping `router-models.ini`, `router-models.runtime.ini`,
+     seed INI, or HostMounts copies of those files as “the real model”
+   - Treating llama-admin download journals, staging dirs, or on-disk GGUF
+     sets as authoritative for which quant is active
+   - Using loaded `--model` / inventory / `/v1/models` args to override or
+     second-guess API installation provenance
+4. **Allowed without extra permission:** GuideAntsApi DB/API reads, API
+   container logs, and edits under GuideAntsApi that apply API-owned
+   selection to the executor.
+5. Fixes belong in GuideAntsApi apply/verify paths. Do not “fix” drift by
+   hand-editing executor state unless the user explicitly orders that
+   intervention in the current message.

--- a/src/client/src/components/notebook/conversations/CellList.tsx
+++ b/src/client/src/components/notebook/conversations/CellList.tsx
@@ -11,8 +11,6 @@ import { useConversationStore } from '../../../store/conversationStore';
 import WorkflowSection from './WorkflowSection';
 import { AssistantOption } from './AssistantSelector';
 import { AttachedFile } from '../../../types/conversation';
-import { useNotebookFilesPolling } from '../../../hooks/useNotebookFilesPolling';
-import { NotebookFolderTreeDto } from '../../../types/notebook';
 
 // Debounce utility hook
 function useDebounce<T extends (...args: any[]) => any>(
@@ -175,8 +173,7 @@ function AssistantCellWrapper({
   conversationId,
   totalMessages,
   canEdit,
-  onTurnFileClick,
-  isValidFilePath
+  onTurnFileClick
 }: { 
   message: MessageDto; 
   isLast: boolean;
@@ -191,8 +188,6 @@ function AssistantCellWrapper({
   totalMessages: number;
   canEdit?: boolean;
   onTurnFileClick?: (relativePath: string) => void;
-  /** Filter function to check if a file path exists in the notebook tree */
-  isValidFilePath?: (path: string) => boolean;
 }) {
   const [editorInfo, setEditorInfo] = useState<UserInfo | null>(null);
   
@@ -270,9 +265,9 @@ function AssistantCellWrapper({
         totalMessages: totalMessages,
       }}
       canEdit={Boolean(canEdit)}
-      // Turn file tracking - filter to only show files that exist in the notebook tree
-      turnFilesCreated={isValidFilePath ? message.turnFilesCreated?.filter(isValidFilePath) : message.turnFilesCreated}
-      turnFilesModified={isValidFilePath ? message.turnFilesModified?.filter(isValidFilePath) : message.turnFilesModified}
+      // Turn file pills: show what the turn recorded (do not gate on live tree membership).
+      turnFilesCreated={message.turnFilesCreated}
+      turnFilesModified={message.turnFilesModified}
       onTurnFileClick={onTurnFileClick}
     />
   );
@@ -334,50 +329,6 @@ const CellList = React.memo(function CellList({
 
   // Get notebook context for projectId/notebookId
   const { projectId, notebookId: contextNotebookId } = useNotebook();
-
-  // Get folder tree to validate which files actually exist (for filtering turn file pills)
-  const { folderTree } = useNotebookFilesPolling({
-    projectId: projectId || '',
-    notebookId: contextNotebookId || '',
-    enabled: Boolean(projectId && contextNotebookId),
-  });
-
-  // Helper to collect all file paths from the folder tree
-  const collectFilePaths = useCallback((node: NotebookFolderTreeDto | null): Set<string> => {
-    const paths = new Set<string>();
-    if (!node) return paths;
-    
-    // Add files in this folder
-    for (const file of node.files) {
-      // Add various path formats that might be used
-      paths.add(file.relativePath);
-      paths.add(file.fileName);
-      // Also add without Output/ prefix if present
-      if (file.relativePath.startsWith('Output/')) {
-        paths.add(file.relativePath.substring(7));
-      }
-    }
-    
-    // Recurse into subfolders
-    for (const subFolder of node.subFolders) {
-      const subPaths = collectFilePaths(subFolder);
-      subPaths.forEach(p => paths.add(p));
-    }
-    
-    return paths;
-  }, []);
-
-  // Memoize the set of valid file paths
-  const validFilePaths = useMemo(() => collectFilePaths(folderTree), [folderTree, collectFilePaths]);
-
-  // Filter function to check if a file path exists in the tree
-  const isValidFilePath = useCallback((filePath: string): boolean => {
-    if (!filePath) return false;
-    // Check exact match or common variations
-    return validFilePaths.has(filePath) || 
-           validFilePaths.has(`Output/${filePath}`) ||
-           validFilePaths.has(filePath.replace(/^\.\.\//, ''));
-  }, [validFilePaths]);
 
   const [currentUser, setCurrentUser] = useState<UserInfo | null>(null);
 
@@ -991,7 +942,6 @@ const CellList = React.memo(function CellList({
                       totalMessages={messages.length}
                       canEdit={canEdit}
                       onTurnFileClick={onPreviewFileByPath}
-                      isValidFilePath={isValidFilePath}
                     />
                   )}
                 </React.Fragment>
@@ -1033,7 +983,6 @@ const CellList = React.memo(function CellList({
                         totalMessages={messages.length}
                         canEdit={canEdit}
                         onTurnFileClick={onPreviewFileByPath}
-                        isValidFilePath={isValidFilePath}
                       />
                     );
                   }

--- a/src/client/src/components/notebook/conversations/__tests__/CellList.scroll.integration.test.tsx
+++ b/src/client/src/components/notebook/conversations/__tests__/CellList.scroll.integration.test.tsx
@@ -113,6 +113,10 @@ describe('CellList scroll & file path integration', () => {
     await waitFor(() => {
       expect(screen.getByText('Created chart')).toBeInTheDocument();
     });
+
+    // Pills must reflect turn-recorded paths even when the file is not in the live tree yet.
+    expect(screen.getByText('chart.png')).toBeInTheDocument();
+    expect(screen.getByText('missing.png')).toBeInTheDocument();
   });
 
   it('pins scroll to bottom when images load and user was at bottom', async () => {

--- a/src/client/src/components/notebook/sidebar/NotebookFolderTree.tsx
+++ b/src/client/src/components/notebook/sidebar/NotebookFolderTree.tsx
@@ -28,6 +28,10 @@ import { HostMountStateBadge } from '../hostMounts/HostMountStateBadge';
 import { HostMountCommandDialog } from '../hostMounts/HostMountCommandDialog';
 import { MapHostFolderDialog } from '../hostMounts/MapHostFolderDialog';
 import { isPathInsideHostMount } from '../../../utils/hostMountDisplayState';
+import {
+  graftLazyMountBranches,
+  mergeHostMountListingIntoTree,
+} from '../../../utils/hostMountTreeMerge';
 
 // Context for sharing state down the tree
 type TreeItem = 
@@ -59,6 +63,8 @@ interface NotebookFolderTreeContextType {
     isAdmin: boolean;
     getMountForPath: (path: string) => NotebookHostMountEntry | undefined;
     getEnclosingMount: (path: string) => NotebookHostMountEntry | undefined;
+    loadHostMountListing: (relativePath: string) => Promise<void>;
+    listingCompletePaths: Set<string>;
     onOpenMapHostFolderDialog: () => void;
     onCheckMappedFolders: () => void;
     onRemoveMappedFolder: (mountId: string) => void;
@@ -362,19 +368,26 @@ const NotebookFolderNodeComponent: React.FC<NotebookFolderNodeProps> = ({
   const displaySubFolders = filteredSubFolders;
   const displayFiles = filteredFiles;
   const hasRenderableChildren = displaySubFolders.length > 0 || displayFiles.length > 0;
-  const hasChildren = hasRenderableChildren || canExpandEmptyLinkedMount;
+  const needsLazyListing = Boolean(
+    isLinkedFolder
+    && folder.relativePath
+    && context
+    && !context.listingCompletePaths.has(folder.relativePath),
+  );
+  const hasChildren = hasRenderableChildren || canExpandEmptyLinkedMount || needsLazyListing;
   const hasActiveSearch = Boolean(searchTerm?.trim());
   const expansionId = folder.relativePath || 'ROOT';
   const isExpanded = hasActiveSearch || (context?.expandedIds.has(expansionId) ?? true);
-  const requestLinkedFolderRefresh = useCallback(() => {
-    if (canExpandEmptyLinkedMount && !hasRenderableChildren) {
-      context?.refreshNotebookFiles();
-    }
-  }, [canExpandEmptyLinkedMount, hasRenderableChildren, context]);
+  const requestLinkedFolderListing = useCallback(() => {
+    if (!folder.relativePath || !context) return;
+    if (!isLinkedFolder) return;
+    if (context.listingCompletePaths.has(folder.relativePath)) return;
+    void context.loadHostMountListing(folder.relativePath);
+  }, [context, folder.relativePath, isLinkedFolder]);
   const toggleExpand = useCallback(() => {
     context?.toggleExpansion(expansionId);
-    requestLinkedFolderRefresh();
-  }, [context, expansionId, requestLinkedFolderRefresh]);
+    requestLinkedFolderListing();
+  }, [context, expansionId, requestLinkedFolderListing]);
   const paddingLeft = level === 0 ? 0 : level * 20 + 8;
   const openCreateSubfolderInput = useCallback(() => {
     if (!isExpanded) {
@@ -1530,6 +1543,48 @@ const NotebookFolderTreeComponent: React.FC<NotebookFolderTreeProps> = ({
 
   // Track locally-created empty folders until they appear in server tree
   const [localEmptyFolders, setLocalEmptyFolders] = useState<Set<string>>(new Set());
+  const [listingCompletePaths, setListingCompletePaths] = useState<Set<string>>(() => new Set());
+  const [workingTree, setWorkingTree] = useState<NotebookFolderTreeDto | null>(null);
+  const listingInFlightRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    setListingCompletePaths(new Set());
+    setWorkingTree(null);
+    listingInFlightRef.current.clear();
+  }, [projectId, notebookId]);
+
+  useEffect(() => {
+    if (!tree) {
+      setWorkingTree(null);
+      return;
+    }
+    setWorkingTree((prev) => graftLazyMountBranches(tree, prev, listingCompletePaths));
+  }, [tree, listingCompletePaths]);
+
+  const loadHostMountListing = useCallback(async (relativePath: string) => {
+    if (!projectId || !notebookId || !relativePath) return;
+    if (listingCompletePaths.has(relativePath)) return;
+    if (listingInFlightRef.current.has(relativePath)) return;
+    listingInFlightRef.current.add(relativePath);
+    try {
+      const listing = await notebookFilesApi.listHostMountLevel(projectId, notebookId, relativePath);
+      setWorkingTree((prev) => {
+        const base = prev ?? tree;
+        if (!base) return prev;
+        return mergeHostMountListingIntoTree(base, listing);
+      });
+      setListingCompletePaths((prev) => {
+        const next = new Set(prev);
+        next.add(relativePath);
+        return next;
+      });
+    } catch (error) {
+      console.error('Failed to lazy-load host mount listing', error);
+      showToast({ type: 'error', title: 'Failed to load mapped folder contents', message: 'Please try again.' });
+    } finally {
+      listingInFlightRef.current.delete(relativePath);
+    }
+  }, [projectId, notebookId, listingCompletePaths, tree, showToast]);
   
   const addLocalEmptyFolder = useCallback((path: string) => {
     setLocalEmptyFolders(prev => new Set([...prev, path]));
@@ -1637,8 +1692,9 @@ const NotebookFolderTreeComponent: React.FC<NotebookFolderTreeProps> = ({
 
   // Merge local folders into tree for rendering
   const effectiveTree = useMemo(() => {
-    if (!tree) return null;
-    let merged = localEmptyFolders.size === 0 ? tree : mergeLocalFolders(tree);
+    const sourceTree = workingTree ?? tree;
+    if (!sourceTree) return null;
+    let merged = localEmptyFolders.size === 0 ? sourceTree : mergeLocalFolders(sourceTree);
     if (hostMounts.length === 0) {
       return merged;
     }
@@ -1660,7 +1716,7 @@ const NotebookFolderTreeComponent: React.FC<NotebookFolderTreeProps> = ({
       ...merged,
       subFolders: mountSubFolders,
     };
-  }, [tree, localEmptyFolders, mergeLocalFolders, hostMounts]);
+  }, [workingTree, tree, localEmptyFolders, mergeLocalFolders, hostMounts]);
 
   const folderHasRenderableChildren = useCallback((node: NotebookFolderTreeDto, relativePath: string): boolean | null => {
     if (node.relativePath === relativePath) {
@@ -1677,32 +1733,36 @@ const NotebookFolderTreeComponent: React.FC<NotebookFolderTreeProps> = ({
     return null;
   }, []);
 
-  const emptyLinkedMountRefreshKeyRef = useRef<string | null>(null);
+  // Prefetch one-level listing for empty linked mount roots (no full-tree refresh).
+  const emptyLinkedMountListingKeyRef = useRef<string | null>(null);
   useEffect(() => {
     if (!effectiveTree || hostMounts.length === 0) {
-      emptyLinkedMountRefreshKeyRef.current = null;
+      emptyLinkedMountListingKeyRef.current = null;
       return;
     }
 
     const emptyLinkedMountPaths = hostMounts
       .filter((mount) => mount.displayState === 'Linked')
+      .filter((mount) => !listingCompletePaths.has(mount.relativePath))
       .filter((mount) => folderHasRenderableChildren(effectiveTree, mount.relativePath) !== true)
       .map((mount) => mount.relativePath)
       .sort();
 
     if (emptyLinkedMountPaths.length === 0) {
-      emptyLinkedMountRefreshKeyRef.current = null;
+      emptyLinkedMountListingKeyRef.current = null;
       return;
     }
 
     const key = emptyLinkedMountPaths.join('|');
-    if (emptyLinkedMountRefreshKeyRef.current === key) {
+    if (emptyLinkedMountListingKeyRef.current === key) {
       return;
     }
 
-    emptyLinkedMountRefreshKeyRef.current = key;
-    requestNotebookFilesRefresh();
-  }, [effectiveTree, hostMounts, folderHasRenderableChildren, requestNotebookFilesRefresh]);
+    emptyLinkedMountListingKeyRef.current = key;
+    for (const path of emptyLinkedMountPaths) {
+      void loadHostMountListing(path);
+    }
+  }, [effectiveTree, hostMounts, folderHasRenderableChildren, listingCompletePaths, loadHostMountListing]);
 
   const getVisibleItems = useCallback((node: NotebookFolderTreeDto): TreeItem[] => {
       let results: TreeItem[] = [];
@@ -1871,6 +1931,8 @@ const NotebookFolderTreeComponent: React.FC<NotebookFolderTreeProps> = ({
       isAdmin,
       getMountForPath,
       getEnclosingMount,
+      loadHostMountListing,
+      listingCompletePaths,
       onOpenMapHostFolderDialog: () => setShowMapHostFolderDialog(true),
       onCheckMappedFolders: handleCheckMappedFolders,
       onRemoveMappedFolder: handleRemoveMappedFolder,

--- a/src/client/src/components/notebook/sidebar/__tests__/NotebookFolderTree.hostMounts.test.tsx
+++ b/src/client/src/components/notebook/sidebar/__tests__/NotebookFolderTree.hostMounts.test.tsx
@@ -7,6 +7,7 @@ import { NotebookFolderTree } from '../NotebookFolderTree';
 import { NotebookFolderTreeDto } from '../../../../types/notebook';
 import { renderWithNotebookRoute } from '../../../../test/test-utils';
 import type { NotebookHostMountEntry } from '../../../../types/hostFolderMount';
+import { notebookFilesApi } from '../../../../services/notebookFiles';
 
 const mockHostMounts: NotebookHostMountEntry[] = [
   {
@@ -179,25 +180,31 @@ describe('NotebookFolderTree host mounts', () => {
 
   it('keeps linked mount roots expandable while scanned children are missing', async () => {
     const user = userEvent.setup();
-    const onRefreshFiles = vi.fn();
+    const listHostMountLevel = vi.fn().mockResolvedValue({
+      path: 'Shared',
+      folders: [{ name: 'inner', relativePath: 'Shared/inner' }],
+      files: [],
+      truncated: false,
+    });
+    vi.spyOn(notebookFilesApi, 'listHostMountLevel').mockImplementation(listHostMountLevel);
 
     renderTree({
       tree: emptyLinkedMountTree,
-      onRefreshFiles,
     });
 
     const expandShared = screen.getByLabelText('Expand Shared');
     expect(expandShared).toBeInTheDocument();
 
+    // Empty linked roots prefetch one-level listing (not a full tree refresh).
     await waitFor(() => {
-      expect(onRefreshFiles).toHaveBeenCalledTimes(1);
+      expect(listHostMountLevel).toHaveBeenCalledWith('proj-1', 'nb-1', 'Shared');
     });
 
-    onRefreshFiles.mockClear();
+    const callsBeforeExpand = listHostMountLevel.mock.calls.length;
     await user.click(expandShared);
-
-    expect(onRefreshFiles).toHaveBeenCalledTimes(1);
     expect(screen.getByLabelText('Collapse Shared')).toBeInTheDocument();
+    // Idempotent: already listingComplete — no extra fetch required on expand.
+    expect(listHostMountLevel.mock.calls.length).toBe(callsBeforeExpand);
   });
 
   it('shows remove mapped folder instead of delete on mount root', () => {

--- a/src/client/src/components/project/sidebar/FolderTree.tsx
+++ b/src/client/src/components/project/sidebar/FolderTree.tsx
@@ -16,6 +16,10 @@ import { useToast } from '../../common/Toast';
 import { HostMountStateBadge } from '../../notebook/hostMounts/HostMountStateBadge';
 import type { HostFolderMountStatus } from '../../../types/hostFolderMount';
 import { deriveHostMountDisplayState } from '../../../utils/hostMountDisplayState';
+import {
+  graftLazyMountBranchesProject,
+  mergeHostMountListingIntoProjectTree,
+} from '../../../utils/hostMountTreeMerge';
 
 // Context for sharing state down the tree
 type TreeItem = 
@@ -38,6 +42,8 @@ interface FolderTreeContextType {
     focusIntentRef: React.MutableRefObject<boolean>;
     /** Mobile detection for touch-friendly single-tap behavior */
     isMobile: boolean;
+    listingCompletePaths: Set<string>;
+    loadHostMountListing: (relativePath: string) => Promise<void>;
 }
 
 const FolderTreeContext = createContext<FolderTreeContextType | undefined>(undefined);
@@ -323,7 +329,18 @@ const FolderNode: React.FC<FolderNodeProps> = ({
     
     // Use expanded state from context or fallback
     const isExpanded = context?.expandedIds.has(folder.id || 'ROOT') ?? true;
-    const toggleExpand = () => context?.toggleExpansion(folder.id || 'ROOT');
+    const needsLazyListing = Boolean(
+      insideMount
+      && folder.relativePath
+      && context
+      && !context.listingCompletePaths.has(folder.relativePath),
+    );
+    const toggleExpand = () => {
+      context?.toggleExpansion(folder.id || 'ROOT');
+      if (needsLazyListing && folder.relativePath) {
+        void context?.loadHostMountListing(folder.relativePath);
+      }
+    };
 
     const [isEditing, setIsEditing] = useState(false);
     const [editName, setEditName] = useState(folder.name);
@@ -1251,13 +1268,58 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
 }) => {
     // Shared state
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set(['ROOT']));
+    const [listingCompletePaths, setListingCompletePaths] = useState<Set<string>>(() => new Set());
+    const [workingTree, setWorkingTree] = useState<FolderTreeDto | null>(null);
+    const listingInFlightRef = useRef<Set<string>>(new Set());
+    const { showToast } = useToast();
+
+    useEffect(() => {
+      setListingCompletePaths(new Set());
+      setWorkingTree(null);
+      listingInFlightRef.current.clear();
+    }, [projectId]);
+
+    useEffect(() => {
+      if (!folderTree) {
+        setWorkingTree(null);
+        return;
+      }
+      setWorkingTree((prev) => graftLazyMountBranchesProject(folderTree, prev, listingCompletePaths));
+    }, [folderTree, listingCompletePaths]);
+
+    const loadHostMountListing = useCallback(async (relativePath: string) => {
+      if (!projectId || !relativePath) return;
+      if (listingCompletePaths.has(relativePath)) return;
+      if (listingInFlightRef.current.has(relativePath)) return;
+      listingInFlightRef.current.add(relativePath);
+      try {
+        const listing = await api.projects.folders.listHostMountLevel(projectId, relativePath);
+        setWorkingTree((prev) => {
+          const base = prev ?? folderTree;
+          if (!base) return prev;
+          return mergeHostMountListingIntoProjectTree(base, listing);
+        });
+        setListingCompletePaths((prev) => {
+          const next = new Set(prev);
+          next.add(relativePath);
+          return next;
+        });
+      } catch (error) {
+        console.error('Failed to lazy-load project host mount listing', error);
+        showToast({ type: 'error', title: 'Failed to load mapped folder contents', message: 'Please try again.' });
+      } finally {
+        listingInFlightRef.current.delete(relativePath);
+      }
+    }, [projectId, listingCompletePaths, folderTree, showToast]);
+
+    const effectiveFolderTree = workingTree ?? folderTree;
     
     // Initialize expandedIds with root folder ID if present
     useEffect(() => {
-        if (folderTree?.id) {
-            setExpandedIds(prev => new Set(prev).add(folderTree.id || 'ROOT'));
+        if (effectiveFolderTree?.id) {
+            setExpandedIds(prev => new Set(prev).add(effectiveFolderTree.id || 'ROOT'));
         }
-    }, [folderTree?.id]);
+    }, [effectiveFolderTree?.id]);
 
     const toggleExpansion = useCallback((id: string) => {
         setExpandedIds(prev => {
@@ -1298,7 +1360,7 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
             // But we usually want to navigate *inside* the tree.
             // If n is root, we usually don't select it.
             // Let's assume root is handled separately or we filter it.
-            if (n.id && n.id !== 'ROOT' && n.id !== folderTree?.id) { 
+            if (n.id && n.id !== 'ROOT' && n.id !== effectiveFolderTree?.id) { 
                  results.push({ type: 'folder', data: n, id: n.id });
             }
 
@@ -1336,9 +1398,9 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
              }
         }
         return results;
-    }, [expandedIds, searchTerm, folderTree?.id]);
+    }, [expandedIds, searchTerm, effectiveFolderTree?.id]);
 
-    const visibleItems = useMemo(() => folderTree ? getVisibleItems(folderTree) : [], [folderTree, getVisibleItems]);
+    const visibleItems = useMemo(() => effectiveFolderTree ? getVisibleItems(effectiveFolderTree) : [], [effectiveFolderTree, getVisibleItems]);
 
     // Selection hooks
     const multiSelect = useMultiSelect<TreeItem>({
@@ -1466,14 +1528,16 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
         setRenamingId,
         isActive: activeSection === 'contentFiles',
         focusIntentRef: listNav.focusIntentRef,
-        isMobile
+        isMobile,
+        listingCompletePaths,
+        loadHostMountListing,
     };
 
     return (
         <FolderTreeContext.Provider value={contextValue}>
             <div className="folder-tree overflow-auto" onContextMenuCapture={(e)=>e.preventDefault()}>
                 <FolderNode
-                    folder={folderTree!}
+                    folder={effectiveFolderTree!}
                     level={0}
                     folders={folders}
                     projectId={projectId}

--- a/src/client/src/contexts/ConversationContext.tsx
+++ b/src/client/src/contexts/ConversationContext.tsx
@@ -57,8 +57,19 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
     userProfiles: {},
   });
 
-  const [currentStreamController, setCurrentStreamController] = React.useState<AbortController | null>(null);
-  const [observerStreamController, setObserverStreamController] = React.useState<AbortController | null>(null);
+  const [currentStreamController, setCurrentStreamControllerState] = React.useState<AbortController | null>(null);
+  const [observerStreamController, setObserverStreamControllerState] = React.useState<AbortController | null>(null);
+  // Refs are authoritative for "is a socket open?" checks. State alone races with setState.
+  const sendStreamRef = React.useRef<AbortController | null>(null);
+  const observerStreamRef = React.useRef<AbortController | null>(null);
+  const setCurrentStreamController = React.useCallback((controller: AbortController | null) => {
+    sendStreamRef.current = controller;
+    setCurrentStreamControllerState(controller);
+  }, []);
+  const setObserverStreamController = React.useCallback((controller: AbortController | null) => {
+    observerStreamRef.current = controller;
+    setObserverStreamControllerState(controller);
+  }, []);
   const reattachIfStreamingRef = React.useRef<(convo: any) => Promise<void>>(async () => {});
   const onTurnIdAssignedRef = React.useRef<(turnId: string) => void>(() => {});
   const onStreamTerminalRef = React.useRef<() => void>(() => {});
@@ -320,15 +331,15 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
 
   // --- Cleanup on conversation change ---
   useEffect(() => {
-    if (currentStreamController) {
+    if (sendStreamRef.current) {
       console.log('🔥 Conversation changed, aborting active send stream');
-      currentStreamController.abort();
+      sendStreamRef.current.abort();
       setCurrentStreamController(null);
     }
 
-    if (observerStreamController) {
+    if (observerStreamRef.current) {
       console.log('🔥 Conversation changed, aborting observer stream');
-      observerStreamController.abort();
+      observerStreamRef.current.abort();
       setObserverStreamController(null);
     }
 
@@ -337,21 +348,21 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
     dispatch({ type: 'SET_MESSAGES', payload: [] });
     assignActiveStreamTurnId(null);
     onStreamTerminalRef.current();
-  }, [conversationId, assignActiveStreamTurnId]);
+  }, [conversationId, assignActiveStreamTurnId, setCurrentStreamController, setObserverStreamController]);
 
   // --- Cleanup on unmount ---
   useEffect(() => {
     return () => {
-      if (currentStreamController) {
-        currentStreamController.abort();
+      if (sendStreamRef.current) {
+        sendStreamRef.current.abort();
         setCurrentStreamController(null);
       }
-      if (observerStreamController) {
-        observerStreamController.abort();
+      if (observerStreamRef.current) {
+        observerStreamRef.current.abort();
         setObserverStreamController(null);
       }
     };
-  }, []);
+  }, [setCurrentStreamController, setObserverStreamController]);
 
   // --- Custom hooks for streaming events and actions ---
   const assistants = useMemo(() => state.assistants ?? [], [state.assistants]);
@@ -381,6 +392,7 @@ export function ConversationProvider({ projectId, notebookId, conversationId, gu
     handleStreamingEvent, showToast, loadNotebookFiles,
     currentStreamController, setCurrentStreamController,
     observerStreamController, setObserverStreamController,
+    sendStreamRef, observerStreamRef,
     inflightRuntimeChecksRef, runtimeReadyCacheRef, assistantByName,
     activeStreamTurnId, setActiveStreamTurnId: assignActiveStreamTurnId, getActiveStreamTurnId, refreshConversation: refresh,
   });

--- a/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
+++ b/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
@@ -49,7 +49,14 @@ function createBaseState(overrides: Partial<ExtendedConversationState> = {}): Ex
 function createDeps(overrides: Partial<Parameters<typeof useConversationActions>[2]> = {}) {
   const inflightRuntimeChecksRef = { current: new Set<string>() };
   const runtimeReadyCacheRef = { current: new Set<string>() };
-  const setCurrentStreamController = vi.fn();
+  const sendStreamRef = { current: null as AbortController | null };
+  const observerStreamRef = { current: null as AbortController | null };
+  const setCurrentStreamController = vi.fn((c: AbortController | null) => {
+    sendStreamRef.current = c;
+  });
+  const setObserverStreamController = vi.fn((c: AbortController | null) => {
+    observerStreamRef.current = c;
+  });
 
   return {
     projectId: PROJECT_ID,
@@ -61,7 +68,9 @@ function createDeps(overrides: Partial<Parameters<typeof useConversationActions>
     currentStreamController: null as AbortController | null,
     setCurrentStreamController,
     observerStreamController: null as AbortController | null,
-    setObserverStreamController: vi.fn(),
+    setObserverStreamController,
+    sendStreamRef,
+    observerStreamRef,
     inflightRuntimeChecksRef,
     runtimeReadyCacheRef,
     activeStreamTurnId: null as string | null,
@@ -618,9 +627,10 @@ describe('useConversationActions', () => {
 
     it('does not open observer SSE while the send stream is still attached', async () => {
       const sendController = new AbortController();
+      const sendStreamRef = { current: sendController };
       const { actions } = mountActions(
         {},
-        { currentStreamController: sendController },
+        { currentStreamController: sendController, sendStreamRef },
       );
 
       await act(async () => {
@@ -630,6 +640,43 @@ describe('useConversationActions', () => {
       });
 
       expect(api.projects.notebooks.conversations.observeConversationEvents).not.toHaveBeenCalled();
+    });
+
+    it('does not open a second observer while one is already attached', async () => {
+      const observerController = new AbortController();
+      const observerStreamRef = { current: observerController };
+      const { actions } = mountActions(
+        {},
+        { observerStreamController: observerController, observerStreamRef },
+      );
+
+      await act(async () => {
+        await actions.reattachIfStreaming({
+          activeTurn: { turnId: 'turn-1', status: 'streaming', turnIndex: 1 },
+        });
+      });
+
+      expect(api.projects.notebooks.conversations.observeConversationEvents).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendMessage observer ownership', () => {
+    it('aborts an open observer before opening the send stream', async () => {
+      const observerController = new AbortController();
+      const abortSpy = vi.spyOn(observerController, 'abort');
+      const observerStreamRef = { current: observerController };
+      const { actions, deps } = mountActions(
+        {},
+        { observerStreamController: observerController, observerStreamRef },
+      );
+
+      await act(async () => {
+        await actions.sendMessage('hello');
+      });
+
+      expect(abortSpy).toHaveBeenCalled();
+      expect(deps.setObserverStreamController).toHaveBeenCalledWith(null);
+      expect(api.projects.notebooks.conversations.sendMessageStream).toHaveBeenCalled();
     });
   });
 

--- a/src/client/src/contexts/conversation/useConversationActions.ts
+++ b/src/client/src/contexts/conversation/useConversationActions.ts
@@ -18,6 +18,8 @@ interface ActionDeps {
   setCurrentStreamController: (c: AbortController | null) => void;
   observerStreamController: AbortController | null;
   setObserverStreamController: (c: AbortController | null) => void;
+  sendStreamRef: React.MutableRefObject<AbortController | null>;
+  observerStreamRef: React.MutableRefObject<AbortController | null>;
   inflightRuntimeChecksRef: React.MutableRefObject<Set<string>>;
   runtimeReadyCacheRef: React.MutableRefObject<Set<string>>;
   assistantByName: Record<string, { name: string; model?: string; avatarUrl: string; id?: string }>;
@@ -35,8 +37,9 @@ export function useConversationActions(
   const {
     projectId, notebookId, conversationId,
     handleStreamingEvent, showToast, loadNotebookFiles,
-    currentStreamController, setCurrentStreamController,
-    observerStreamController, setObserverStreamController,
+    setCurrentStreamController,
+    setObserverStreamController,
+    sendStreamRef, observerStreamRef,
     inflightRuntimeChecksRef, runtimeReadyCacheRef, assistantByName,
     activeStreamTurnId, setActiveStreamTurnId, getActiveStreamTurnId, refreshConversation,
   } = deps;
@@ -48,6 +51,22 @@ export function useConversationActions(
     pendingStopRef.current = false;
     stopPostedForTurnRef.current = null;
   }, []);
+
+  const adoptSendStream = useCallback((controller: AbortController | null) => {
+    setCurrentStreamController(controller);
+  }, [setCurrentStreamController]);
+
+  const adoptObserverStream = useCallback((controller: AbortController | null) => {
+    setObserverStreamController(controller);
+  }, [setObserverStreamController]);
+
+  const abortObserverStream = useCallback(() => {
+    const existing = observerStreamRef.current;
+    if (existing && !existing.signal.aborted) {
+      existing.abort();
+    }
+    setObserverStreamController(null);
+  }, [observerStreamRef, setObserverStreamController]);
 
   const requestServerStop = useCallback((turnId: string) => {
     if (stopPostedForTurnRef.current === turnId) {
@@ -138,8 +157,11 @@ export function useConversationActions(
       dispatch({ type: 'SET_DRAFT', payload: '' });
       clearPendingStop();
 
+      // Send exclusively owns token appends for this turn.
+      abortObserverStream();
+
       const controller = new AbortController();
-      setCurrentStreamController(controller);
+      adoptSendStream(controller);
 
       const attList = (attachments && attachments.length > 0) ? attachments : (state.pendingAttachments ?? []);
 
@@ -202,7 +224,7 @@ export function useConversationActions(
 
             if (isUserCancel) {
               console.log('SSE client disconnected; server run may continue');
-              setCurrentStreamController(null);
+              adoptSendStream(null);
               if (!pendingStopRef.current) {
                 dispatch({ type: 'SET_CANCELLING', payload: false });
               }
@@ -217,7 +239,7 @@ export function useConversationActions(
               dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
               dispatch({ type: 'CONVERT_STREAMING_IDS' });
               dispatch({ type: 'COMPLETE_STREAMING_TURN' });
-              setCurrentStreamController(null);
+              adoptSendStream(null);
               setActiveStreamTurnId?.(null);
               const streamErrorMessage = error.message || 'The conversation stream stopped sending data.';
               dispatch({ type: 'SET_STREAMING_ERROR', payload: streamErrorMessage });
@@ -248,7 +270,7 @@ export function useConversationActions(
             dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
             dispatch({ type: 'CONVERT_STREAMING_IDS' });
             dispatch({ type: 'COMPLETE_STREAMING_TURN' });
-            setCurrentStreamController(null);
+            adoptSendStream(null);
             setActiveStreamTurnId?.(null);
             const streamErrorMessage = error.message || 'Chat request failed';
             dispatch({ type: 'SET_STREAMING_ERROR', payload: streamErrorMessage });
@@ -262,7 +284,7 @@ export function useConversationActions(
             clearPendingStop();
             dispatch({ type: 'COMPLETE_STREAMING_TURN' });
             dispatch({ type: 'SET_CANCELLING', payload: false });
-            setCurrentStreamController(null);
+            adoptSendStream(null);
             dispatch({ type: 'CLEAR_ATTACHMENTS' });
             try { window.dispatchEvent(new Event('refresh-notebook-toolbar')); } catch {}
             console.log('📄 [onComplete] Triggering loadNotebookFiles');
@@ -285,7 +307,7 @@ export function useConversationActions(
         );
       } catch (error: any) {
         if (error instanceof Error && (error.name === 'AbortError' || error.message.includes('aborted'))) {
-          setCurrentStreamController(null);
+          adoptSendStream(null);
           if (!pendingStopRef.current) {
             dispatch({ type: 'SET_CANCELLING', payload: false });
           }
@@ -300,7 +322,7 @@ export function useConversationActions(
         dispatch({ type: 'FINALIZE_STREAMING_MESSAGE', payload: {} });
         dispatch({ type: 'CONVERT_STREAMING_IDS' });
         dispatch({ type: 'COMPLETE_STREAMING_TURN' });
-        setCurrentStreamController(null);
+        adoptSendStream(null);
 
         if (error.status === 409) {
           const body = error.body;
@@ -361,7 +383,7 @@ export function useConversationActions(
         });
       }
     },
-    [state._isUndoing, state.selectedAssistant, state.assistants, state.notebookTemplate, projectId, notebookId, conversationId, handleStreamingEvent, state.pendingAttachments, loadNotebookFiles, showToast]
+    [state._isUndoing, state.selectedAssistant, state.assistants, state.notebookTemplate, projectId, notebookId, conversationId, handleStreamingEvent, state.pendingAttachments, loadNotebookFiles, showToast, abortObserverStream, adoptSendStream, clearPendingStop, getActiveStreamTurnId, refreshConversation, runtimeReadyCacheRef, setActiveStreamTurnId]
   );
 
   const editAssistantMessage = useCallback(
@@ -480,11 +502,11 @@ export function useConversationActions(
       return;
     }
 
-    if (currentStreamController && !currentStreamController.signal.aborted) {
+    if (sendStreamRef.current && !sendStreamRef.current.signal.aborted) {
       return;
     }
 
-    if (observerStreamController && !observerStreamController.signal.aborted) {
+    if (observerStreamRef.current && !observerStreamRef.current.signal.aborted) {
       return;
     }
 
@@ -517,8 +539,9 @@ export function useConversationActions(
       }
     }
 
+    // Claim ownership synchronously before the fetch starts so a concurrent reattach cannot open a second socket.
     const controller = new AbortController();
-    setObserverStreamController(controller);
+    adoptObserverStream(controller);
 
     void api.projects.notebooks.conversations.observeConversationEvents(
       projectId,
@@ -533,7 +556,9 @@ export function useConversationActions(
         dispatch({ type: 'SET_STREAMING_ERROR', payload: error.message || 'Observer stream failed' });
       },
       () => {
-        setObserverStreamController(null);
+        if (observerStreamRef.current === controller) {
+          adoptObserverStream(null);
+        }
         setActiveStreamTurnId(null);
         dispatch({ type: 'SET_CANCELLING', payload: false });
         clearPendingStop();
@@ -541,17 +566,16 @@ export function useConversationActions(
       controller.signal,
     );
   }, [
-    observerStreamController,
     projectId,
     notebookId,
     conversationId,
     handleStreamingEvent,
     dispatch,
     setActiveStreamTurnId,
-    setObserverStreamController,
+    adoptObserverStream,
+    clearPendingStop,
     state.messages,
     state.selectedAssistant,
-    currentStreamController,
   ]);
 
   const cancelStream = useCallback(() => {

--- a/src/client/src/contexts/conversation/useStreamingEventHandler.ts
+++ b/src/client/src/contexts/conversation/useStreamingEventHandler.ts
@@ -97,6 +97,8 @@ export function useStreamingEventHandler(
           }
           dispatch({ type: 'COMPLETE_STREAMING_TURN' });
 
+          // Fast-register completes on the server before SSE `complete`. Refresh the notebook
+          // file tree so sidebar/serving gate pick up newly registered paths without a hard reload.
           console.log('📄 [SSE complete] Triggering loadNotebookFiles');
           loadNotebookFiles().catch(error => {
             console.error('Failed to refresh notebook files after conversation turn:', error);

--- a/src/client/src/features/localModelOnboarding/curated/QuantSelect.tsx
+++ b/src/client/src/features/localModelOnboarding/curated/QuantSelect.tsx
@@ -117,8 +117,9 @@ export function QuantSelect({
           </div>
           {installedName && selected.id !== installedQuantId ? (
             <div className="mt-1 text-gray-600">
-              Replaces <span className="font-mono">{installedName}</span>
-              {installedDetail ? ` (${installedDetail})` : ''}
+              Switches active quant from <span className="font-mono">{installedName}</span>
+              {installedDetail ? ` (${installedDetail})` : ''}. Other downloaded quants for this
+              model stay on disk.
             </div>
           ) : null}
           {guidance ? <div className="mt-1 text-gray-600">{guidance}</div> : null}

--- a/src/client/src/features/localModelOnboarding/installed/ChangeQuantModal.tsx
+++ b/src/client/src/features/localModelOnboarding/installed/ChangeQuantModal.tsx
@@ -167,7 +167,9 @@ export function ChangeQuantModal({ isOpen, detail, onClose, onOperationStarted }
             installedQuantLabel={detail.quantLabel}
           />
           <p className="text-xs text-gray-500">
-            The download runs in the background. Progress appears on this model's row in the model list.
+            Downloads only what is missing. Other quants already on disk for this model stay there
+            so you can switch back without downloading again. Progress appears on this model&apos;s
+            row in the model list.
           </p>
         </div>
       ) : null}

--- a/src/client/src/services/api.ts
+++ b/src/client/src/services/api.ts
@@ -921,6 +921,10 @@ export const api = {
             getFolderTree: (projectId: string) =>
                 dedupeInFlight(`project-folder-tree:${projectId}`, () =>
                     callApi<FolderTreeDto>(`/projects/${projectId}/folders/tree`)),
+
+            listHostMountLevel: (projectId: string, path: string) =>
+                callApi<import('../types/notebook').HostMountListingDto>(
+                    `/projects/${projectId}/folders/host-mounts/listing?path=${encodeURIComponent(path)}`),
             
             getFolders: (projectId: string) => 
                 callApi<ProjectFolderDto[]>(`/projects/${projectId}/folders`),

--- a/src/client/src/services/notebookFiles.ts
+++ b/src/client/src/services/notebookFiles.ts
@@ -54,6 +54,17 @@ export const notebookFilesApi = {
     return callNotebookApi<NotebookFolderTreeDto>(`/projects/${projectId}/notebooks/${notebookId}/files/tree`);
   },
 
+  listHostMountLevel: async (
+    projectId: string,
+    notebookId: string,
+    path: string,
+  ): Promise<import('../types/notebook').HostMountListingDto> => {
+    const encoded = encodeURIComponent(path);
+    return callNotebookApi(
+      `/projects/${projectId}/notebooks/${notebookId}/files/host-mounts/listing?path=${encoded}`,
+    );
+  },
+
   // Upload files to notebook
   uploadFiles: async (projectId: string, notebookId: string, files: File[], targetRelativePath: string, index: boolean): Promise<NotebookFileDto[]> => {
     const formData = new FormData();

--- a/src/client/src/types/notebook.ts
+++ b/src/client/src/types/notebook.ts
@@ -233,6 +233,28 @@ export interface NotebookFolderTreeDto {
   files: NotebookFileDto[];
 }
 
+export interface HostMountListingFolderDto {
+  name: string;
+  relativePath: string;
+}
+
+export interface HostMountListingFileDto {
+  id: string;
+  fileName: string;
+  relativePath: string;
+  fileSize: number;
+  lastModifiedUtc: string;
+  fileHash: string;
+  isLinked?: boolean;
+}
+
+export interface HostMountListingDto {
+  path: string;
+  folders: HostMountListingFolderDto[];
+  files: HostMountListingFileDto[];
+  truncated: boolean;
+}
+
 export interface PublishNotebookFileDto {
   notebookFileId: string;
   destinationFolderId?: string;

--- a/src/client/src/utils/__tests__/hostMountTreeMerge.test.ts
+++ b/src/client/src/utils/__tests__/hostMountTreeMerge.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { HostMountListingDto, NotebookFolderTreeDto } from '../../types/notebook';
+import {
+  graftLazyMountBranches,
+  mergeHostMountListingIntoTree,
+} from '../hostMountTreeMerge';
+
+describe('hostMountTreeMerge', () => {
+  const baseTree: NotebookFolderTreeDto = {
+    name: 'Root',
+    relativePath: '',
+    subFolders: [
+      {
+        name: 'leaf',
+        relativePath: 'leaf',
+        subFolders: [
+          {
+            name: 'd1',
+            relativePath: 'leaf/d1',
+            subFolders: [
+              {
+                name: 'd2',
+                relativePath: 'leaf/d1/d2',
+                subFolders: [
+                  {
+                    name: 'd3',
+                    relativePath: 'leaf/d1/d2/d3',
+                    subFolders: [],
+                    files: [
+                      {
+                        id: 'readme',
+                        fileName: 'README.md',
+                        relativePath: 'leaf/d1/d2/d3/README.md',
+                        fileSize: 6,
+                        lastModifiedUtc: '2024-01-01T00:00:00Z',
+                        fileHash: 'h',
+                        index: false,
+                        isIndexed: false,
+                        isLinked: true,
+                      },
+                    ],
+                  },
+                ],
+                files: [],
+              },
+            ],
+            files: [],
+          },
+        ],
+        files: [],
+      },
+    ],
+    files: [],
+  };
+
+  it('merges one-level listing under d3 without full-tree refresh', () => {
+    const listing: HostMountListingDto = {
+      path: 'leaf/d1/d2/d3',
+      truncated: false,
+      folders: [
+        { name: 'audiocpp', relativePath: 'leaf/d1/d2/d3/audiocpp' },
+        { name: 'audiocpp-asr', relativePath: 'leaf/d1/d2/d3/audiocpp-asr' },
+      ],
+      files: [
+        {
+          id: 'readme',
+          fileName: 'README.md',
+          relativePath: 'leaf/d1/d2/d3/README.md',
+          fileSize: 6,
+          lastModifiedUtc: '2024-01-01T00:00:00Z',
+          fileHash: 'h',
+          isLinked: true,
+        },
+      ],
+    };
+
+    const merged = mergeHostMountListingIntoTree(baseTree, listing);
+    const d3 = merged.subFolders[0].subFolders[0].subFolders[0].subFolders[0];
+    expect(d3.subFolders.map((f) => f.name).sort()).toEqual(['audiocpp', 'audiocpp-asr']);
+    expect(d3.files).toHaveLength(1);
+  });
+
+  it('graft preserves lazy children across poll', () => {
+    const listing: HostMountListingDto = {
+      path: 'leaf/d1/d2/d3',
+      truncated: false,
+      folders: [{ name: 'audiocpp', relativePath: 'leaf/d1/d2/d3/audiocpp' }],
+      files: [],
+    };
+    const previous = mergeHostMountListingIntoTree(baseTree, listing);
+    const complete = new Set(['leaf/d1/d2/d3']);
+    const grafted = graftLazyMountBranches(baseTree, previous, complete);
+    const d3 = grafted.subFolders[0].subFolders[0].subFolders[0].subFolders[0];
+    expect(d3.subFolders.map((f) => f.name)).toContain('audiocpp');
+  });
+});

--- a/src/client/src/utils/hostMountTreeMerge.ts
+++ b/src/client/src/utils/hostMountTreeMerge.ts
@@ -1,0 +1,282 @@
+import type {
+  HostMountListingDto,
+  NotebookFileDto,
+  NotebookFolderTreeDto,
+} from '../types/notebook';
+import type { FolderTreeDto, ProjectContentFile } from '../types/project';
+
+/**
+ * Merges a one-level host-mount listing into the folder tree at `listing.path`.
+ * Existing child folders keep their nested children (lazy deeper state preserved).
+ */
+export function mergeHostMountListingIntoTree(
+  tree: NotebookFolderTreeDto,
+  listing: HostMountListingDto,
+): NotebookFolderTreeDto {
+  const targetPath = (listing.path || '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+
+  const mergeAt = (node: NotebookFolderTreeDto): NotebookFolderTreeDto => {
+    const nodePath = (node.relativePath || '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+    if (nodePath === targetPath) {
+      const existingByPath = new Map(
+        node.subFolders.map((f) => [f.relativePath.replace(/\\/g, '/'), f]),
+      );
+
+      const mergedFolders: NotebookFolderTreeDto[] = listing.folders.map((folder) => {
+        const existing = existingByPath.get(folder.relativePath.replace(/\\/g, '/'));
+        if (existing) {
+          return existing;
+        }
+        return {
+          name: folder.name,
+          relativePath: folder.relativePath,
+          subFolders: [],
+          files: [],
+        };
+      });
+
+      for (const [path, folder] of existingByPath) {
+        if (!mergedFolders.some((f) => f.relativePath.replace(/\\/g, '/') === path)) {
+          mergedFolders.push(folder);
+        }
+      }
+
+      mergedFolders.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+
+      const files: NotebookFileDto[] = listing.files.map((file) => ({
+        id: file.id,
+        fileName: file.fileName,
+        relativePath: file.relativePath,
+        fileSize: file.fileSize,
+        lastModifiedUtc: file.lastModifiedUtc,
+        fileHash: file.fileHash,
+        index: false,
+        isIndexed: false,
+        isLinked: file.isLinked ?? true,
+      }));
+
+      return {
+        ...node,
+        subFolders: mergedFolders,
+        files,
+      };
+    }
+
+    return {
+      ...node,
+      subFolders: node.subFolders.map(mergeAt),
+    };
+  };
+
+  return mergeAt(tree);
+}
+
+/**
+ * When a polled shallow tree arrives, graft previously lazy-loaded subtrees back
+ * onto matching folder paths so poll does not wipe expand results.
+ */
+export function graftLazyMountBranches(
+  polledTree: NotebookFolderTreeDto,
+  previousTree: NotebookFolderTreeDto | null,
+  listingCompletePaths: Set<string>,
+): NotebookFolderTreeDto {
+  if (!previousTree || listingCompletePaths.size === 0) {
+    return polledTree;
+  }
+
+  const previousByPath = new Map<string, NotebookFolderTreeDto>();
+  const index = (node: NotebookFolderTreeDto) => {
+    const path = (node.relativePath || '').replace(/\\/g, '/');
+    if (path) {
+      previousByPath.set(path, node);
+    }
+    node.subFolders.forEach(index);
+  };
+  index(previousTree);
+
+  const graft = (node: NotebookFolderTreeDto): NotebookFolderTreeDto => {
+    const path = (node.relativePath || '').replace(/\\/g, '/');
+    const prev = path ? previousByPath.get(path) : undefined;
+
+    let subFolders = node.subFolders.map(graft);
+    let files = node.files;
+
+    if (path && listingCompletePaths.has(path) && prev) {
+      const polledFolderPaths = new Set(subFolders.map((f) => f.relativePath.replace(/\\/g, '/')));
+      for (const prevChild of prev.subFolders) {
+        const childPath = prevChild.relativePath.replace(/\\/g, '/');
+        if (!polledFolderPaths.has(childPath)) {
+          subFolders = [...subFolders, graft(prevChild)];
+        }
+      }
+      if (prev.files.length > 0 || listingCompletePaths.has(path)) {
+        const byPath = new Map(files.map((f) => [f.relativePath.replace(/\\/g, '/'), f]));
+        for (const prevFile of prev.files) {
+          byPath.set(prevFile.relativePath.replace(/\\/g, '/'), prevFile);
+        }
+        files = Array.from(byPath.values());
+      }
+    }
+
+    subFolders = subFolders
+      .map((child) => {
+        const childPath = child.relativePath.replace(/\\/g, '/');
+        const prevChild = previousByPath.get(childPath);
+        if (prevChild && listingCompletePaths.has(childPath)) {
+          return graft({
+            ...child,
+            subFolders: prevChild.subFolders,
+            files: prevChild.files.length ? prevChild.files : child.files,
+          });
+        }
+        return child;
+      })
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+
+    return { ...node, subFolders, files };
+  };
+
+  return graft(polledTree);
+}
+
+function createProjectFolderId(relativePath: string): string {
+  let hash = 0;
+  for (let i = 0; i < relativePath.length; i++) {
+    hash = ((hash << 5) - hash) + relativePath.charCodeAt(i);
+    hash |= 0;
+  }
+  const hex = (hash >>> 0).toString(16).padStart(8, '0');
+  return `00000000-0000-4000-8000-${hex.padStart(12, '0').slice(-12)}`;
+}
+
+export function mergeHostMountListingIntoProjectTree(
+  tree: FolderTreeDto,
+  listing: HostMountListingDto,
+): FolderTreeDto {
+  const targetPath = (listing.path || '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+
+  const mergeAt = (node: FolderTreeDto): FolderTreeDto => {
+    const nodePath = (node.relativePath || '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+    if (nodePath === targetPath) {
+      const existingByPath = new Map(
+        node.subFolders.map((f) => [f.relativePath.replace(/\\/g, '/'), f]),
+      );
+
+      const mergedFolders: FolderTreeDto[] = listing.folders.map((folder) => {
+        const existing = existingByPath.get(folder.relativePath.replace(/\\/g, '/'));
+        if (existing) {
+          return existing;
+        }
+        return {
+          id: createProjectFolderId(folder.relativePath),
+          name: folder.name,
+          relativePath: folder.relativePath,
+          subFolders: [],
+          files: [],
+          isLinked: true,
+        };
+      });
+
+      for (const [path, folder] of existingByPath) {
+        if (!mergedFolders.some((f) => f.relativePath.replace(/\\/g, '/') === path)) {
+          mergedFolders.push(folder);
+        }
+      }
+
+      mergedFolders.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+
+      const files: ProjectContentFile[] = listing.files.map((file) => ({
+        id: file.id,
+        fileName: file.fileName,
+        path: '',
+        relativePath: file.relativePath,
+        contentType: 'application/octet-stream',
+        index: false,
+        documentId: '',
+        created: file.lastModifiedUtc,
+        fileSize: file.fileSize,
+        folderId: undefined,
+        folderPath: targetPath,
+        latestVersion: 0,
+        isSnapshot: false,
+        hasMarkdownShadow: false,
+        markdownStatus: null,
+        markdownProcessedAt: null,
+      }));
+
+      return {
+        ...node,
+        subFolders: mergedFolders,
+        files,
+      };
+    }
+
+    return {
+      ...node,
+      subFolders: node.subFolders.map(mergeAt),
+    };
+  };
+
+  return mergeAt(tree);
+}
+
+export function graftLazyMountBranchesProject(
+  polledTree: FolderTreeDto,
+  previousTree: FolderTreeDto | null,
+  listingCompletePaths: Set<string>,
+): FolderTreeDto {
+  if (!previousTree || listingCompletePaths.size === 0) {
+    return polledTree;
+  }
+
+  const previousByPath = new Map<string, FolderTreeDto>();
+  const index = (node: FolderTreeDto) => {
+    const path = (node.relativePath || '').replace(/\\/g, '/');
+    if (path) {
+      previousByPath.set(path, node);
+    }
+    node.subFolders.forEach(index);
+  };
+  index(previousTree);
+
+  const graft = (node: FolderTreeDto): FolderTreeDto => {
+    const path = (node.relativePath || '').replace(/\\/g, '/');
+    const prev = path ? previousByPath.get(path) : undefined;
+    let subFolders = node.subFolders.map(graft);
+    let files = node.files;
+
+    if (path && listingCompletePaths.has(path) && prev) {
+      const polledFolderPaths = new Set(subFolders.map((f) => f.relativePath.replace(/\\/g, '/')));
+      for (const prevChild of prev.subFolders) {
+        const childPath = prevChild.relativePath.replace(/\\/g, '/');
+        if (!polledFolderPaths.has(childPath)) {
+          subFolders = [...subFolders, graft(prevChild)];
+        }
+      }
+      const byPath = new Map(files.map((f) => [f.relativePath.replace(/\\/g, '/'), f]));
+      for (const prevFile of prev.files) {
+        byPath.set(prevFile.relativePath.replace(/\\/g, '/'), prevFile);
+      }
+      files = Array.from(byPath.values());
+    }
+
+    subFolders = subFolders
+      .map((child) => {
+        const childPath = child.relativePath.replace(/\\/g, '/');
+        const prevChild = previousByPath.get(childPath);
+        if (prevChild && listingCompletePaths.has(childPath)) {
+          return graft({
+            ...child,
+            subFolders: prevChild.subFolders,
+            files: prevChild.files.length ? prevChild.files : child.files,
+          });
+        }
+        return child;
+      })
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+
+    return { ...node, subFolders, files };
+  };
+
+  return graft(polledTree);
+}

--- a/src/server/GuideAntsApi.Tests/Architecture/LocalAiLifecycleAuthorityContractTests.cs
+++ b/src/server/GuideAntsApi.Tests/Architecture/LocalAiLifecycleAuthorityContractTests.cs
@@ -93,6 +93,9 @@ public sealed partial class LocalAiLifecycleAuthorityContractTests
                 $"{Path.DirectorySeparatorChar}_archive{Path.DirectorySeparatorChar}",
                 StringComparison.OrdinalIgnoreCase))
             .Where(path => !path.Contains(
+                $"{Path.DirectorySeparatorChar}volumes{Path.DirectorySeparatorChar}",
+                StringComparison.OrdinalIgnoreCase))
+            .Where(path => !path.Contains(
                 $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
                 StringComparison.OrdinalIgnoreCase))
             .Where(path => !path.Contains(

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiRuntimeWatchdogHostedServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiRuntimeWatchdogHostedServiceTests.cs
@@ -30,4 +30,32 @@ public sealed class LocalAiRuntimeWatchdogHostedServiceTests
 
         LocalAiRuntimeWatchdogHostedService.ExecutorNeedsApiPlan(status).Should().Be(expected);
     }
+
+    [TestMethod]
+    public void ExecutorNeedsApiPlan_DesiredServiceNotApplied_NeedsPlan()
+    {
+        var status = new WarmupStatusDocument(
+            SchemaVersion: 2,
+            DesiredRevision: 4,
+            AppliedRevision: 4,
+            InProgressRevision: null,
+            ApplyStatus: "applied",
+            ApplyError: null,
+            DesiredSha256: string.Empty,
+            WrittenAt: string.Empty,
+            Services: new Dictionary<string, WarmupServiceStatus>(StringComparer.Ordinal)
+            {
+                ["SpeechTranscription"] = new WarmupServiceStatus(
+                    Desired: "on",
+                    Applied: "off",
+                    Phase: "idle",
+                    Error: null,
+                    PlanRef: "whisper-large",
+                    RouterAlias: null,
+                    ModelId: null,
+                    BundleId: null),
+            });
+
+        LocalAiRuntimeWatchdogHostedService.ExecutorNeedsApiPlan(status).Should().BeTrue();
+    }
 }

--- a/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiWarmupOrchestrationClientTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Bootstrap/LocalAiWarmupOrchestrationClientTests.cs
@@ -40,4 +40,37 @@ public sealed class LocalAiWarmupOrchestrationClientTests
         merged.ApplyStatus.Should().Be("applied");
         merged.DesiredRevision.Should().BeLessThanOrEqualTo(merged.AppliedRevision);
     }
+
+    [TestMethod]
+    public void MergeStackStatuses_OneStackIdleAfterRestart_MergedApplyStatusIsIdle()
+    {
+        var localStack = new WarmupStatusDocument(
+            SchemaVersion: 1,
+            DesiredRevision: 5,
+            AppliedRevision: 5,
+            InProgressRevision: null,
+            ApplyStatus: "applied",
+            ApplyError: null,
+            DesiredSha256: string.Empty,
+            WrittenAt: string.Empty,
+            Services: new Dictionary<string, WarmupServiceStatus>());
+
+        var remoteStack = new WarmupStatusDocument(
+            SchemaVersion: 1,
+            DesiredRevision: 0,
+            AppliedRevision: 0,
+            InProgressRevision: null,
+            ApplyStatus: "idle",
+            ApplyError: null,
+            DesiredSha256: string.Empty,
+            WrittenAt: string.Empty,
+            Services: new Dictionary<string, WarmupServiceStatus>());
+
+        var merged = LocalAiWarmupOrchestrationClient.MergeStackStatuses(
+            [localStack, remoteStack],
+            new Dictionary<string, WarmupServiceStatus>());
+
+        merged.ApplyStatus.Should().Be("idle");
+        LocalAiRuntimeWatchdogHostedService.ExecutorNeedsApiPlan(merged).Should().BeTrue();
+    }
 }

--- a/src/server/GuideAntsApi.Tests/Services/Components/HostMountDirectoryScannerTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Components/HostMountDirectoryScannerTests.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using GuideAntsApi.Services.Components;
+
+namespace GuideAntsApi.Tests.Services.Components;
+
+[TestClass]
+public class HostMountDirectoryScannerTests
+{
+    private string _root = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ga-mount-scan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        var d3 = Path.Combine(_root, "d1", "d2", "d3");
+        Directory.CreateDirectory(Path.Combine(d3, "audiocpp"));
+        Directory.CreateDirectory(Path.Combine(d3, "audiocpp-asr"));
+        File.WriteAllText(Path.Combine(d3, "README.md"), "readme");
+        File.WriteAllText(Path.Combine(d3, "audiocpp", "SKILL.md"), "skill");
+        File.WriteAllText(Path.Combine(d3, "audiocpp-asr", "SKILL.md"), "asr");
+        HostMountListingCache.ClearAll();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+
+        HostMountListingCache.ClearAll();
+    }
+
+    [TestMethod]
+    public void Scan_Depth3_IncludesReadme_ExcludesDepth4Files()
+    {
+        var result = HostMountDirectoryScanner.Scan(
+            [new HostMountDirectoryScanner.MountRoot("leaf", _root)],
+            maxFiles: 5000,
+            maxDepth: 3,
+            scanBudget: TimeSpan.FromSeconds(5));
+
+        result.Files.Select(f => f.RelativePath).Should().Contain("leaf/d1/d2/d3/README.md");
+        result.Files.Select(f => f.RelativePath).Should().NotContain("leaf/d1/d2/d3/audiocpp/SKILL.md");
+        result.Directories.Select(d => d.RelativePath).Should().Contain("leaf/d1/d2/d3");
+        result.Directories.Select(d => d.RelativePath).Should().NotContain("leaf/d1/d2/d3/audiocpp");
+    }
+
+    [TestMethod]
+    public void ListLevel_ReturnsImmediateChildrenOnly()
+    {
+        var result = HostMountDirectoryScanner.ListLevel(
+            _root,
+            relativePathPrefix: "leaf",
+            relativeWithinMount: "d1/d2/d3",
+            maxFiles: 5000,
+            scanBudget: TimeSpan.FromSeconds(5));
+
+        result.Files.Select(f => f.RelativePath).Should().ContainSingle("leaf/d1/d2/d3/README.md");
+        result.Directories.Select(d => d.Name).Should().BeEquivalentTo("audiocpp", "audiocpp-asr");
+        result.Files.Select(f => f.RelativePath).Should().NotContain("leaf/d1/d2/d3/audiocpp/SKILL.md");
+    }
+
+    [TestMethod]
+    public void ListingCache_ReturnsWarmEntry_UntilInvalidated()
+    {
+        var mountKey = Guid.NewGuid().ToString("N");
+        var key = HostMountListingCache.ShallowKey(mountKey);
+        var scan = HostMountDirectoryScanner.Scan(
+            [new HostMountDirectoryScanner.MountRoot("leaf", _root)],
+            maxFiles: 5000,
+            maxDepth: 3,
+            scanBudget: TimeSpan.FromSeconds(5));
+
+        HostMountListingCache.Set(key, scan, TimeSpan.FromMinutes(2));
+        HostMountListingCache.TryGet(key, out var cached).Should().BeTrue();
+        cached.Files.Count.Should().Be(scan.Files.Count);
+
+        HostMountListingCache.InvalidateMount(mountKey);
+        HostMountListingCache.TryGet(key, out _).Should().BeFalse();
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Components/NotebookFileChangeReporterTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Components/NotebookFileChangeReporterTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Security.Cryptography;
+using AntRunner.Chat;
 using AntRunner.ToolCalling;
 using FluentAssertions;
 using GuideAntsApi.DataModel;
@@ -39,10 +40,11 @@ public sealed class NotebookFileChangeReporterTests
     }
 
     [TestMethod]
-    public void ToCwdRelativePath_Private_SimpleFileReturnedAsIs()
+    public void ToCwdRelativePath_Private_NotebookRootFileGetsParentPrefix()
     {
+        // Private CWD is Output/; a notebook-root file must be addressed via ../
         NotebookFileChangeReporter.ToCwdRelativePath("notes.txt", isPublished: false, runId: null)
-            .Should().Be("notes.txt");
+            .Should().Be("../notes.txt");
     }
 
     [TestMethod]
@@ -88,7 +90,7 @@ public sealed class NotebookFileChangeReporterTests
     }
 
     [TestMethod]
-    public async Task DetectChangesAsync_ReturnsEmpty_WhenWorkingDirectoryMissing()
+    public async Task DetectChangesAsync_ReturnsEmpty_WhenNotebookRootMissing()
     {
         using var storage = new TempStorage();
         var projectId = Guid.NewGuid();
@@ -100,6 +102,63 @@ public sealed class NotebookFileChangeReporterTests
 
         newFiles.Should().BeEmpty();
         modifiedFiles.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task DetectChangesAsync_DetectsNotebookRootFile_AsParentRelativePath()
+    {
+        using var storage = new TempStorage();
+        var projectId = Guid.NewGuid();
+        var notebookId = Guid.NewGuid();
+        storage.OutputDir(projectId, notebookId); // ensure Output exists (CWD)
+        File.WriteAllText(Path.Combine(storage.NotebookRoot(projectId, notebookId), "root-out.rttm"), "SPEAKER 1");
+
+        var provider = BuildProvider(storage.Root, projectId, notebookId);
+        var context = new InvocationContext(projectId, notebookId, Guid.NewGuid()) { IsPublished = false };
+
+        var (newFiles, modifiedFiles) = await NotebookFileChangeReporter.DetectChangesAsync(provider, storage.Root, context);
+
+        newFiles.Should().Contain("../root-out.rttm");
+        modifiedFiles.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task DetectChangesAsync_IgnoresCacheArtifactPaths()
+    {
+        using var storage = new TempStorage();
+        var projectId = Guid.NewGuid();
+        var notebookId = Guid.NewGuid();
+        var outputDir = storage.OutputDir(projectId, notebookId);
+        var cacheDir = Path.Combine(outputDir, "models", ".cache", "huggingface");
+        Directory.CreateDirectory(cacheDir);
+        File.WriteAllText(Path.Combine(cacheDir, "CACHEDIR.TAG"), "Signature: 8a477f597d28d172789f06886806bc55");
+        File.WriteAllText(Path.Combine(outputDir, "real-output.txt"), "ok");
+
+        var provider = BuildProvider(storage.Root, projectId, notebookId);
+        var context = new InvocationContext(projectId, notebookId, Guid.NewGuid()) { IsPublished = false };
+
+        var (newFiles, modifiedFiles) = await NotebookFileChangeReporter.DetectChangesAsync(provider, storage.Root, context);
+
+        newFiles.Should().ContainSingle().Which.Should().Be("real-output.txt");
+        newFiles.Should().NotContain(p => p.Contains(".cache", StringComparison.OrdinalIgnoreCase));
+        modifiedFiles.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void GetDbRelativePaths_DropsExcludedArtifactPaths()
+    {
+        var output = new ChatRunOutput
+        {
+            NewFiles =
+            [
+                "real.txt",
+                "models/.cache/huggingface/CACHEDIR.TAG",
+            ]
+        };
+
+        var paths = NotebookFileChangeReporter.GetDbRelativePaths(output, isPublished: false, runId: null);
+
+        paths.Should().ContainSingle().Which.Should().Be("Output/real.txt");
     }
 
     [TestMethod]

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ContextOptionFilesFormatterTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ContextOptionFilesFormatterTests.cs
@@ -62,6 +62,8 @@ public sealed class NotebookArtifactPathExclusionsTests
     {
         NotebookArtifactPathExclusions.IsExcludedRelativePath("Output/.npm/_cacache/foo").Should().BeTrue();
         NotebookArtifactPathExclusions.IsExcludedRelativePath("Output/node_modules/pkg/index.js").Should().BeTrue();
+        NotebookArtifactPathExclusions.IsExcludedRelativePath("Output/.audiocpp-extended/engine-18099.log").Should().BeTrue();
+        NotebookArtifactPathExclusions.IsExcludedRelativePath("Output/.wire-attachments/x.bin").Should().BeTrue();
         NotebookArtifactPathExclusions.IsExcludedRelativePath("docs/readme.md").Should().BeFalse();
     }
 }

--- a/src/server/GuideAntsApi.Tests/Services/DocumentServerServiceDeepTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/DocumentServerServiceDeepTests.cs
@@ -436,6 +436,7 @@ public sealed class DocumentServerServiceDeepTests
 
         public Task<IEnumerable<NotebookFileDto>> ListFilesAsync(Guid projectId, Guid notebookId) => Task.FromResult<IEnumerable<NotebookFileDto>>([]);
         public Task<NotebookFolderTreeDto?> GetFolderTreeAsync(Guid projectId, Guid notebookId) => Task.FromResult<NotebookFolderTreeDto?>(null);
+        public Task<HostMountListingDto?> ListHostMountLevelAsync(Guid projectId, Guid notebookId, string relativePath) => Task.FromResult<HostMountListingDto?>(null);
         public Task<(Stream Stream, string ContentType, string FileName)?> GetFileAsync(Guid projectId, Guid notebookId, string relativePath) => Task.FromResult<(Stream, string, string)?>(null);
         public Task<(Stream stream, string contentType)> GetFileContentStreamAsync(Guid projectId, Guid notebookId, string relativePath) => throw new NotImplementedException();
         public Task<(Stream Stream, string ContentType, string FileName)?> GetFileContentStreamAsync(Guid notebookFileId, CancellationToken cancellationToken = default) => Task.FromResult(FileContentStream);

--- a/src/server/GuideAntsApi.Tests/Services/DocumentServerServiceTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/DocumentServerServiceTests.cs
@@ -617,6 +617,7 @@ public sealed class DocumentServerServiceTests
 
         public Task<IEnumerable<NotebookFileDto>> ListFilesAsync(Guid projectId, Guid notebookId) => Task.FromResult<IEnumerable<NotebookFileDto>>([]);
         public Task<NotebookFolderTreeDto?> GetFolderTreeAsync(Guid projectId, Guid notebookId) => Task.FromResult<NotebookFolderTreeDto?>(null);
+        public Task<HostMountListingDto?> ListHostMountLevelAsync(Guid projectId, Guid notebookId, string relativePath) => Task.FromResult<HostMountListingDto?>(null);
         public Task<(Stream Stream, string ContentType, string FileName)?> GetFileAsync(Guid projectId, Guid notebookId, string relativePath) => Task.FromResult< (Stream, string, string)?>(null);
         public Task<(Stream stream, string contentType)> GetFileContentStreamAsync(Guid projectId, Guid notebookId, string relativePath) => throw new NotImplementedException();
         public Task<(Stream Stream, string ContentType, string FileName)?> GetFileContentStreamAsync(Guid notebookFileId, CancellationToken cancellationToken = default) => Task.FromResult<(Stream, string, string)?>(null);

--- a/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LlamaNegativeContractTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LlamaNegativeContractTests.cs
@@ -11,6 +11,7 @@ using GuideAntsApi.Settings;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using GuideAntsApi.Tests.TestUtils;
 using Moq;
@@ -451,7 +452,15 @@ public sealed class LlamaNegativeContractTests
             inventory.Object,
             coordinator,
             CreateLifecycleScopeFactory(db, coordinator),
+            CreateHostApplicationLifetime(),
             NullLogger<LocalModelLifecycleService>.Instance);
+    }
+
+    private static IHostApplicationLifetime CreateHostApplicationLifetime()
+    {
+        var lifetime = new Mock<IHostApplicationLifetime>();
+        lifetime.Setup(x => x.ApplicationStopping).Returns(CancellationToken.None);
+        return lifetime.Object;
     }
 
     private static IServiceScopeFactory CreateLifecycleScopeFactory(

--- a/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LocalModelOnboarding/LocalModelLifecycleTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LocalModelOnboarding/LocalModelLifecycleTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using GuideAntsApi.Tests.TestUtils;
 using Moq;
@@ -42,7 +43,7 @@ public sealed class LocalModelLifecycleTests
     }
 
     [TestMethod]
-    public async Task ChangeQuant_CreatesOperation_WithObsoletePaths()
+    public async Task ChangeQuant_CreatesOperation_WithoutDeletingPriorQuants()
     {
         await using var db = CreateDbContext();
         SeedInstallation(db, managementMode: "curated");
@@ -59,7 +60,8 @@ public sealed class LocalModelLifecycleTests
         operation.OperationKind.Should().Be(LocalModelOperationKinds.ChangeQuant);
 
         var input = ChangeQuantImmutableInput.Deserialize(operation.ImmutableInputJson);
-        input.ObsoleteRepositoryPaths.Should().NotBeEmpty();
+        input.ModelFiles.Should().Contain("model-q4.gguf");
+        // Sibling quants that are not active stay on disk; change-quant does not track them for deletion.
     }
 
     [TestMethod]
@@ -210,7 +212,15 @@ public sealed class LocalModelLifecycleTests
             inventory.Object,
             new Mock<ILlamaRuntimeCoordinator>().Object,
             CreateLifecycleScopeFactory(db, adminClient.Object),
+            CreateHostApplicationLifetime(),
             NullLogger<LocalModelLifecycleService>.Instance);
+    }
+
+    private static IHostApplicationLifetime CreateHostApplicationLifetime()
+    {
+        var lifetime = new Mock<IHostApplicationLifetime>();
+        lifetime.Setup(x => x.ApplicationStopping).Returns(CancellationToken.None);
+        return lifetime.Object;
     }
 
     private static IServiceScopeFactory CreateLifecycleScopeFactory(

--- a/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LocalModelOnboarding/LocalModelOperationDispatchTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/LlamaCpp/LocalModelOnboarding/LocalModelOperationDispatchTests.cs
@@ -9,6 +9,7 @@ using GuideAntsApi.Services.LlamaCpp.LocalModelOnboarding;
 using GuideAntsApi.Services.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using GuideAntsApi.Tests.TestUtils;
 using Moq;
@@ -82,6 +83,9 @@ public sealed class LocalModelOperationDispatchTests
         adminClient
             .Setup(x => x.GetDownloadStatusAsync(operationId.ToString("D"), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ModelDownloadOperationDto?)null);
+        adminClient
+            .Setup(x => x.GetRouterEntriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlamaAdminRouterEntriesResponseDto([]));
 
         var service = CreateLifecycleOperationService(db, adminClient.Object);
         await service.ReconcileInFlightLifecycleOperationsAsync(CancellationToken.None);
@@ -106,6 +110,9 @@ public sealed class LocalModelOperationDispatchTests
         adminClient
             .Setup(x => x.GetDownloadStatusAsync(strandedId.ToString("D"), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ModelDownloadOperationDto?)null);
+        adminClient
+            .Setup(x => x.GetRouterEntriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlamaAdminRouterEntriesResponseDto([]));
 
         var lifecycleOperations = CreateLifecycleOperationService(db, adminClient.Object);
         await lifecycleOperations.ReconcileInFlightLifecycleOperationsAsync(CancellationToken.None);
@@ -196,7 +203,187 @@ public sealed class LocalModelOperationDispatchTests
             inventory.Object,
             new Mock<ILlamaRuntimeCoordinator>().Object,
             services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+            CreateHostApplicationLifetime(),
             NullLogger<LocalModelLifecycleService>.Instance);
+    }
+
+    private static IHostApplicationLifetime CreateHostApplicationLifetime()
+    {
+        var lifetime = new Mock<IHostApplicationLifetime>();
+        lifetime.Setup(x => x.ApplicationStopping).Returns(CancellationToken.None);
+        return lifetime.Object;
+    }
+
+    /// <summary>
+    /// SEV1: download finished and router already points at the new quant, but
+    /// llama-admin dropped the journal. Must finalize provenance — not MarkFailed
+    /// and not leave the alias blocked.
+    /// </summary>
+    [TestMethod]
+    public async Task Sweep_ChangeQuant_JournalLostButRouterHasArtifacts_CompletesAndUnblocksAlias()
+    {
+        await using var db = CreateDbContext();
+        SeedInstallation(db);
+        var operationId = Guid.Parse("ffffffff-0000-1111-2222-333333333333");
+        SeedChangeQuantOperation(db, operationId, status: "downloading", downloadStarted: true);
+
+        var llamaClient = new Mock<ILlamaServerRuntimeClient>();
+        llamaClient
+            .Setup(x => x.LoadModelAsync("qwen-local", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var adminClient = new Mock<ILlamaRuntimeAdminClient>();
+        adminClient
+            .Setup(x => x.GetDownloadStatusAsync(operationId.ToString("D"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModelDownloadOperationDto?)null);
+        adminClient
+            .Setup(x => x.GetRouterEntriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlamaAdminRouterEntriesResponseDto(
+            [
+                new LlamaAdminRouterEntryDto(
+                    Alias: "qwen-local",
+                    ModelPath: "/models-local/llama/qwen-local/model-q4.gguf",
+                    MmprojPath: null,
+                    HasModelFile: true,
+                    HasMmprojFile: false,
+                    ContextSize: 8192,
+                    CacheRamMib: null,
+                    Preset: new Dictionary<string, string> { ["ctx-size"] = "8192" }),
+            ]));
+        adminClient
+            .Setup(x => x.AddOrUpdateRouterEntryAsync(
+                "qwen-local",
+                It.Is<string>(p => p.Contains("model-q4.gguf", StringComparison.OrdinalIgnoreCase)),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        adminClient
+            .Setup(x => x.DeleteObsoleteArtifactPathsAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("change-quant must not delete prior quants"));
+
+        var service = new LocalModelLifecycleOperationService(
+            db,
+            adminClient.Object,
+            new Mock<IHuggingFaceTokenResolver>().Object,
+            llamaClient.Object,
+            new Mock<ILlamaRuntimeCoordinator>().Object,
+            NullLogger<LocalModelLifecycleOperationService>.Instance);
+
+        await service.ReconcileInFlightLifecycleOperationsAsync(CancellationToken.None);
+
+        var operation = await db.LocalModelOperations.SingleAsync(o => o.OperationId == operationId);
+        operation.Status.Should().Be(LocalModelOperationStatuses.Completed);
+        adminClient.Verify(
+            x => x.DeleteObsoleteArtifactPathsAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        var installation = await db.LocalModelInstallations.SingleAsync();
+        installation.QuantId.Should().Be("q4_k_m");
+        installation.QuantLabel.Should().Be("Q4_K_M");
+        installation.ResolvedRevision.Should().Be("8f4c3f1a2b3c4d5e6f708192a3b4c5d6e7f8091a");
+
+        var lifecycle = CreateLifecycleService(db, CreateAdminClientForChangeQuant());
+        var act = () => lifecycle.StartChangeQuantAsync(
+            "qwen-local",
+            new ChangeQuantRequestDto("q4_k_m", "8f4c3f1a2b3c4d5e6f708192a3b4c5d6e7f8091a"),
+            CancellationToken.None);
+        // In-flight gate must be clear; same quant then correctly rejects as unchanged.
+        (await act.Should().ThrowAsync<LocalModelLifecycleException>())
+            .Which.Code.Should().Be("QUANT_UNCHANGED");
+    }
+
+    /// <summary>
+    /// SEV1 recovery: journal lost and router does not have the expected artifacts.
+    /// Must reach a terminal status so the alias is not permanently bricked.
+    /// </summary>
+    [TestMethod]
+    public async Task Sweep_ChangeQuant_JournalLostAndRouterMissingArtifacts_FailsAndUnblocksAlias()
+    {
+        await using var db = CreateDbContext();
+        SeedInstallation(db);
+        var strandedId = Guid.Parse("aaaaaaaa-1111-2222-3333-444444444444");
+        SeedChangeQuantOperation(db, strandedId, status: "downloading", downloadStarted: true);
+
+        var adminClient = new Mock<ILlamaRuntimeAdminClient>();
+        adminClient
+            .Setup(x => x.GetDownloadStatusAsync(strandedId.ToString("D"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModelDownloadOperationDto?)null);
+        adminClient
+            .Setup(x => x.GetRouterEntriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlamaAdminRouterEntriesResponseDto(
+            [
+                new LlamaAdminRouterEntryDto(
+                    Alias: "qwen-local",
+                    ModelPath: "/models-local/llama/qwen-local/model-q6.gguf",
+                    MmprojPath: null,
+                    HasModelFile: true,
+                    HasMmprojFile: false,
+                    ContextSize: 8192,
+                    CacheRamMib: null,
+                    Preset: null),
+            ]));
+
+        var service = CreateLifecycleOperationService(db, adminClient.Object);
+        await service.ReconcileInFlightLifecycleOperationsAsync(CancellationToken.None);
+
+        var operation = await db.LocalModelOperations.SingleAsync(o => o.OperationId == strandedId);
+        operation.Status.Should().Be(LocalModelOperationStatuses.Failed);
+        operation.ErrorCode.Should().Be("INSTALL_STEP_FAILED");
+
+        var lifecycleAdmin = CreateAdminClientForChangeQuant();
+        var lifecycle = CreateLifecycleService(db, lifecycleAdmin);
+        var response = await lifecycle.StartChangeQuantAsync(
+            "qwen-local",
+            new ChangeQuantRequestDto("q4_k_m", "8f4c3f1a2b3c4d5e6f708192a3b4c5d6e7f8091a"),
+            CancellationToken.None);
+        response.OperationId.Should().NotBeNullOrWhiteSpace();
+        response.Status.Should().Be("queued");
+    }
+
+    private static void SeedChangeQuantOperation(
+        ApplicationDbContext db,
+        Guid operationId,
+        string status,
+        bool downloadStarted)
+    {
+        db.LocalModelOperations.Add(new LocalModelOperation
+        {
+            OperationId = operationId,
+            OperationKind = LocalModelOperationKinds.ChangeQuant,
+            ModelId = "qwen-local",
+            RouterModelId = "qwen-local",
+            // Prior non-active quant path must not be deleted when this op finalizes.
+            ImmutableInputJson = new ChangeQuantImmutableInput(
+                "qwen-local",
+                "qwen3.6-35b-a3b",
+                "2026-07-10",
+                "q6_k_xl",
+                "q4_k_m",
+                "Q4_K_M",
+                "org/model",
+                "8f4c3f1a2b3c4d5e6f708192a3b4c5d6e7f8091a",
+                ["model-q4.gguf"],
+                [],
+                [],
+                "qwen-local",
+                "qwen-local",
+                new Dictionary<string, string> { ["ctx-size"] = "8192" }).ToJson(),
+            Status = status,
+            CurrentStep = status,
+            CompletedSideEffectsJson = downloadStarted
+                ? """{"wasLoadedAtStart":true,"unloadedForOperation":true,"downloadStarted":true}"""
+                : "{}",
+            CreatedUtc = DateTime.UtcNow.AddMinutes(-30),
+            UpdatedUtc = DateTime.UtcNow.AddMinutes(-20),
+            RowVersion = DefaultRowVersion,
+        });
+        db.SaveChanges();
     }
 
     private static void SeedRepairOperation(

--- a/src/server/GuideAntsApi/Endpoints/NotebookEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/NotebookEndpoints.cs
@@ -201,6 +201,26 @@ public static class NotebookEndpoints
         .Produces<NotebookFolderTreeDto>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized);
 
+        fileGroup.MapGet("/host-mounts/listing", async (
+            Guid projectId,
+            Guid notebookId,
+            string path,
+            INotebookFileService fsService) =>
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return Results.BadRequest(new { message = "Query parameter 'path' is required." });
+            }
+
+            var listing = await fsService.ListHostMountLevelAsync(projectId, notebookId, path);
+            return listing == null ? Results.NotFound() : Results.Ok(listing);
+        })
+        .WithName("ListNotebookHostMountLevel")
+        .Produces<HostMountListingDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status401Unauthorized);
+
         fileGroup.MapPost("/sync", async (
             Guid projectId,
             Guid notebookId,

--- a/src/server/GuideAntsApi/Endpoints/ProjectFolderEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/ProjectFolderEndpoints.cs
@@ -32,6 +32,33 @@ public static class ProjectFolderEndpoints
         .Produces(StatusCodes.Status401Unauthorized)
         .Produces(StatusCodes.Status403Forbidden);
 
+        group.MapGet("/host-mounts/listing", async (
+            Guid projectId,
+            string path,
+            IProjectFolderService folderService) =>
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return Results.BadRequest(new { message = "Query parameter 'path' is required." });
+            }
+
+            try
+            {
+                var listing = await folderService.ListHostMountLevelAsync(projectId, path);
+                return listing == null ? Results.NotFound() : Results.Ok(listing);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Results.Forbid();
+            }
+        })
+        .WithName("ListProjectHostMountLevel")
+        .Produces<HostMountListingDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden);
+
         // Get all folders
         group.MapGet("/", async (Guid projectId, IProjectFolderService folderService) =>
         {

--- a/src/server/GuideAntsApi/Models/NotebookFileDto.cs
+++ b/src/server/GuideAntsApi/Models/NotebookFileDto.cs
@@ -20,6 +20,25 @@ public record NotebookFolderTreeDto(
     List<NotebookFileDto> Files
 );
 
+public record HostMountListingFolderDto(
+    string Name,
+    string RelativePath);
+
+public record HostMountListingFileDto(
+    Guid Id,
+    string FileName,
+    string RelativePath,
+    long FileSize,
+    DateTime LastModifiedUtc,
+    string FileHash,
+    bool IsLinked = true);
+
+public record HostMountListingDto(
+    string Path,
+    List<HostMountListingFolderDto> Folders,
+    List<HostMountListingFileDto> Files,
+    bool Truncated);
+
 public record RenameItemDto(string SourcePath, string NewName);
 public record MoveItemDto(string SourcePath, string DestinationPath);
 public record NotebookCreateFolderDto(string Path);

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiRuntimeWatchdogHostedService.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiRuntimeWatchdogHostedService.cs
@@ -6,8 +6,9 @@ using Microsoft.EntityFrameworkCore;
 namespace GuideAntsApi.Services.Bootstrap;
 
 /// <summary>
-/// Re-submits API-owned lifecycle policy after the executor restarts, and repairs
-/// a missing configured local llama model while the API process remains alive.
+/// Re-submits API-owned lifecycle policy after an executor restarts (including a
+/// remote aux stack in split mode), and repairs a missing configured local llama
+/// model while the API process remains alive.
 /// </summary>
 public sealed class LocalAiRuntimeWatchdogHostedService : BackgroundService
 {
@@ -97,9 +98,30 @@ public sealed class LocalAiRuntimeWatchdogHostedService : BackgroundService
         return ExecutorNeedsApiPlan(status);
     }
 
-    internal static bool ExecutorNeedsApiPlan(WarmupStatusDocument status) =>
-        status.DesiredRevision == 0
-            || string.Equals(status.ApplyStatus, "idle", StringComparison.OrdinalIgnoreCase);
+    /// <summary>
+    /// True when any configured stack has no API plan yet, was reset to idle, or has an
+    /// API-desired service that is not applied (e.g. remote aux stack restarted while the
+    /// local llama stack still looks healthy).
+    /// </summary>
+    internal static bool ExecutorNeedsApiPlan(WarmupStatusDocument status)
+    {
+        if (status.DesiredRevision == 0
+            || string.Equals(status.ApplyStatus, "idle", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        foreach (var service in status.Services.Values)
+        {
+            if (string.Equals(service.Desired, "on", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(service.Applied, "on", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private async Task<bool> IsConfiguredDefaultLlamaLoadedAsync(CancellationToken cancellationToken)
     {

--- a/src/server/GuideAntsApi/Services/Bootstrap/LocalAiWarmupOrchestrationClient.cs
+++ b/src/server/GuideAntsApi/Services/Bootstrap/LocalAiWarmupOrchestrationClient.cs
@@ -79,7 +79,22 @@ public sealed class LocalAiWarmupOrchestrationClient : ILocalAiWarmupOrchestrati
         var stackStatuses = new List<WarmupStatusDocument>(stacks.Count);
         foreach (var stackBase in stacks)
         {
-            var status = await GetStatusForStackAsync(stackBase, cancellationToken).ConfigureAwait(false);
+            WarmupStatusDocument status;
+            try
+            {
+                status = await GetStatusForStackAsync(stackBase, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Split mode: one stack down/restarting must not hide the need to re-apply.
+                // Treat unreachable/failing status as idle revision 0 so the watchdog re-submits.
+                _logger.LogWarning(
+                    ex,
+                    "Warmup status unavailable for stack {StackBase}; treating stack as idle (needs API plan).",
+                    stackBase);
+                status = EmptyStatusDocument();
+            }
+
             stackStatuses.Add(status);
             foreach (var serviceId in LocalAiStackHostUrls.WarmupServiceIds)
             {

--- a/src/server/GuideAntsApi/Services/Components/HostFolderMountService.cs
+++ b/src/server/GuideAntsApi/Services/Components/HostFolderMountService.cs
@@ -253,6 +253,8 @@ public sealed class HostFolderMountService : IHostFolderMountService
             throw new InvalidOperationException(UnlinkFailureRemediation);
         }
 
+        HostMountListingCache.InvalidateMount(mountId.ToString("N"));
+
         var removeCommand = BuildRemoveCommandText(mount.Id);
 
         return new HostFolderMountRemoveCommandResult(
@@ -278,6 +280,7 @@ public sealed class HostFolderMountService : IHostFolderMountService
 
         db.HostFolderMounts.Remove(mount);
         await db.SaveChangesAsync(cancellationToken);
+        HostMountListingCache.InvalidateMount(mountId.ToString("N"));
         return true;
     }
 
@@ -303,6 +306,8 @@ public sealed class HostFolderMountService : IHostFolderMountService
             notebookId: null,
             mountId: mountId,
             cancellationToken);
+
+        HostMountListingCache.InvalidateMount(mountId.ToString("N"));
 
         await db.Entry(mount).ReloadAsync(cancellationToken);
         await db.Entry(mount).Collection(m => m.Links).LoadAsync(cancellationToken);

--- a/src/server/GuideAntsApi/Services/Components/HostMountDirectoryScanner.cs
+++ b/src/server/GuideAntsApi/Services/Components/HostMountDirectoryScanner.cs
@@ -10,8 +10,13 @@ public static class HostMountDirectoryScanner
         long FileSize,
         DateTime LastModifiedUtc);
 
+    public sealed record ScannedDirectory(
+        string RelativePath,
+        string Name);
+
     public sealed record ScanResult(
         IReadOnlyList<ScannedFile> Files,
+        IReadOnlyList<ScannedDirectory> Directories,
         bool WasTruncated);
 
     public sealed record MountRoot(
@@ -25,8 +30,10 @@ public static class HostMountDirectoryScanner
         TimeSpan scanBudget,
         ILogger? logger = null)
     {
-        var results = new List<ScannedFile>();
-        var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var files = new List<ScannedFile>();
+        var directories = new List<ScannedDirectory>();
+        var seenFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenDirPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var truncated = false;
         var scanDeadlineUtc = DateTimeOffset.UtcNow + scanBudget;
         var fileEnumerationOptions = new EnumerationOptions
@@ -36,10 +43,18 @@ public static class HostMountDirectoryScanner
             ReturnSpecialDirectories = false,
             MaxRecursionDepth = maxDepth
         };
+        var directoryEnumerationOptions = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true,
+            ReturnSpecialDirectories = false,
+            // Include the frontier directory level so stubs exist for lazy expand.
+            MaxRecursionDepth = Math.Max(0, maxDepth)
+        };
 
         foreach (var root in roots)
         {
-            if (DateTimeOffset.UtcNow >= scanDeadlineUtc || results.Count >= maxFiles)
+            if (DateTimeOffset.UtcNow >= scanDeadlineUtc || files.Count >= maxFiles)
             {
                 truncated = true;
                 break;
@@ -48,6 +63,53 @@ public static class HostMountDirectoryScanner
             if (string.IsNullOrWhiteSpace(root.PhysicalPath) || !Directory.Exists(root.PhysicalPath))
             {
                 continue;
+            }
+
+            try
+            {
+                foreach (var physicalDirectory in Directory.EnumerateDirectories(
+                             root.PhysicalPath, "*", directoryEnumerationOptions))
+                {
+                    if (DateTimeOffset.UtcNow >= scanDeadlineUtc)
+                    {
+                        truncated = true;
+                        break;
+                    }
+
+                    var relativeWithinMount = Path.GetRelativePath(root.PhysicalPath, physicalDirectory)
+                        .Replace("\\", "/").TrimStart('/');
+                    if (string.IsNullOrWhiteSpace(relativeWithinMount) || relativeWithinMount == ".")
+                    {
+                        continue;
+                    }
+
+                    // Keep directory stubs inside the initial window only (same depth as files).
+                    var directoryDepth = relativeWithinMount.Split('/', StringSplitOptions.RemoveEmptyEntries).Length;
+                    if (directoryDepth > maxDepth)
+                    {
+                        continue;
+                    }
+
+                    var fullRelativePath = $"{root.RelativePathPrefix}/{relativeWithinMount}".Replace("\\", "/");
+                    var directoryName = Path.GetFileName(fullRelativePath);
+                    if (IsExcludedDirectoryName(directoryName) || IsInPycacheFolder(fullRelativePath))
+                    {
+                        continue;
+                    }
+
+                    if (!seenDirPaths.Add(fullRelativePath))
+                    {
+                        continue;
+                    }
+
+                    directories.Add(new ScannedDirectory(
+                        RelativePath: fullRelativePath,
+                        Name: directoryName));
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Skipping mount directory enumeration for root {MountRoot}", root.RelativePathPrefix);
             }
 
             IEnumerable<string> physicalFiles;
@@ -63,7 +125,7 @@ public static class HostMountDirectoryScanner
 
             foreach (var physicalFile in physicalFiles)
             {
-                if (DateTimeOffset.UtcNow >= scanDeadlineUtc || results.Count >= maxFiles)
+                if (DateTimeOffset.UtcNow >= scanDeadlineUtc || files.Count >= maxFiles)
                 {
                     truncated = true;
                     break;
@@ -99,12 +161,12 @@ public static class HostMountDirectoryScanner
                     continue;
                 }
 
-                if (!seenPaths.Add(fullRelativePath))
+                if (!seenFilePaths.Add(fullRelativePath))
                 {
                     continue;
                 }
 
-                results.Add(new ScannedFile(
+                files.Add(new ScannedFile(
                     RelativePath: fullRelativePath,
                     FileName: fileName,
                     FileSize: fileInfo.Length,
@@ -112,10 +174,136 @@ public static class HostMountDirectoryScanner
             }
         }
 
-        results.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.RelativePath, b.RelativePath));
+        files.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.RelativePath, b.RelativePath));
+        directories.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.RelativePath, b.RelativePath));
 
-        return new ScanResult(results, truncated);
+        return new ScanResult(files, directories, truncated);
     }
+
+    /// <summary>
+    /// Lists one directory level under <paramref name="relativeWithinMount"/> (empty = mount root).
+    /// Paths in the result are prefixed with <paramref name="relativePathPrefix"/>.
+    /// </summary>
+    public static ScanResult ListLevel(
+        string physicalRoot,
+        string relativePathPrefix,
+        string relativeWithinMount,
+        int maxFiles,
+        TimeSpan scanBudget,
+        ILogger? logger = null)
+    {
+        var files = new List<ScannedFile>();
+        var directories = new List<ScannedDirectory>();
+        var truncated = false;
+        var scanDeadlineUtc = DateTimeOffset.UtcNow + scanBudget;
+
+        if (string.IsNullOrWhiteSpace(physicalRoot) || !Directory.Exists(physicalRoot))
+        {
+            return new ScanResult(files, directories, WasTruncated: false);
+        }
+
+        var normalizedWithin = NormalizeRelative(relativeWithinMount);
+        var targetPhysical = string.IsNullOrEmpty(normalizedWithin)
+            ? physicalRoot
+            : Path.GetFullPath(Path.Combine(physicalRoot, normalizedWithin.Replace('/', Path.DirectorySeparatorChar)));
+
+        var physicalRootFull = Path.GetFullPath(physicalRoot)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (!IsPathUnderRoot(targetPhysical, physicalRootFull) || !Directory.Exists(targetPhysical))
+        {
+            return new ScanResult(files, directories, WasTruncated: false);
+        }
+
+        var prefix = NormalizeRelative(relativePathPrefix);
+
+        try
+        {
+            foreach (var physicalDirectory in Directory.EnumerateDirectories(targetPhysical))
+            {
+                if (DateTimeOffset.UtcNow >= scanDeadlineUtc)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                var name = Path.GetFileName(physicalDirectory);
+                if (IsExcludedDirectoryName(name))
+                {
+                    continue;
+                }
+
+                var within = string.IsNullOrEmpty(normalizedWithin) ? name : $"{normalizedWithin}/{name}";
+                if (IsInPycacheFolder(within))
+                {
+                    continue;
+                }
+
+                var fullRelative = string.IsNullOrEmpty(prefix) ? within : $"{prefix}/{within}";
+                directories.Add(new ScannedDirectory(fullRelative, name));
+            }
+
+            foreach (var physicalFile in Directory.EnumerateFiles(targetPhysical))
+            {
+                if (DateTimeOffset.UtcNow >= scanDeadlineUtc || files.Count >= maxFiles)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                FileInfo fileInfo;
+                try
+                {
+                    fileInfo = new FileInfo(physicalFile);
+                    if (!fileInfo.Exists)
+                    {
+                        continue;
+                    }
+                }
+                catch
+                {
+                    continue;
+                }
+
+                var fileName = fileInfo.Name;
+                if (IsTemporaryScriptFile(fileName))
+                {
+                    continue;
+                }
+
+                var within = string.IsNullOrEmpty(normalizedWithin) ? fileName : $"{normalizedWithin}/{fileName}";
+                if (IsInPycacheFolder(within))
+                {
+                    continue;
+                }
+
+                var fullRelative = string.IsNullOrEmpty(prefix) ? within : $"{prefix}/{within}";
+                files.Add(new ScannedFile(
+                    RelativePath: fullRelative,
+                    FileName: fileName,
+                    FileSize: fileInfo.Length,
+                    LastModifiedUtc: fileInfo.LastWriteTimeUtc));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(
+                ex,
+                "Skipping mount one-level listing for root {MountRoot} path {RelativePath}",
+                prefix,
+                normalizedWithin);
+        }
+
+        files.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.RelativePath, b.RelativePath));
+        directories.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.RelativePath, b.RelativePath));
+
+        return new ScanResult(files, directories, truncated);
+    }
+
+    private static bool IsExcludedDirectoryName(string directoryName) =>
+        string.Equals(directoryName, "__pycache__", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(directoryName, ".guideants", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(directoryName, "node_modules", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(directoryName, ".git", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsTemporaryScriptFile(string filename)
     {
@@ -125,8 +313,27 @@ public static class HostMountDirectoryScanner
 
     private static bool IsInPycacheFolder(string relativePath)
     {
-        return relativePath.StartsWith("__pycache__/") ||
-               relativePath.Contains("/__pycache__/") ||
-               relativePath.EndsWith("/__pycache__");
+        return relativePath.StartsWith("__pycache__/", StringComparison.OrdinalIgnoreCase) ||
+               relativePath.Contains("/__pycache__/", StringComparison.OrdinalIgnoreCase) ||
+               relativePath.EndsWith("/__pycache__", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeRelative(string path) =>
+        (path ?? string.Empty).Replace('\\', '/').Trim('/');
+
+    private static bool IsPathUnderRoot(string candidatePath, string rootPath)
+    {
+        var rootFullPath = Path.GetFullPath(rootPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var candidateFullPath = Path.GetFullPath(candidatePath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (candidateFullPath.Equals(rootFullPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var rootWithSeparator = rootFullPath + Path.DirectorySeparatorChar;
+        return candidateFullPath.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/server/GuideAntsApi/Services/Components/HostMountListingCache.cs
+++ b/src/server/GuideAntsApi/Services/Components/HostMountListingCache.cs
@@ -1,0 +1,79 @@
+using System.Collections.Concurrent;
+
+namespace GuideAntsApi.Services.Components;
+
+/// <summary>
+/// Process-wide cache for host-mount shallow scans and one-level listings.
+/// Keys: <c>shallow:{mountKey}</c> and <c>level:{mountKey}:{relativePath}</c>.
+/// </summary>
+public static class HostMountListingCache
+{
+    private static readonly ConcurrentDictionary<string, CacheEntry> Entries = new(StringComparer.OrdinalIgnoreCase);
+
+    private sealed record CacheEntry(DateTimeOffset ExpiresUtc, HostMountDirectoryScanner.ScanResult Result);
+
+    public static bool TryGet(string key, out HostMountDirectoryScanner.ScanResult result)
+    {
+        PruneExpired(DateTimeOffset.UtcNow);
+        if (Entries.TryGetValue(key, out var entry) && entry.ExpiresUtc > DateTimeOffset.UtcNow)
+        {
+            result = entry.Result;
+            return true;
+        }
+
+        result = null!;
+        return false;
+    }
+
+    public static void Set(string key, HostMountDirectoryScanner.ScanResult result, TimeSpan ttl)
+    {
+        Entries[key] = new CacheEntry(DateTimeOffset.UtcNow + ttl, result);
+    }
+
+    public static string ShallowKey(string mountKey) => $"shallow:{NormalizeMountKey(mountKey)}";
+
+    public static string LevelKey(string mountKey, string relativePath) =>
+        $"level:{NormalizeMountKey(mountKey)}:{NormalizeRelative(relativePath)}";
+
+    public static void InvalidateMount(string mountKey)
+    {
+        var prefixShallow = $"shallow:{NormalizeMountKey(mountKey)}";
+        var prefixLevel = $"level:{NormalizeMountKey(mountKey)}:";
+        foreach (var key in Entries.Keys)
+        {
+            if (key.Equals(prefixShallow, StringComparison.OrdinalIgnoreCase)
+                || key.StartsWith(prefixLevel, StringComparison.OrdinalIgnoreCase))
+            {
+                Entries.TryRemove(key, out _);
+            }
+        }
+    }
+
+    public static void InvalidatePath(string mountKey, string relativePath)
+    {
+        var normalized = NormalizeRelative(relativePath);
+        Entries.TryRemove(LevelKey(mountKey, normalized), out _);
+
+        // Parent listings and the shallow page may include this path.
+        InvalidateMount(mountKey);
+    }
+
+    public static void ClearAll() => Entries.Clear();
+
+    private static void PruneExpired(DateTimeOffset now)
+    {
+        foreach (var kvp in Entries)
+        {
+            if (kvp.Value.ExpiresUtc <= now)
+            {
+                Entries.TryRemove(kvp.Key, out _);
+            }
+        }
+    }
+
+    private static string NormalizeMountKey(string mountKey) =>
+        (mountKey ?? string.Empty).Trim().ToLowerInvariant();
+
+    private static string NormalizeRelative(string path) =>
+        (path ?? string.Empty).Replace('\\', '/').Trim('/');
+}

--- a/src/server/GuideAntsApi/Services/Components/INotebookFileService.cs
+++ b/src/server/GuideAntsApi/Services/Components/INotebookFileService.cs
@@ -6,6 +6,7 @@ public interface INotebookFileService
 {
     Task<IEnumerable<NotebookFileDto>> ListFilesAsync(Guid projectId, Guid notebookId);
     Task<NotebookFolderTreeDto?> GetFolderTreeAsync(Guid projectId, Guid notebookId);
+    Task<HostMountListingDto?> ListHostMountLevelAsync(Guid projectId, Guid notebookId, string relativePath);
     Task<(Stream Stream, string ContentType, string FileName)?> GetFileAsync(Guid projectId, Guid notebookId, string relativePath);
     Task<(Stream stream, string contentType)> GetFileContentStreamAsync(Guid projectId, Guid notebookId, string relativePath);
     Task<(Stream Stream, string ContentType, string FileName)?> GetFileContentStreamAsync(Guid notebookFileId, CancellationToken cancellationToken = default);

--- a/src/server/GuideAntsApi/Services/Components/IProjectFolderService.cs
+++ b/src/server/GuideAntsApi/Services/Components/IProjectFolderService.cs
@@ -9,6 +9,7 @@ public interface IProjectFolderService
     Task<bool> DeleteFolderAsync(Guid projectId, Guid folderId);
     Task<IEnumerable<ProjectFolderDto>> GetFoldersAsync(Guid projectId);
     Task<FolderTreeDto> GetFolderTreeAsync(Guid projectId);
+    Task<HostMountListingDto?> ListHostMountLevelAsync(Guid projectId, string relativePath);
     Task<bool> MoveFolderAsync(Guid projectId, Guid folderId, Guid? newParentId);
     Task<ProjectFolderDto?> GetFolderAsync(Guid projectId, Guid folderId);
 

--- a/src/server/GuideAntsApi/Services/Components/NotebookFileChangeReporter.cs
+++ b/src/server/GuideAntsApi/Services/Components/NotebookFileChangeReporter.cs
@@ -13,8 +13,8 @@ namespace GuideAntsApi.Services.Components;
 public static class NotebookFileChangeReporter
 {
     /// <summary>
-    /// Scans the notebook working directory and returns CWD-relative paths for new and modified files.
-    /// Call this BEFORE database sync to surface change hints to the assistant.
+    /// Scans the notebook root (same rules as sync indexing) and returns CWD-relative paths for
+    /// new and modified files. Call this BEFORE database sync to surface change hints to the assistant.
     /// <para>
     /// This is a best-effort, metadata-only heuristic: modification is inferred from a difference in
     /// file size or last-write time, NOT from content hashing. It intentionally trades precision for
@@ -30,47 +30,31 @@ public static class NotebookFileChangeReporter
         InvocationContext context,
         ILogger? logger = null)
     {
-        var localNotebookPath = NotebookPathHelper.GetLocalWorkingDirectory(context, storageRoot);
-        if (!Directory.Exists(localNotebookPath))
+        using var scope = serviceProvider.CreateScope();
+        var resolver = scope.ServiceProvider.GetService<IStoragePathResolver>();
+        var notebookRoot = resolver != null
+            ? resolver.GetNotebookRootPath(context.ProjectId, context.NotebookId)
+            : Path.Combine(storageRoot, context.ProjectId.ToString(), "notebooks", context.NotebookId.ToString());
+
+        if (!Directory.Exists(notebookRoot))
             return (new List<string>(), new List<string>());
 
-        using var scope = serviceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
         var dbFiles = await dbContext.NotebookFiles
             .Where(f => f.NotebookId == context.NotebookId)
             .ToDictionaryAsync(f => f.RelativePath, f => new { f.FileSize, f.LastModifiedUtc });
 
-        var resourceFileNames = dbFiles.Keys
-            .Where(p => p.StartsWith("Resources/", StringComparison.OrdinalIgnoreCase) ||
-                        p.StartsWith("Resources\\", StringComparison.OrdinalIgnoreCase))
-            .Select(Path.GetFileName)
-            .Where(name => !string.IsNullOrWhiteSpace(name))
-            .Select(name => name!)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var localFiles = Directory.GetFiles(localNotebookPath, "*", SearchOption.AllDirectories)
-            .Where(f => !IsTempScriptFile(Path.GetFileName(f)))
-            .ToArray();
+        var syncableRelativePaths = NotebookSyncFileEnumerator.EnumerateSyncableRelativePaths(
+            notebookRoot,
+            fileNameFilter: f => !IsTempScriptFile(f) && !NotebookFileIndexingRules.IsTemporaryScriptFile(f));
 
         var newFiles = new List<string>();
         var modifiedFiles = new List<string>();
 
-        var resolver = scope.ServiceProvider.GetService<IStoragePathResolver>();
-        var notebookRoot = resolver != null
-            ? resolver.GetNotebookRootPath(context.ProjectId, context.NotebookId)
-            : Path.Combine(storageRoot, context.ProjectId.ToString(), "notebooks", context.NotebookId.ToString());
-
-        foreach (var localFile in localFiles)
+        foreach (var dbRelativePath in syncableRelativePaths)
         {
-            // Get path relative to notebook root (for DB comparison)
-            var dbRelativePath = Path.GetRelativePath(notebookRoot, localFile).Replace("\\", "/");
-
-            // Internal bootstrap links (Output/* -> ../Resources/*) should not be surfaced as user-created files.
-            if (ShouldIgnoreProjectedResourceSymlink(localFile, dbRelativePath, notebookRoot, resourceFileNames, logger))
-            {
-                continue;
-            }
+            var localFile = Path.Combine(notebookRoot, dbRelativePath.Replace('/', Path.DirectorySeparatorChar));
 
             long fileSize;
             DateTime lastModifiedUtc;
@@ -110,20 +94,26 @@ public static class NotebookFileChangeReporter
         }
 
         logger?.LogDebug(
-            "Notebook {NotebookId} change report: {NewCount} new, {ModifiedCount} modified (of {ScannedCount} files scanned)",
+            "Notebook {NotebookId} change report: {NewCount} new, {ModifiedCount} modified (of {ScannedCount} syncable paths)",
             context.NotebookId,
             newFiles.Count,
             modifiedFiles.Count,
-            localFiles.Length);
+            syncableRelativePaths.Count);
 
         return (newFiles, modifiedFiles);
     }
 
     /// <summary>
     /// Collects DB-relative paths from turn output for fast register.
+    /// Excludes tooling/artifact paths that sync will not index.
     /// </summary>
-    public static IReadOnlyList<string> GetDbRelativePaths(ChatRunOutput? output, bool isPublished, string? runId) =>
-        NotebookPathResolver.GetDbRelativePaths(output, isPublished, runId);
+    public static IReadOnlyList<string> GetDbRelativePaths(ChatRunOutput? output, bool isPublished, string? runId)
+    {
+        var paths = NotebookPathResolver.GetDbRelativePaths(output, isPublished, runId);
+        return paths
+            .Where(p => !NotebookArtifactPathExclusions.IsExcludedRelativePath(p))
+            .ToList();
+    }
 
     /// <summary>
     /// Converts a specific file's relative path to CWD-relative format.
@@ -167,12 +157,9 @@ public static class NotebookFileChangeReporter
             {
                 return normalized.Substring(outputPrefix.Length);
             }
-            // File is elsewhere - return as-is or with ../
-            if (normalized.Contains('/'))
-            {
-                return $"../{normalized}";
-            }
-            return normalized;
+
+            // Notebook-root or other non-Output paths are addressed from Output/ via ../
+            return $"../{normalized}";
         }
     }
 
@@ -200,7 +187,7 @@ public static class NotebookFileChangeReporter
             {
                 var prefix = fileName.Substring(0, underscoreIdx);
                 // Check if it's a GUID (with or without hyphens)
-                if (Guid.TryParse(prefix, out _) || 
+                if (Guid.TryParse(prefix, out _) ||
                     (prefix.Length == 32 && prefix.All(c => char.IsAsciiHexDigit(c))))
                 {
                     return true;
@@ -210,112 +197,4 @@ public static class NotebookFileChangeReporter
 
         return false;
     }
-
-    private static bool ShouldIgnoreProjectedResourceSymlink(
-        string localFile,
-        string dbRelativePath,
-        string notebookRoot,
-        HashSet<string> resourceFileNames,
-        ILogger? logger)
-    {
-        if (!dbRelativePath.StartsWith("Output/", StringComparison.OrdinalIgnoreCase) &&
-            !dbRelativePath.StartsWith("Output\\", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (!TryGetAttributes(localFile, out var attributes) || !attributes.HasFlag(FileAttributes.ReparsePoint))
-        {
-            return false;
-        }
-
-        if (ResolvesUnderResourcesRoot(localFile, notebookRoot))
-        {
-            logger?.LogDebug("Ignoring projected resource symlink in file change reporting: {Path}", dbRelativePath);
-            return true;
-        }
-
-        var fileName = Path.GetFileName(dbRelativePath);
-        if (!string.IsNullOrWhiteSpace(fileName) && resourceFileNames.Contains(fileName))
-        {
-            logger?.LogDebug("Ignoring Output reparse-point file with matching Resources filename: {Path}", dbRelativePath);
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool TryGetAttributes(string path, out FileAttributes attributes)
-    {
-        attributes = default;
-        try
-        {
-            attributes = File.GetAttributes(path);
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    private static bool ResolvesUnderResourcesRoot(string localFile, string notebookRoot)
-    {
-        var resourcesRoot = Path.GetFullPath(Path.Combine(notebookRoot, "Resources"));
-        var resolvedTarget = ResolveSymlinkTarget(localFile);
-        if (string.IsNullOrWhiteSpace(resolvedTarget))
-        {
-            return false;
-        }
-
-        return IsPathUnderRoot(resolvedTarget, resourcesRoot);
-    }
-
-    private static string? ResolveSymlinkTarget(string localFile)
-    {
-        try
-        {
-            var fileInfo = new FileInfo(localFile);
-            var linkTarget = fileInfo.LinkTarget;
-            if (!string.IsNullOrWhiteSpace(linkTarget))
-            {
-                var candidate = Path.IsPathRooted(linkTarget)
-                    ? linkTarget
-                    : Path.Combine(fileInfo.DirectoryName ?? Path.GetDirectoryName(localFile) ?? string.Empty, linkTarget);
-                return Path.GetFullPath(candidate);
-            }
-
-            var resolved = fileInfo.ResolveLinkTarget(returnFinalTarget: true);
-            if (resolved != null)
-            {
-                return Path.GetFullPath(resolved.FullName);
-            }
-        }
-        catch
-        {
-            // Best-effort resolution only.
-        }
-
-        return null;
-    }
-
-    private static bool IsPathUnderRoot(string candidatePath, string rootPath)
-    {
-        var rootFullPath = Path.GetFullPath(rootPath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var candidateFullPath = Path.GetFullPath(candidatePath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        if (candidateFullPath.Equals(rootFullPath, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        var rootWithSeparator = rootFullPath + Path.DirectorySeparatorChar;
-        var rootWithAltSeparator = rootFullPath + Path.AltDirectorySeparatorChar;
-        return candidateFullPath.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase) ||
-               candidateFullPath.StartsWith(rootWithAltSeparator, StringComparison.OrdinalIgnoreCase);
-    }
 }
-
-

--- a/src/server/GuideAntsApi/Services/Components/NotebookFileService.cs
+++ b/src/server/GuideAntsApi/Services/Components/NotebookFileService.cs
@@ -8,7 +8,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using System.Collections.Concurrent;
 using GuideAntsApi.Services.Components.Sync;
 
 namespace GuideAntsApi.Services.Components;
@@ -18,9 +17,7 @@ public class NotebookFileService : INotebookFileService
     private const int DefaultLinkedMountTreeMaxFiles = 5000;
     private const int DefaultLinkedMountTreeMaxDepth = 3;
     private const int DefaultLinkedMountTreeScanBudgetMs = 2500;
-    private const int DefaultLinkedMountTreeCacheSeconds = 15;
-
-    private static readonly ConcurrentDictionary<string, LinkedMountCacheEntry> LinkedMountTreeCache = new(StringComparer.Ordinal);
+    private const int DefaultLinkedMountTreeCacheSeconds = 120;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly string _storagePath;
@@ -65,7 +62,7 @@ public class NotebookFileService : INotebookFileService
             configuration["FileStorage:LinkedMountTreeCacheSeconds"],
             DefaultLinkedMountTreeCacheSeconds,
             min: 1,
-            max: 300));
+            max: 3600));
     }
 
     // Backward-compatible overload used by tests.
@@ -143,7 +140,7 @@ using var scope2 = CreateDbScope();
             .Select(f => new NotebookFileDto(f.Id, Path.GetFileName(f.RelativePath), f.RelativePath, f.FileSize, f.LastModifiedUtc, f.FileHash, f.OriginContentFileVersionId, false, false))
             .ToList();
 
-        var linkedFileDtos = await BuildLinkedMountFileDtosAsync(context, notebookId);
+        var (linkedFileDtos, linkedDirectories) = await BuildLinkedMountOverlayAsync(context, notebookId);
         if (linkedFileDtos.Count > 0)
         {
             var existingPaths = new HashSet<string>(
@@ -159,19 +156,121 @@ using var scope2 = CreateDbScope();
             }
         }
         
-        return BuildNotebookFolderTree(fileDtos);
+        return BuildNotebookFolderTree(fileDtos, linkedDirectories);
     }
 
-    private static NotebookFolderTreeDto BuildNotebookFolderTree(List<NotebookFileDto> files)
+    public async Task<HostMountListingDto?> ListHostMountLevelAsync(
+        Guid projectId,
+        Guid notebookId,
+        string relativePath)
     {
-        // Build folder tree from database file paths only - no filesystem scanning.
-        // This is much faster than scanning the filesystem, especially for large trees.
-        // Empty folders are managed client-side until they contain files.
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativePath);
+
+        using var scope = CreateDbScope();
+        var context = GetDbContext(scope);
+        var linkedMountRoots = await GetLinkedMountRootsAsync(context, notebookId);
+        if (linkedMountRoots.Count == 0)
+        {
+            return null;
+        }
+
+        var normalizedPath = NormalizeRelativePath(relativePath);
+        var mount = linkedMountRoots.FirstOrDefault(root =>
+            normalizedPath.Equals(root.LinkRelativePath, StringComparison.OrdinalIgnoreCase)
+            || normalizedPath.StartsWith(root.LinkRelativePath + "/", StringComparison.OrdinalIgnoreCase));
+        if (mount == null)
+        {
+            return null;
+        }
+
+        var withinMount = normalizedPath.Equals(mount.LinkRelativePath, StringComparison.OrdinalIgnoreCase)
+            ? string.Empty
+            : normalizedPath[(mount.LinkRelativePath.Length + 1)..];
+
+        var mountKey = mount.MountId.ToString("N");
+        var cacheKey = HostMountListingCache.LevelKey(mountKey, normalizedPath);
+        HostMountDirectoryScanner.ScanResult scanResult;
+        if (HostMountListingCache.TryGet(cacheKey, out var cached))
+        {
+            _logger.LogDebug(
+                "Host mount listing cache_hit for notebook {NotebookId} path {Path}",
+                notebookId,
+                normalizedPath);
+            scanResult = cached;
+        }
+        else
+        {
+            scanResult = HostMountDirectoryScanner.ListLevel(
+                mount.LinkPhysicalPath,
+                mount.LinkRelativePath,
+                withinMount,
+                _linkedMountTreeMaxFiles,
+                _linkedMountTreeScanBudget,
+                _logger);
+            HostMountListingCache.Set(cacheKey, scanResult, _linkedMountTreeCacheTtl);
+            _logger.LogInformation(
+                "Host mount lazy_list for notebook {NotebookId} path {Path} (files={FileCount}, dirs={DirCount}, truncated={Truncated})",
+                notebookId,
+                normalizedPath,
+                scanResult.Files.Count,
+                scanResult.Directories.Count,
+                scanResult.WasTruncated);
+        }
+
+        var folders = scanResult.Directories
+            .Where(d => !IsInResourcesFolder(d.RelativePath) && !IsInGuideantsFolder(d.RelativePath))
+            .Select(d => new HostMountListingFolderDto(d.Name, d.RelativePath))
+            .ToList();
+
+        var listingFiles = scanResult.Files
+            .Where(f => !IsInResourcesFolder(f.RelativePath) && !IsInGuideantsFolder(f.RelativePath))
+            .Select(f => new HostMountListingFileDto(
+                Id: CreateLinkedVirtualFileId(f.RelativePath),
+                FileName: f.FileName,
+                RelativePath: f.RelativePath,
+                FileSize: f.FileSize,
+                LastModifiedUtc: f.LastModifiedUtc,
+                FileHash: $"{f.FileSize:x}-{f.LastModifiedUtc.Ticks:x}",
+                IsLinked: true))
+            .ToList();
+
+        return new HostMountListingDto(normalizedPath, folders, listingFiles, scanResult.WasTruncated);
+    }
+
+    private static NotebookFolderTreeDto BuildNotebookFolderTree(
+        List<NotebookFileDto> files,
+        IReadOnlyCollection<string>? linkedDirectories = null)
+    {
+        // Build folder tree from file paths plus explicit directory stubs (host mounts).
+        // Empty non-mount folders are still managed client-side until they contain files.
         
-        var folderStructure = new Dictionary<string, NotebookFolderTreeDto>();
+        var folderStructure = new Dictionary<string, NotebookFolderTreeDto>(StringComparer.OrdinalIgnoreCase);
         var rootFiles = new List<NotebookFileDto>();
 
-        // Collect all files that are in the root (no directory separators)
+        void EnsureFolderPath(string folderPath)
+        {
+            if (string.IsNullOrWhiteSpace(folderPath))
+            {
+                return;
+            }
+
+            var pathParts = folderPath.Replace('\\', '/').Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+            var currentPath = "";
+            foreach (var folderName in pathParts)
+            {
+                currentPath = string.IsNullOrEmpty(currentPath) ? folderName : $"{currentPath}/{folderName}";
+                if (!folderStructure.ContainsKey(currentPath))
+                {
+                    folderStructure[currentPath] = new NotebookFolderTreeDto(
+                        folderName,
+                        currentPath,
+                        new List<NotebookFolderTreeDto>(),
+                        new List<NotebookFileDto>()
+                    );
+                }
+            }
+        }
+
         foreach (var file in files)
         {
             if (!file.RelativePath.Contains('/'))
@@ -180,13 +279,12 @@ using var scope2 = CreateDbScope();
             }
         }
 
-        // Build folder structure from files - this extracts the folder hierarchy from file paths
         foreach (var file in files.Where(f => f.RelativePath.Contains('/')))
         {
             var pathParts = file.RelativePath.Split('/');
             var currentPath = "";
 
-            for (int i = 0; i < pathParts.Length - 1; i++) // Exclude the filename
+            for (int i = 0; i < pathParts.Length - 1; i++)
             {
                 var folderName = pathParts[i];
                 currentPath = string.IsNullOrEmpty(currentPath) ? folderName : $"{currentPath}/{folderName}";
@@ -201,7 +299,6 @@ using var scope2 = CreateDbScope();
                     );
                 }
 
-                // Add the file to its parent folder if this is the last folder in the path
                 if (i == pathParts.Length - 2)
                 {
                     folderStructure[currentPath].Files.Add(file);
@@ -209,9 +306,16 @@ using var scope2 = CreateDbScope();
             }
         }
 
-        // Build the hierarchy by organizing folders into their parents
+        if (linkedDirectories != null)
+        {
+            foreach (var directory in linkedDirectories)
+            {
+                EnsureFolderPath(directory);
+            }
+        }
+
         var rootFolders = new List<NotebookFolderTreeDto>();
-        var processedFolders = new HashSet<string>();
+        var processedFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var kvp in folderStructure.OrderBy(f => f.Key))
         {
@@ -223,13 +327,11 @@ using var scope2 = CreateDbScope();
             var pathParts = folderPath.Split('/');
             if (pathParts.Length == 1)
             {
-                // This is a root folder
                 AttachSubFolders(folder, folderStructure, processedFolders);
                 rootFolders.Add(folder);
             }
         }
 
-        // Create the root tree node
         return new NotebookFolderTreeDto(
             "Root",
             "",
@@ -426,6 +528,7 @@ using var scope = CreateDbScope();
                 (link, mount) => new { Link = link, Mount = mount })
             .Where(row => row.Mount.Status != HostFolderMountStatus.Removed)
             .Select(row => new LinkedMountRoot(
+                row.Mount.Id,
                 row.Link.LinkRelativePath.Replace("\\", "/").Trim('/'),
                 row.Link.LinkPhysicalPath))
             .ToListAsync(cancellationToken);
@@ -447,7 +550,9 @@ using var scope = CreateDbScope();
         return deduped.Values.ToList();
     }
 
-    private async Task<List<NotebookFileDto>> BuildLinkedMountFileDtosAsync(
+    private sealed record LinkedMountRoot(Guid MountId, string LinkRelativePath, string LinkPhysicalPath);
+
+    private async Task<(List<NotebookFileDto> Files, List<string> Directories)> BuildLinkedMountOverlayAsync(
         ApplicationDbContext context,
         Guid notebookId,
         CancellationToken cancellationToken = default)
@@ -455,60 +560,101 @@ using var scope = CreateDbScope();
         var linkedMountRoots = await GetLinkedMountRootsAsync(context, notebookId, cancellationToken);
         if (linkedMountRoots.Count == 0)
         {
-            return [];
+            return ([], []);
         }
 
-        var now = DateTimeOffset.UtcNow;
-        PruneExpiredLinkedMountCache(now);
-        var cacheKey = BuildLinkedMountCacheKey(notebookId, linkedMountRoots);
-        if (LinkedMountTreeCache.TryGetValue(cacheKey, out var cached)
-            && cached.ExpiresUtc > now)
+        var allFiles = new List<NotebookFileDto>();
+        var allDirectories = new List<string>();
+        var seenFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var root in linkedMountRoots)
         {
-            return [.. cached.Files];
+            var mountKey = root.MountId.ToString("N");
+            var cacheKey = HostMountListingCache.ShallowKey(mountKey);
+            HostMountDirectoryScanner.ScanResult scanResult;
+            if (HostMountListingCache.TryGet(cacheKey, out var cached))
+            {
+                _logger.LogDebug(
+                    "Host mount shallow cache_hit for notebook {NotebookId} mount {MountId}",
+                    notebookId,
+                    root.MountId);
+                scanResult = cached;
+            }
+            else
+            {
+                scanResult = HostMountDirectoryScanner.Scan(
+                    [new HostMountDirectoryScanner.MountRoot(root.LinkRelativePath, root.LinkPhysicalPath)],
+                    _linkedMountTreeMaxFiles,
+                    _linkedMountTreeMaxDepth,
+                    _linkedMountTreeScanBudget,
+                    _logger);
+                HostMountListingCache.Set(cacheKey, scanResult, _linkedMountTreeCacheTtl);
+                _logger.LogInformation(
+                    "Host mount shallow_scan for notebook {NotebookId} mount {MountId} (files={FileCount}, dirs={DirCount}, truncated={Truncated})",
+                    notebookId,
+                    root.MountId,
+                    scanResult.Files.Count,
+                    scanResult.Directories.Count,
+                    scanResult.WasTruncated);
+
+                if (scanResult.WasTruncated)
+                {
+                    _logger.LogWarning(
+                        "Linked mount tree enumeration was truncated for notebook {NotebookId} mount {MountId} (maxFiles={MaxFiles}, maxDepth={MaxDepth}, scanBudgetMs={ScanBudgetMs}).",
+                        notebookId,
+                        root.MountId,
+                        _linkedMountTreeMaxFiles,
+                        _linkedMountTreeMaxDepth,
+                        (int)_linkedMountTreeScanBudget.TotalMilliseconds);
+                }
+            }
+
+            if (seenDirs.Add(root.LinkRelativePath))
+            {
+                allDirectories.Add(root.LinkRelativePath);
+            }
+
+            foreach (var directory in scanResult.Directories)
+            {
+                if (IsInResourcesFolder(directory.RelativePath) || IsInGuideantsFolder(directory.RelativePath))
+                {
+                    continue;
+                }
+
+                if (seenDirs.Add(directory.RelativePath))
+                {
+                    allDirectories.Add(directory.RelativePath);
+                }
+            }
+
+            foreach (var file in scanResult.Files)
+            {
+                if (IsInResourcesFolder(file.RelativePath) || IsInGuideantsFolder(file.RelativePath))
+                {
+                    continue;
+                }
+
+                if (!seenFiles.Add(file.RelativePath))
+                {
+                    continue;
+                }
+
+                allFiles.Add(new NotebookFileDto(
+                    Id: CreateLinkedVirtualFileId(file.RelativePath),
+                    FileName: file.FileName,
+                    RelativePath: file.RelativePath,
+                    FileSize: file.FileSize,
+                    LastModifiedUtc: file.LastModifiedUtc,
+                    FileHash: $"{file.FileSize:x}-{file.LastModifiedUtc.Ticks:x}",
+                    OriginContentFileVersionId: null,
+                    Index: false,
+                    IsIndexed: false,
+                    IsLinked: true));
+            }
         }
 
-        var scanRoots = linkedMountRoots
-            .Select(r => new HostMountDirectoryScanner.MountRoot(r.LinkRelativePath, r.LinkPhysicalPath))
-            .ToList();
-
-        var scanResult = HostMountDirectoryScanner.Scan(
-            scanRoots,
-            _linkedMountTreeMaxFiles,
-            _linkedMountTreeMaxDepth,
-            _linkedMountTreeScanBudget,
-            _logger);
-
-        var results = scanResult.Files
-            .Where(f => !IsInResourcesFolder(f.RelativePath) && !IsInGuideantsFolder(f.RelativePath))
-            .Select(f => new NotebookFileDto(
-                Id: CreateLinkedVirtualFileId(f.RelativePath),
-                FileName: f.FileName,
-                RelativePath: f.RelativePath,
-                FileSize: f.FileSize,
-                LastModifiedUtc: f.LastModifiedUtc,
-                FileHash: $"{f.FileSize:x}-{f.LastModifiedUtc.Ticks:x}",
-                OriginContentFileVersionId: null,
-                Index: false,
-                IsIndexed: false,
-                IsLinked: true))
-            .ToList();
-
-        if (scanResult.WasTruncated)
-        {
-            _logger.LogWarning(
-                "Linked mount tree enumeration was truncated for notebook {NotebookId} (roots={RootCount}, maxFiles={MaxFiles}, maxDepth={MaxDepth}, scanBudgetMs={ScanBudgetMs}).",
-                notebookId,
-                linkedMountRoots.Count,
-                _linkedMountTreeMaxFiles,
-                _linkedMountTreeMaxDepth,
-                (int)_linkedMountTreeScanBudget.TotalMilliseconds);
-        }
-
-        LinkedMountTreeCache[cacheKey] = new LinkedMountCacheEntry(
-            ExpiresUtc: DateTimeOffset.UtcNow + _linkedMountTreeCacheTtl,
-            Files: [.. results]);
-
-        return results;
+        return (allFiles, allDirectories);
     }
 
     private static Guid CreateLinkedVirtualFileId(string relativePath)
@@ -539,29 +685,34 @@ using var scope = CreateDbScope();
         return parsed;
     }
 
-    private static string BuildLinkedMountCacheKey(Guid notebookId, IReadOnlyCollection<LinkedMountRoot> linkedMountRoots)
+    private async Task InvalidateMountCachesForNotebookPathAsync(Guid notebookId, string relativePath)
     {
-        var parts = linkedMountRoots
-            .OrderBy(r => r.LinkRelativePath, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(r => r.LinkPhysicalPath, StringComparer.OrdinalIgnoreCase)
-            .Select(r => $"{r.LinkRelativePath}|{r.LinkPhysicalPath}");
-        return $"{notebookId:N}:{string.Join(";", parts)}";
-    }
-
-    private static void PruneExpiredLinkedMountCache(DateTimeOffset now)
-    {
-        foreach (var kvp in LinkedMountTreeCache)
+        try
         {
-            if (kvp.Value.ExpiresUtc <= now)
+            using var scope = CreateDbScope();
+            var context = GetDbContext(scope);
+            var roots = await GetLinkedMountRootsAsync(context, notebookId);
+            var normalized = NormalizeRelativePath(relativePath);
+            foreach (var root in roots)
             {
-                LinkedMountTreeCache.TryRemove(kvp.Key, out _);
+                if (normalized.Equals(root.LinkRelativePath, StringComparison.OrdinalIgnoreCase)
+                    || normalized.StartsWith(root.LinkRelativePath + "/", StringComparison.OrdinalIgnoreCase)
+                    || root.LinkRelativePath.StartsWith(normalized + "/", StringComparison.OrdinalIgnoreCase)
+                    || normalized.Length == 0)
+                {
+                    HostMountListingCache.InvalidateMount(root.MountId.ToString("N"));
+                    _logger.LogInformation(
+                        "Host mount cache_invalidated for mount {MountId} due to path {Path}",
+                        root.MountId,
+                        normalized);
+                }
             }
         }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to invalidate host mount listing cache for notebook {NotebookId}", notebookId);
+        }
     }
-
-    private sealed record LinkedMountCacheEntry(DateTimeOffset ExpiresUtc, IReadOnlyList<NotebookFileDto> Files);
-
-    private sealed record LinkedMountRoot(string LinkRelativePath, string LinkPhysicalPath);
 
     private async Task<(NotebookFile? file, string normalizedPath)> FindNotebookFileByRelativePathAsync(
         ApplicationDbContext context,
@@ -1880,6 +2031,7 @@ using var scope = CreateDbScope();
         await context.SaveChangesAsync();
         
         await QueueNotebookSyncBestEffortAsync(notebookId);
+        await InvalidateMountCachesForNotebookPathAsync(notebookId, relativePath);
         
         return true;
     }
@@ -1962,6 +2114,7 @@ using var scope = CreateDbScope();
         await context.SaveChangesAsync();
         
         await QueueNotebookSyncBestEffortAsync(notebookId);
+        await InvalidateMountCachesForNotebookPathAsync(notebookId, sourceRelativePath);
         
         return true;
     }
@@ -2038,6 +2191,8 @@ using var scope = CreateDbScope();
         await context.SaveChangesAsync();
         
         await QueueNotebookSyncBestEffortAsync(notebookId);
+        await InvalidateMountCachesForNotebookPathAsync(notebookId, sourceRelativePath);
+        await InvalidateMountCachesForNotebookPathAsync(notebookId, destinationRelativePath);
         
         return true;
     }

--- a/src/server/GuideAntsApi/Services/Components/ProjectFolderService.cs
+++ b/src/server/GuideAntsApi/Services/Components/ProjectFolderService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNetCore.StaticFiles;
@@ -24,11 +23,6 @@ public class ProjectFolderService : IProjectFolderService
     // aggressively to discover out-of-band changes; a couple of minutes bounds staleness
     // for the read-only host-mount overlay while cutting the scan rate dramatically.
     private const int DefaultProjectMountTreeCacheSeconds = 120;
-
-    // Shared across all instances/requests so concurrent folder-tree polls for the same
-    // mount reuse a single filesystem scan instead of re-walking the host directory
-    // (which can hit the maxFiles/maxDepth/scanBudget limits) on every poll.
-    private static readonly ConcurrentDictionary<string, MountScanCacheEntry> MountScanCache = new(StringComparer.Ordinal);
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IConfiguration _configuration;
@@ -687,11 +681,85 @@ using var scope = CreateDbScope();
         foreach (var mount in mounts)
         {
             var scanResult = GetOrScanMount(mount);
-            var mountRootNode = BuildMountFolderTree(mount, scanResult.Files);
+            var mountRootNode = BuildMountFolderTree(mount, scanResult.Files, scanResult.Directories);
             mountNodes.Add(mountRootNode);
         }
 
         return mountNodes;
+    }
+
+    public async Task<HostMountListingDto?> ListHostMountLevelAsync(Guid projectId, string relativePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativePath);
+
+        using var scope = CreateDbScope();
+        var context = GetDbContext(scope);
+        var mounts = await context.HostFolderMounts
+            .AsNoTracking()
+            .Where(m => m.ProjectId == projectId
+                && m.Scope == HostFolderMountScope.Project
+                && m.Status != HostFolderMountStatus.Removed
+                && m.Status != HostFolderMountStatus.PendingRemoval)
+            .ToListAsync();
+
+        var normalizedPath = relativePath.Replace('\\', '/').Trim('/');
+        var mount = mounts.FirstOrDefault(m =>
+            normalizedPath.Equals(m.LeafName, StringComparison.OrdinalIgnoreCase)
+            || normalizedPath.StartsWith(m.LeafName + "/", StringComparison.OrdinalIgnoreCase));
+        if (mount == null)
+        {
+            return null;
+        }
+
+        var withinMount = normalizedPath.Equals(mount.LeafName, StringComparison.OrdinalIgnoreCase)
+            ? string.Empty
+            : normalizedPath[(mount.LeafName.Length + 1)..];
+
+        var mountKey = mount.Id.ToString("N");
+        var cacheKey = HostMountListingCache.LevelKey(mountKey, normalizedPath);
+        HostMountDirectoryScanner.ScanResult scanResult;
+        if (HostMountListingCache.TryGet(cacheKey, out var cached))
+        {
+            _logger.LogDebug(
+                "Project host mount listing cache_hit for mount {MountId} path {Path}",
+                mount.Id,
+                normalizedPath);
+            scanResult = cached;
+        }
+        else
+        {
+            scanResult = HostMountDirectoryScanner.ListLevel(
+                mount.ContainerSourcePath,
+                mount.LeafName,
+                withinMount,
+                _linkedMountTreeMaxFiles,
+                _linkedMountTreeScanBudget,
+                _logger);
+            HostMountListingCache.Set(cacheKey, scanResult, _projectMountTreeCacheTtl);
+            _logger.LogInformation(
+                "Project host mount lazy_list for mount {MountId} path {Path} (files={FileCount}, dirs={DirCount}, truncated={Truncated})",
+                mount.Id,
+                normalizedPath,
+                scanResult.Files.Count,
+                scanResult.Directories.Count,
+                scanResult.WasTruncated);
+        }
+
+        var folders = scanResult.Directories
+            .Select(d => new HostMountListingFolderDto(d.Name, d.RelativePath))
+            .ToList();
+        var files = scanResult.Files
+            .Select(f => new HostMountListingFileDto(
+                Id: CreateMountVirtualFileId(mount.Id, f.RelativePath),
+                FileName: f.FileName,
+                RelativePath: f.RelativePath,
+                FileSize: f.FileSize,
+                LastModifiedUtc: f.LastModifiedUtc,
+                FileHash: $"{f.FileSize:x}-{f.LastModifiedUtc.Ticks:x}",
+                IsLinked: true))
+            .ToList();
+
+        return new HostMountListingDto(normalizedPath, folders, files, scanResult.WasTruncated);
     }
 
     /// <summary>
@@ -701,13 +769,12 @@ using var scope = CreateDbScope();
     /// </summary>
     private HostMountDirectoryScanner.ScanResult GetOrScanMount(HostFolderMount mount)
     {
-        var now = DateTimeOffset.UtcNow;
-        PruneExpiredMountScanCache(now);
-
-        var cacheKey = BuildMountScanCacheKey(mount);
-        if (MountScanCache.TryGetValue(cacheKey, out var cached) && cached.ExpiresUtc > now)
+        var mountKey = mount.Id.ToString("N");
+        var cacheKey = HostMountListingCache.ShallowKey(mountKey);
+        if (HostMountListingCache.TryGet(cacheKey, out var cached))
         {
-            return cached.Result;
+            _logger.LogDebug("Project host mount shallow cache_hit for mount {MountId}", mount.Id);
+            return cached;
         }
 
         var scanRoots = new List<HostMountDirectoryScanner.MountRoot>
@@ -722,6 +789,14 @@ using var scope = CreateDbScope();
             _linkedMountTreeScanBudget,
             _logger);
 
+        HostMountListingCache.Set(cacheKey, scanResult, _projectMountTreeCacheTtl);
+        _logger.LogInformation(
+            "Project host mount shallow_scan for mount {MountId} (files={FileCount}, dirs={DirCount}, truncated={Truncated})",
+            mount.Id,
+            scanResult.Files.Count,
+            scanResult.Directories.Count,
+            scanResult.WasTruncated);
+
         if (scanResult.WasTruncated)
         {
             _logger.LogWarning(
@@ -732,38 +807,24 @@ using var scope = CreateDbScope();
                 (int)_linkedMountTreeScanBudget.TotalMilliseconds);
         }
 
-        MountScanCache[cacheKey] = new MountScanCacheEntry(
-            ExpiresUtc: DateTimeOffset.UtcNow + _projectMountTreeCacheTtl,
-            Result: scanResult);
-
         return scanResult;
     }
 
-    private static string BuildMountScanCacheKey(HostFolderMount mount) =>
-        $"{mount.Id:N}|{mount.LeafName}|{mount.ContainerSourcePath}";
-
-    private static void PruneExpiredMountScanCache(DateTimeOffset now)
-    {
-        foreach (var kvp in MountScanCache)
-        {
-            if (kvp.Value.ExpiresUtc <= now)
-            {
-                MountScanCache.TryRemove(kvp.Key, out _);
-            }
-        }
-    }
-
-    private sealed record MountScanCacheEntry(DateTimeOffset ExpiresUtc, HostMountDirectoryScanner.ScanResult Result);
-
     private FolderTreeDto BuildMountFolderTree(
         HostFolderMount mount,
-        IReadOnlyList<HostMountDirectoryScanner.ScannedFile> files)
+        IReadOnlyList<HostMountDirectoryScanner.ScannedFile> files,
+        IReadOnlyList<HostMountDirectoryScanner.ScannedDirectory> directories)
     {
         var folderChildren = new Dictionary<string, List<FolderTreeDto>>(StringComparer.OrdinalIgnoreCase);
         var fileChildren = new Dictionary<string, List<ContentFileDetailsDto>>(StringComparer.OrdinalIgnoreCase);
 
         folderChildren[mount.LeafName] = [];
         fileChildren[mount.LeafName] = [];
+
+        foreach (var directory in directories)
+        {
+            EnsureFolderPath(directory.RelativePath, mount.LeafName, folderChildren, fileChildren);
+        }
 
         foreach (var file in files)
         {

--- a/src/server/GuideAntsApi/Services/Components/Sync/NotebookArtifactPathExclusions.cs
+++ b/src/server/GuideAntsApi/Services/Components/Sync/NotebookArtifactPathExclusions.cs
@@ -20,6 +20,9 @@ public static class NotebookArtifactPathExclusions
         ".tox",
         ".mypy_cache",
         ".ruff_cache",
+        // Skill/runtime working state under the notebook CWD (not user content).
+        ".audiocpp-extended",
+        ".wire-attachments",
     };
 
     public static bool IsExcludedDirectorySegment(string directoryName) =>

--- a/src/server/GuideAntsApi/Services/Components/Sync/NotebookFileReconciler.cs
+++ b/src/server/GuideAntsApi/Services/Components/Sync/NotebookFileReconciler.cs
@@ -71,6 +71,15 @@ public sealed class NotebookFileReconciler : INotebookFileReconciler
                 continue;
             }
 
+            if (NotebookArtifactPathExclusions.IsExcludedRelativePath(relativePath))
+            {
+                _logger.LogDebug(
+                    "Skipping register for excluded artifact path {RelativePath} in notebook {NotebookId}",
+                    relativePath,
+                    notebookId);
+                continue;
+            }
+
             var fullPath = Path.Combine(rootPath, relativePath.Replace("/", Path.DirectorySeparatorChar.ToString()));
             if (!File.Exists(fullPath))
             {

--- a/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LifecycleImmutableInputs.cs
+++ b/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LifecycleImmutableInputs.cs
@@ -29,7 +29,6 @@ public sealed record ChangeQuantImmutableInput(
     string RouterModelId,
     string TargetDirectory,
     IReadOnlyDictionary<string, string> RouterPreset,
-    IReadOnlyList<string> ObsoleteRepositoryPaths,
     IReadOnlyList<CuratedArtifactMetadataInput>? ArtifactMetadata = null)
 {
     private static readonly JsonSerializerOptions CanonicalJsonOptions = new()

--- a/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelLifecycleOperationService.cs
+++ b/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelLifecycleOperationService.cs
@@ -212,6 +212,18 @@ public sealed class LocalModelLifecycleOperationService : ILocalModelLifecycleOp
         {
             if (sideEffects.DownloadStarted)
             {
+                // Journal can disappear after a successful download. Verify the router
+                // already holds the expected artifacts before failing the operation —
+                // otherwise a completed change-quant bricks the alias forever.
+                if (await TryAdvanceCompletedDownloadWithoutJournalAsync(
+                        operation,
+                        sideEffects,
+                        cancellationToken)
+                    .ConfigureAwait(false))
+                {
+                    return null;
+                }
+
                 await MarkFailedAsync(
                     operation,
                     "INSTALL_STEP_FAILED",
@@ -245,14 +257,107 @@ public sealed class LocalModelLifecycleOperationService : ILocalModelLifecycleOp
             return journalSnapshot;
         }
 
+        await AdvanceToProvenanceFinalizationAsync(operation, sideEffects, cancellationToken)
+            .ConfigureAwait(false);
+        return journalSnapshot;
+    }
+
+    /// <summary>
+    /// When llama-admin no longer has the download journal, treat the download as
+    /// complete only if the router alias already points at the expected model files.
+    /// </summary>
+    private async Task<bool> TryAdvanceCompletedDownloadWithoutJournalAsync(
+        LocalModelOperation operation,
+        LifecycleSideEffects sideEffects,
+        CancellationToken cancellationToken)
+    {
+        bool verified;
+        try
+        {
+            verified = await IsDownloadOutcomePresentOnRouterAsync(operation, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not verify router outcome for lifecycle operation {OperationId} after journal loss.",
+                operation.OperationId);
+            return false;
+        }
+
+        if (!verified)
+        {
+            return false;
+        }
+
+        _logger.LogInformation(
+            "Lifecycle operation {OperationId} journal is gone but router already has expected artifacts; finalizing.",
+            operation.OperationId);
+
+        await AdvanceToProvenanceFinalizationAsync(operation, sideEffects, cancellationToken)
+            .ConfigureAwait(false);
+        return true;
+    }
+
+    private async Task AdvanceToProvenanceFinalizationAsync(
+        LocalModelOperation operation,
+        LifecycleSideEffects sideEffects,
+        CancellationToken cancellationToken)
+    {
         sideEffects.ArtifactsActivated = true;
         sideEffects.AliasRegistered = true;
         operation.CompletedSideEffectsJson = SerializeSideEffects(sideEffects);
         operation.Status = "provenanceFinalization";
         operation.CurrentStep = "provenanceFinalization";
+        operation.UpdatedUtc = DateTime.UtcNow;
         await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         await TryProvenanceFinalizationAsync(operation, sideEffects, cancellationToken).ConfigureAwait(false);
-        return journalSnapshot;
+    }
+
+    private async Task<bool> IsDownloadOutcomePresentOnRouterAsync(
+        LocalModelOperation operation,
+        CancellationToken cancellationToken)
+    {
+        var request = BuildExactDownloadRequest(operation);
+        if (request.ModelFiles.Count == 0 || string.IsNullOrWhiteSpace(request.Alias))
+        {
+            return false;
+        }
+
+        var entries = await _adminClient.GetRouterEntriesAsync(cancellationToken).ConfigureAwait(false);
+        var entry = entries.Entries.FirstOrDefault(
+            e => string.Equals(e.Alias, request.Alias, StringComparison.Ordinal));
+        if (entry is null || !entry.HasModelFile || string.IsNullOrWhiteSpace(entry.ModelPath))
+        {
+            return false;
+        }
+
+        foreach (var modelFile in request.ModelFiles)
+        {
+            if (entry.ModelPath.IndexOf(modelFile, StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return false;
+            }
+        }
+
+        if (request.MmprojFiles.Count > 0)
+        {
+            if (!entry.HasMmprojFile || string.IsNullOrWhiteSpace(entry.MmprojPath))
+            {
+                return false;
+            }
+
+            foreach (var mmprojFile in request.MmprojFiles)
+            {
+                if (entry.MmprojPath.IndexOf(mmprojFile, StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     private async Task BeginQueuedOperationAsync(
@@ -354,7 +459,24 @@ public sealed class LocalModelLifecycleOperationService : ILocalModelLifecycleOp
 
             sideEffects.ProvenanceCommitted = true;
             operation.CompletedSideEffectsJson = SerializeSideEffects(sideEffects);
-            operation.Status = sideEffects.ObsoletePaths.Count > 0 ? "obsoleteCleanup" : "loadRestore";
+
+            if (string.Equals(operation.OperationKind, LocalModelOperationKinds.ChangeQuant, StringComparison.OrdinalIgnoreCase))
+            {
+                // GuideAntsApi installation provenance is the sole selection authority.
+                // Apply that selection to the router before any load-restore — do not trust
+                // download-side alias registration or leftover executor state.
+                await ApplyRouterSelectionFromChangeQuantAsync(operation, cancellationToken)
+                    .ConfigureAwait(false);
+                sideEffects.AliasRegistered = true;
+                operation.CompletedSideEffectsJson = SerializeSideEffects(sideEffects);
+                operation.Status = "loadRestore";
+            }
+            else
+            {
+                operation.Status =
+                    sideEffects.ObsoletePaths.Count > 0 ? "obsoleteCleanup" : "loadRestore";
+            }
+
             operation.CurrentStep = operation.Status;
             operation.UpdatedUtc = DateTime.UtcNow;
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -402,11 +524,43 @@ public sealed class LocalModelLifecycleOperationService : ILocalModelLifecycleOp
         installation.RouterPresetSnapshotJson = JsonSerializer.Serialize(input.RouterPreset);
         installation.UpdatedUtc = DateTime.UtcNow;
 
-        var sideEffects = ParseSideEffects(operation.CompletedSideEffectsJson);
-        sideEffects.ObsoletePaths = input.ObsoleteRepositoryPaths.ToList();
-        operation.CompletedSideEffectsJson = SerializeSideEffects(sideEffects);
-
         await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Writes the router alias model/mmproj paths from API-owned change-quant input.
+    /// Executor inventory and prior loads are not authoritative for which quant is active.
+    /// </summary>
+    private async Task ApplyRouterSelectionFromChangeQuantAsync(
+        LocalModelOperation operation,
+        CancellationToken cancellationToken)
+    {
+        var input = ChangeQuantImmutableInput.Deserialize(operation.ImmutableInputJson);
+        if (input.ModelFiles.Count == 0 || string.IsNullOrWhiteSpace(input.RouterModelId))
+        {
+            throw new InvalidOperationException(
+                "Change-quant provenance is missing model files or router alias.");
+        }
+
+        var target = input.TargetDirectory.Trim().Trim('/');
+        var modelFile = Path.GetFileName(input.ModelFiles[0].Replace('\\', '/'));
+        var modelPath = $"/models-local/llama/{target}/{modelFile}";
+        var mmprojPath = string.Empty;
+        if (input.MmprojFiles.Count > 0)
+        {
+            var mmprojFile = Path.GetFileName(input.MmprojFiles[0].Replace('\\', '/'));
+            mmprojPath = $"/models-local/llama/{target}/{mmprojFile}";
+        }
+
+        await _adminClient
+            .AddOrUpdateRouterEntryAsync(input.RouterModelId, modelPath, mmprojPath, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!await IsDownloadOutcomePresentOnRouterAsync(operation, cancellationToken).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException(
+                $"Router alias '{input.RouterModelId}' does not point at the API-selected quant file '{modelFile}'.");
+        }
     }
 
     private async Task CommitRepairProvenanceAsync(LocalModelOperation operation, CancellationToken cancellationToken)
@@ -477,6 +631,21 @@ public sealed class LocalModelLifecycleOperationService : ILocalModelLifecycleOp
         LifecycleSideEffects sideEffects,
         CancellationToken cancellationToken)
     {
+        // Change-quant must never delete sibling quants that are simply not active.
+        // Legacy rows may still carry status obsoleteCleanup or listed paths.
+        if (string.Equals(operation.OperationKind, LocalModelOperationKinds.ChangeQuant, StringComparison.OrdinalIgnoreCase))
+        {
+            sideEffects.ObsoletePaths = [];
+            sideEffects.ObsoleteCleanupCompleted = true;
+            operation.CompletedSideEffectsJson = SerializeSideEffects(sideEffects);
+            operation.Status = "loadRestore";
+            operation.CurrentStep = "loadRestore";
+            operation.UpdatedUtc = DateTime.UtcNow;
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await TryLoadRestoreAsync(operation, sideEffects, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         if (sideEffects.ObsoleteCleanupCompleted || sideEffects.ObsoletePaths.Count == 0)
         {
             operation.Status = "loadRestore";
@@ -531,6 +700,13 @@ public sealed class LocalModelLifecycleOperationService : ILocalModelLifecycleOp
         var alias = operation.RouterModelId ?? string.Empty;
         try
         {
+            if (string.Equals(operation.OperationKind, LocalModelOperationKinds.ChangeQuant, StringComparison.OrdinalIgnoreCase)
+                && !await IsDownloadOutcomePresentOnRouterAsync(operation, cancellationToken).ConfigureAwait(false))
+            {
+                await ApplyRouterSelectionFromChangeQuantAsync(operation, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
             await _llamaClient.LoadModelAsync(alias, cancellationToken).ConfigureAwait(false);
             sideEffects.LoadRestored = true;
             operation.CompletedSideEffectsJson = SerializeSideEffects(sideEffects);

--- a/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelLifecycleService.cs
+++ b/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelOnboarding/LocalModelLifecycleService.cs
@@ -5,6 +5,7 @@ using GuideAntsApi.Services.HuggingFace;
 using GuideAntsApi.Services.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace GuideAntsApi.Services.LlamaCpp.LocalModelOnboarding;
 
@@ -44,7 +45,10 @@ public sealed class LocalModelLifecycleService : ILocalModelLifecycleService
     private readonly ILlamaRuntimeInventoryService _inventoryService;
     private readonly ILlamaRuntimeCoordinator _coordinator;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IHostApplicationLifetime _applicationLifetime;
     private readonly ILogger<LocalModelLifecycleService> _logger;
+
+    private static readonly TimeSpan BackgroundReconcilePollInterval = TimeSpan.FromSeconds(2);
 
     public LocalModelLifecycleService(
         ApplicationDbContext db,
@@ -55,6 +59,7 @@ public sealed class LocalModelLifecycleService : ILocalModelLifecycleService
         ILlamaRuntimeInventoryService inventoryService,
         ILlamaRuntimeCoordinator coordinator,
         IServiceScopeFactory scopeFactory,
+        IHostApplicationLifetime applicationLifetime,
         ILogger<LocalModelLifecycleService> logger)
     {
         _db = db;
@@ -65,6 +70,7 @@ public sealed class LocalModelLifecycleService : ILocalModelLifecycleService
         _inventoryService = inventoryService;
         _coordinator = coordinator;
         _scopeFactory = scopeFactory;
+        _applicationLifetime = applicationLifetime;
         _logger = logger;
     }
 
@@ -157,15 +163,8 @@ public sealed class LocalModelLifecycleService : ILocalModelLifecycleService
         var companions = quants.Companions ?? Array.Empty<LlamaProjectorArtifactDto>();
         var companionFiles = companions.Select(c => c.Path).ToList();
 
-        var oldPaths = InstallationArtifactRecords.Parse(installation.ModelArtifactsJson)
-            .Concat(InstallationArtifactRecords.Parse(installation.ProjectorArtifactsJson))
-            .Concat(InstallationArtifactRecords.Parse(installation.CompanionArtifactsJson))
-            .Select(a => a.RepositoryPath)
-            .Where(p => !string.IsNullOrWhiteSpace(p))
-            .ToList();
-        var newPaths = modelFiles.Concat(mmprojFiles).Concat(companionFiles).ToHashSet(StringComparer.Ordinal);
-        var obsoletePaths = oldPaths.Where(p => !newPaths.Contains(p)).ToList();
-
+        // Prior quants that are not the newly selected active set stay on disk.
+        // Change-quant only retargets alias + provenance; it does not delete siblings.
         var immutableInput = new ChangeQuantImmutableInput(
             ModelId: installation.ModelId,
             CatalogId: installation.CatalogId,
@@ -181,7 +180,6 @@ public sealed class LocalModelLifecycleService : ILocalModelLifecycleService
             RouterModelId: installation.RouterModelId!,
             TargetDirectory: installation.TargetDirectory!,
             RouterPreset: routerPreset,
-            ObsoleteRepositoryPaths: obsoletePaths,
             ArtifactMetadata: BuildArtifactMetadata(quant, quants.Projector, companions));
 
         var wasLoaded = await CaptureLoadedStateAsync(installation.RouterModelId!, cancellationToken).ConfigureAwait(false);
@@ -486,15 +484,30 @@ public sealed class LocalModelLifecycleService : ILocalModelLifecycleService
 
     private void QueueBackgroundLifecycleReconciliation(Guid operationId, string failureMessageTemplate)
     {
+        var stopping = _applicationLifetime.ApplicationStopping;
         _ = Task.Run(async () =>
         {
             try
             {
-                using var scope = _scopeFactory.CreateScope();
-                var operationService = scope.ServiceProvider.GetRequiredService<ILocalModelLifecycleOperationService>();
-                await operationService
-                    .ReconcileLifecycleOperationAsync(operationId, CancellationToken.None)
-                    .ConfigureAwait(false);
+                while (!stopping.IsCancellationRequested)
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var operationService = scope.ServiceProvider
+                        .GetRequiredService<ILocalModelLifecycleOperationService>();
+                    var status = await operationService
+                        .ReconcileLifecycleOperationAsync(operationId, stopping)
+                        .ConfigureAwait(false);
+
+                    if (LocalModelOperationStatuses.IsTerminal(status.Status))
+                    {
+                        return;
+                    }
+
+                    await Task.Delay(BackgroundReconcilePollInterval, stopping).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) when (stopping.IsCancellationRequested)
+            {
             }
             catch (Exception ex)
             {

--- a/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelStartupReconciliationService.cs
+++ b/src/server/GuideAntsApi/Services/LlamaCpp/LocalModelStartupReconciliationService.cs
@@ -3,10 +3,16 @@ namespace GuideAntsApi.Services.LlamaCpp;
 using GuideAntsApi.Services.LlamaCpp.LocalModelOnboarding;
 
 /// <summary>
-/// Reconciles in-flight local model operations on startup.
+/// Reconciles in-flight local model operations on startup and periodically while
+/// the API is alive. Client polling and one-shot background tasks are not sufficient
+/// for long downloads: without a server-side sweep, a lost journal or abandoned UI
+/// poller leaves a non-terminal row that permanently blocks the alias.
 /// </summary>
-public sealed class LocalModelStartupReconciliationService : IHostedService
+public sealed class LocalModelStartupReconciliationService : BackgroundService
 {
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(15);
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<LocalModelStartupReconciliationService> _logger;
 
@@ -18,22 +24,53 @@ public sealed class LocalModelStartupReconciliationService : IHostedService
         _logger = logger;
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         try
         {
-            using var scope = _scopeFactory.CreateScope();
-            var operationService = scope.ServiceProvider.GetRequiredService<ILocalModelOperationService>();
-            await operationService.ReconcileInFlightOperationsAsync(cancellationToken).ConfigureAwait(false);
-
-            var lifecycleOperationService = scope.ServiceProvider.GetRequiredService<ILocalModelLifecycleOperationService>();
-            await lifecycleOperationService.ReconcileInFlightLifecycleOperationsAsync(cancellationToken).ConfigureAwait(false);
+            await Task.Delay(InitialDelay, stoppingToken).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
-            _logger.LogError(ex, "Local model startup reconciliation failed.");
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ReconcileOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Local model in-flight operation reconciliation failed.");
+            }
+
+            try
+            {
+                await Task.Delay(SweepInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
         }
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    private async Task ReconcileOnceAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var operationService = scope.ServiceProvider.GetRequiredService<ILocalModelOperationService>();
+        await operationService.ReconcileInFlightOperationsAsync(cancellationToken).ConfigureAwait(false);
+
+        var lifecycleOperationService = scope.ServiceProvider
+            .GetRequiredService<ILocalModelLifecycleOperationService>();
+        await lifecycleOperationService
+            .ReconcileInFlightLifecycleOperationsAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
 }

--- a/src/server/GuideAntsApi/Services/NotebookDockerScriptService.cs
+++ b/src/server/GuideAntsApi/Services/NotebookDockerScriptService.cs
@@ -167,6 +167,7 @@ namespace GuideAntsApi.Services
                                     p,
                                     context!.IsPublished,
                                     context.RunId))
+                                .Where(p => !GuideAntsApi.Services.Components.Sync.NotebookArtifactPathExclusions.IsExcludedRelativePath(p))
                                 .Distinct(StringComparer.OrdinalIgnoreCase)
                                 .ToList();
 

--- a/src/server/GuideAntsApi/appsettings.Development.json
+++ b/src/server/GuideAntsApi/appsettings.Development.json
@@ -45,7 +45,7 @@
     "LinkedMountTreeMaxFiles": 5000,
     "LinkedMountTreeMaxDepth": 3,
     "LinkedMountTreeScanBudgetMs": 2500,
-    "LinkedMountTreeCacheSeconds": 15,
+    "LinkedMountTreeCacheSeconds": 120,
     "ProjectMountTreeCacheSeconds": 120
   },
   "SearXngSearch": {

--- a/src/server/GuideAntsApi/appsettings.json
+++ b/src/server/GuideAntsApi/appsettings.json
@@ -51,7 +51,7 @@
     "LinkedMountTreeMaxFiles": 5000,
     "LinkedMountTreeMaxDepth": 3,
     "LinkedMountTreeScanBudgetMs": 2500,
-    "LinkedMountTreeCacheSeconds": 15,
+    "LinkedMountTreeCacheSeconds": 120,
     "ProjectMountTreeCacheSeconds": 120
   },
   "SearXngSearch": {

--- a/src/server/ScriptExecutionAgent.Tests/InProcess/ScriptExecutionAgentAdminApiTests.cs
+++ b/src/server/ScriptExecutionAgent.Tests/InProcess/ScriptExecutionAgentAdminApiTests.cs
@@ -193,11 +193,12 @@ public sealed class ScriptExecutionAgentAdminApiTests
 
         var packageName = $"ga_reconcile_probe_{Guid.NewGuid():N}".ToLowerInvariant();
         var createPackageScript = $$"""
-import site
+import sysconfig
 from pathlib import Path
 
 name = "{{packageName}}"
-site_packages = Path(site.getsitepackages()[0])
+# Prefer purelib: on Windows Python 3.12 venvs, site.getsitepackages()[0] is the venv root.
+site_packages = Path(sysconfig.get_paths()["purelib"])
 dist_info = site_packages / f"{name}-0.1.0.dist-info"
 dist_info.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- Shallow-scan host mounts with on-demand listing APIs, and graft expanded branches across tree polls so large mounts no longer block the notebook/project folder trees.
- Fix notebook folder-tree sync regressions so expanded host-mount state stays consistent across refreshes and multi-tab use.
- Harden stream/watchdog and ChangeQuant lifecycle edges that could leave aliases or SSE stuck, or delete prior quants when switching.
