### PR TITLE
Bugfix/chat send preflight delay

### DIFF
--- a/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
+++ b/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
@@ -276,6 +276,62 @@ describe('useConversationActions', () => {
       }));
     });
 
+    it('renders the user message optimistically before the runtime check resolves', async () => {
+      let resolveCheck!: (v: unknown) => void;
+      vi.mocked(checkRuntimeStatus).mockImplementation(
+        () => new Promise((res) => { resolveCheck = res; }) as any,
+      );
+      const { actions, dispatch } = mountActions();
+
+      let sendPromise!: Promise<void>;
+      act(() => {
+        sendPromise = actions.sendMessage('hello');
+      });
+
+      await vi.waitFor(() => {
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+          type: 'ADD_MESSAGE',
+          payload: expect.objectContaining({ role: 'user', content: 'hello' }),
+        }));
+      });
+      expect(api.projects.notebooks.conversations.sendMessageStream).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveCheck({ state: 'ready' });
+        await sendPromise;
+      });
+    });
+
+    it('rolls back the optimistic messages when the runtime check reports not ready', async () => {
+      vi.mocked(checkRuntimeStatus).mockResolvedValue({ state: 'failed' } as any);
+      const { actions, dispatch } = mountActions();
+
+      await act(async () => {
+        await actions.sendMessage('hello');
+      });
+
+      const types = dispatch.mock.calls.map((c) => c[0].type);
+      expect(types).toContain('ADD_MESSAGE');
+      expect(types).toContain('REMOVE_LAST_TURN');
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_DRAFT', payload: 'hello' });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_STREAMING_MODE', payload: { mode: 'at-rest' } });
+      expect(api.projects.notebooks.conversations.sendMessageStream).not.toHaveBeenCalled();
+    });
+
+    it('rolls back when the runtime check throws', async () => {
+      vi.mocked(checkRuntimeStatus).mockRejectedValue(Object.assign(new Error('boom'), { status: 500 }));
+      const { actions, dispatch, deps } = mountActions();
+
+      await act(async () => {
+        await actions.sendMessage('hello');
+      });
+
+      const types = dispatch.mock.calls.map((c) => c[0].type);
+      expect(types).toContain('REMOVE_LAST_TURN');
+      expect(deps.showToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Runtime Error' }));
+      expect(api.projects.notebooks.conversations.sendMessageStream).not.toHaveBeenCalled();
+    });
+
     it('handles 409 ROUTING_MODEL_NOT_READY', async () => {
       const error = Object.assign(new Error('conflict'), {
         status: 409,

--- a/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
+++ b/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
@@ -176,6 +176,53 @@ describe('useConversationActions', () => {
       expect(deps.setCurrentStreamController).toHaveBeenCalled();
     });
 
+    it('does not pre-fetch the conversation snapshot before streaming', async () => {
+      const { actions } = mountActions();
+
+      await act(async () => {
+        await actions.sendMessage('hello world');
+      });
+
+      expect(api.projects.notebooks.conversations.get).not.toHaveBeenCalled();
+      expect(api.projects.notebooks.conversations.sendMessageStream).toHaveBeenCalled();
+    });
+
+    it('does not block the streaming POST on the conversation snapshot round-trip', async () => {
+      const conversations = api.projects.notebooks.conversations as Record<string, unknown>;
+      const SNAPSHOT_LATENCY_MS = 300;
+      let snapshotSettled = false;
+      conversations.get = vi.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, SNAPSHOT_LATENCY_MS));
+        snapshotSettled = true;
+        return { messages: [], activeTurn: { turnId: 'turn-1' } };
+      });
+
+      let postElapsedMs: number | null = null;
+      conversations.sendMessageStream = vi.fn(async () => {
+        postElapsedMs = performance.now() - startedAt;
+      });
+
+      const { actions } = mountActions();
+
+      const startedAt = performance.now();
+      let sendPromise!: Promise<void>;
+      await act(async () => {
+        sendPromise = actions.sendMessage('hello world');
+        // One macrotask boundary flushes every await in the send path that is
+        // NOT gated on the snapshot request. Anything still pending after this
+        // is waiting on the 300ms snapshot round-trip.
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      expect(snapshotSettled).toBe(false);
+      expect(conversations.sendMessageStream).toHaveBeenCalled();
+      expect(postElapsedMs).toBeLessThan(SNAPSHOT_LATENCY_MS);
+
+      await act(async () => {
+        await sendPromise;
+      });
+    });
+
     it('returns when runtime check is deduplicated (null)', async () => {
       vi.mocked(checkRuntimeStatus).mockResolvedValue(null);
       const { actions } = mountActions();

--- a/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
+++ b/src/client/src/contexts/conversation/__tests__/useConversationActions.test.ts
@@ -302,6 +302,57 @@ describe('useConversationActions', () => {
       });
     });
 
+    it('does not discard a Stop click that lands during the runtime preflight window', async () => {
+      // Regression test: SET_STREAMING_MODE (which drives isStreaming, and
+      // therefore the Stop button's visibility) fires before checkRuntimeStatus
+      // resolves. If the SET_CANCELLING/clearPendingStop reset still ran AFTER
+      // the runtime check (the old ordering), a Stop click issued in that window
+      // would be silently wiped before the turn id ever arrived.
+      let resolveCheck!: (v: unknown) => void;
+      vi.mocked(checkRuntimeStatus).mockImplementation(
+        () => new Promise((res) => { resolveCheck = res; }) as any,
+      );
+      const { actions, dispatch } = mountActions();
+
+      let sendPromise!: Promise<void>;
+      act(() => {
+        sendPromise = actions.sendMessage('hello');
+      });
+
+      // Optimistic dispatches (and isStreaming flipping true) have landed;
+      // checkRuntimeStatus is still pending.
+      await vi.waitFor(() => {
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'ADD_MESSAGE' }));
+      });
+      expect(api.projects.notebooks.conversations.sendMessageStream).not.toHaveBeenCalled();
+
+      // User clicks Stop while the preflight is still in flight. No real turn
+      // id exists yet (getActiveStreamTurnId/activeStreamTurnId are both
+      // null), so this only queues pendingStopRef via SET_CANCELLING.
+      act(() => {
+        actions.cancelStream();
+      });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CANCELLING', payload: true });
+      expect(api.projects.notebooks.conversations.cancelTurn).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveCheck({ state: 'ready' });
+        await sendPromise;
+      });
+
+      // The real turn id arrives later via the turn_created SSE event.
+      act(() => {
+        actions.onTurnIdAssigned('turn-real');
+      });
+
+      // If clearPendingStop() had run after the (now-resolved) runtime check,
+      // as it used to, pendingStopRef would already be false here and this
+      // would never fire.
+      expect(api.projects.notebooks.conversations.cancelTurn).toHaveBeenCalledWith(
+        PROJECT_ID, NOTEBOOK_ID, CONVERSATION_ID, 'turn-real',
+      );
+    });
+
     it('rolls back the optimistic messages when the runtime check reports not ready', async () => {
       vi.mocked(checkRuntimeStatus).mockResolvedValue({ state: 'failed' } as any);
       const { actions, dispatch } = mountActions();
@@ -316,6 +367,47 @@ describe('useConversationActions', () => {
       expect(dispatch).toHaveBeenCalledWith({ type: 'SET_DRAFT', payload: 'hello' });
       expect(dispatch).toHaveBeenCalledWith({ type: 'SET_STREAMING_MODE', payload: { mode: 'at-rest' } });
       expect(api.projects.notebooks.conversations.sendMessageStream).not.toHaveBeenCalled();
+    });
+
+    it('resets SET_CANCELLING on rollback so a Stop-then-not-ready sequence cannot leak into the next send', async () => {
+      // A Stop click can flip _isCancelling true while the runtime check is
+      // still pending (see the preflight-window test above). If the check
+      // then reports not-ready, rollbackOptimisticSend must reset
+      // SET_CANCELLING back to false itself rather than leaving it for a
+      // future send to clean up.
+      let resolveCheck!: (v: unknown) => void;
+      vi.mocked(checkRuntimeStatus).mockImplementation(
+        () => new Promise((res) => { resolveCheck = res; }) as any,
+      );
+      const { actions, dispatch } = mountActions();
+
+      let sendPromise!: Promise<void>;
+      act(() => {
+        sendPromise = actions.sendMessage('hello');
+      });
+
+      await vi.waitFor(() => {
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'ADD_MESSAGE' }));
+      });
+
+      act(() => {
+        actions.cancelStream();
+      });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CANCELLING', payload: true });
+
+      const cancellingTrueIndex = dispatch.mock.calls.findIndex(
+        (c) => c[0].type === 'SET_CANCELLING' && c[0].payload === true,
+      );
+
+      await act(async () => {
+        resolveCheck({ state: 'failed' });
+        await sendPromise;
+      });
+
+      const cancellingFalseAfterRollback = dispatch.mock.calls
+        .slice(cancellingTrueIndex + 1)
+        .some((c) => c[0].type === 'SET_CANCELLING' && c[0].payload === false);
+      expect(cancellingFalseAfterRollback).toBe(true);
     });
 
     it('rolls back when the runtime check throws', async () => {

--- a/src/client/src/contexts/conversation/useConversationActions.ts
+++ b/src/client/src/contexts/conversation/useConversationActions.ts
@@ -124,55 +124,9 @@ export function useConversationActions(
       const assistantName = state.selectedAssistant || (() => { throw new Error('No assistant selected when sending message'); })();
       const assistant = (state.assistants || []).find((candidate: any) => candidate?.name === assistantName);
 
-      if (assistant?.id) {
-        try {
-          const runtimeStatus = await checkRuntimeStatus(projectId, notebookId, assistant.id, inflightRuntimeChecksRef.current, runtimeReadyCacheRef.current);
-          if (!runtimeStatus) {
-            return;
-          }
-          if (runtimeStatus.state !== 'ready') {
-            if (runtimeStatus.state === 'failed' || runtimeStatus.state === 'invalid') {
-              showToast({
-                type: 'error',
-                title: runtimeStatus.state === 'invalid' ? 'Incompatible Local Models' : 'Local Runtime Error',
-                message: getRuntimeBlockingMessage(runtimeStatus)
-              });
-            }
-            return;
-          }
-        } catch (error: any) {
-          console.error('Failed to check local runtime status:', error);
-          showToast({
-            type: 'error',
-            title: 'Runtime Error',
-            message: `Failed to check model runtime status: ${error.message}`
-          });
-          return;
-        }
-      }
-
-      dispatch({ type: 'SET_STREAMING_MODE', payload: { mode: 'sending' } });
-      dispatch({ type: 'SET_CANCELLING', payload: false });
-      dispatch({ type: 'SET_STREAMING_ERROR', payload: undefined });
-      dispatch({ type: 'SET_DRAFT', payload: '' });
-      clearPendingStop();
-
-      // Send exclusively owns token appends for this turn.
-      abortObserverStream();
-
-      const controller = new AbortController();
-      adoptSendStream(controller);
-
+      // Optimistic render: paint the user's message and the placeholder immediately,
+      // before the runtime preflight. Every early-return below must roll this back.
       const attList = (attachments && attachments.length > 0) ? attachments : (state.pendingAttachments ?? []);
-
-      dispatch({ type: 'START_STREAMING_TURN' });
-
-      // activeStreamTurnId is assigned from the SSE `turnId` event once the
-      // stream opens (see useStreamingEventHandler); no need to pre-fetch
-      // the conversation snapshot just to learn it a few hundred ms early.
-      // A Stop click that races ahead of that event is queued via
-      // pendingStopRef/onTurnIdAssigned and re-issued once the id lands
-      // (pre-existing behavior, unchanged by this removal).
 
       const userMessage: MessageDto = {
         id: `tmp-${Date.now()}`,
@@ -188,7 +142,6 @@ export function useConversationActions(
           type: 'Referenced' as const
         }))
       } as MessageDto;
-      dispatch({ type: 'ADD_MESSAGE', payload: userMessage });
 
       const placeholderAssistant: MessageDto = {
         id: `streaming-${Date.now()}`,
@@ -199,7 +152,68 @@ export function useConversationActions(
         assistantName: state.selectedAssistant || undefined,
         streaming: true,
       } as MessageDto;
+
+      dispatch({ type: 'SET_STREAMING_MODE', payload: { mode: 'sending' } });
+      dispatch({ type: 'SET_DRAFT', payload: '' });
+      dispatch({ type: 'ADD_MESSAGE', payload: userMessage });
       dispatch({ type: 'ADD_MESSAGE', payload: placeholderAssistant });
+
+      const rollbackOptimisticSend = () => {
+        // REMOVE_LAST_TURN pops trailing messages through the last user message —
+        // exactly the placeholder + user message added above.
+        dispatch({ type: 'REMOVE_LAST_TURN' });
+        dispatch({ type: 'SET_DRAFT', payload: content });
+        dispatch({ type: 'SET_STREAMING_MODE', payload: { mode: 'at-rest' } });
+      };
+
+      if (assistant?.id) {
+        try {
+          const runtimeStatus = await checkRuntimeStatus(projectId, notebookId, assistant.id, inflightRuntimeChecksRef.current, runtimeReadyCacheRef.current);
+          if (!runtimeStatus) {
+            rollbackOptimisticSend();
+            return;
+          }
+          if (runtimeStatus.state !== 'ready') {
+            if (runtimeStatus.state === 'failed' || runtimeStatus.state === 'invalid') {
+              showToast({
+                type: 'error',
+                title: runtimeStatus.state === 'invalid' ? 'Incompatible Local Models' : 'Local Runtime Error',
+                message: getRuntimeBlockingMessage(runtimeStatus)
+              });
+            }
+            rollbackOptimisticSend();
+            return;
+          }
+        } catch (error: any) {
+          console.error('Failed to check local runtime status:', error);
+          showToast({
+            type: 'error',
+            title: 'Runtime Error',
+            message: `Failed to check model runtime status: ${error.message}`
+          });
+          rollbackOptimisticSend();
+          return;
+        }
+      }
+
+      dispatch({ type: 'SET_CANCELLING', payload: false });
+      dispatch({ type: 'SET_STREAMING_ERROR', payload: undefined });
+      clearPendingStop();
+
+      // Send exclusively owns token appends for this turn.
+      abortObserverStream();
+
+      const controller = new AbortController();
+      adoptSendStream(controller);
+
+      dispatch({ type: 'START_STREAMING_TURN' });
+
+      // activeStreamTurnId is assigned from the SSE `turnId` event once the
+      // stream opens (see useStreamingEventHandler); no need to pre-fetch
+      // the conversation snapshot just to learn it a few hundred ms early.
+      // A Stop click that races ahead of that event is queued via
+      // pendingStopRef/onTurnIdAssigned and re-issued once the id lands
+      // (pre-existing behavior, unchanged by this removal).
 
       try {
         await api.projects.notebooks.conversations.sendMessageStream(

--- a/src/client/src/contexts/conversation/useConversationActions.ts
+++ b/src/client/src/contexts/conversation/useConversationActions.ts
@@ -167,14 +167,12 @@ export function useConversationActions(
 
       dispatch({ type: 'START_STREAMING_TURN' });
 
-      try {
-        const convoSnapshot = await api.projects.notebooks.conversations.get(projectId, notebookId, conversationId);
-        if (convoSnapshot.activeTurn?.turnId) {
-          setActiveStreamTurnId(convoSnapshot.activeTurn.turnId);
-        }
-      } catch (snapshotError) {
-        console.warn('Failed to load active turn id before streaming:', snapshotError);
-      }
+      // activeStreamTurnId is assigned from the SSE `turnId` event once the
+      // stream opens (see useStreamingEventHandler); no need to pre-fetch
+      // the conversation snapshot just to learn it a few hundred ms early.
+      // A Stop click that races ahead of that event is queued via
+      // pendingStopRef/onTurnIdAssigned and re-issued once the id lands
+      // (pre-existing behavior, unchanged by this removal).
 
       const userMessage: MessageDto = {
         id: `tmp-${Date.now()}`,

--- a/src/client/src/contexts/conversation/useConversationActions.ts
+++ b/src/client/src/contexts/conversation/useConversationActions.ts
@@ -153,6 +153,20 @@ export function useConversationActions(
         streaming: true,
       } as MessageDto;
 
+      // Reset stream-cancellation state BEFORE the optimistic dispatches flip
+      // isStreaming to true. The Stop button renders on isStreaming alone (no
+      // currentTurn guard), so it's clickable for the entire runtime-preflight
+      // window below; if that reset ran after the preflight (as it used to),
+      // a Stop click during the preflight would queue pendingStopRef, and this
+      // clearPendingStop() would then wipe it out before onTurnIdAssigned ever
+      // saw it — silently discarding the stop. Also clear any stale turn id
+      // from a previous send here so an early Stop on this new send can't
+      // target the wrong turn (see stale-active-stream-turn-id.md).
+      dispatch({ type: 'SET_CANCELLING', payload: false });
+      dispatch({ type: 'SET_STREAMING_ERROR', payload: undefined });
+      clearPendingStop();
+      setActiveStreamTurnId?.(null);
+
       dispatch({ type: 'SET_STREAMING_MODE', payload: { mode: 'sending' } });
       dispatch({ type: 'SET_DRAFT', payload: '' });
       dispatch({ type: 'ADD_MESSAGE', payload: userMessage });
@@ -164,6 +178,10 @@ export function useConversationActions(
         dispatch({ type: 'REMOVE_LAST_TURN' });
         dispatch({ type: 'SET_DRAFT', payload: content });
         dispatch({ type: 'SET_STREAMING_MODE', payload: { mode: 'at-rest' } });
+        // A Stop click during the runtime preflight (window between the
+        // optimistic dispatches above and this rollback) sets _isCancelling
+        // true; undo that here so it can't leak into the next send attempt.
+        dispatch({ type: 'SET_CANCELLING', payload: false });
       };
 
       if (assistant?.id) {
@@ -195,10 +213,6 @@ export function useConversationActions(
           return;
         }
       }
-
-      dispatch({ type: 'SET_CANCELLING', payload: false });
-      dispatch({ type: 'SET_STREAMING_ERROR', payload: undefined });
-      clearPendingStop();
 
       // Send exclusively owns token appends for this turn.
       abortObserverStream();

--- a/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/DatabaseStorage.cs
+++ b/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/DatabaseStorage.cs
@@ -199,13 +199,19 @@ namespace AntRunner.ToolCalling.AssistantDefinitions.Storage
                 return null;
             }
 
-            using var context = CreateContext();
+            var nowUtc = DateTime.UtcNow;
+            if (!ReasoningChoicesCache.TryGet(modelId, nowUtc, out var reasoningChoicesJson))
+            {
+                using var context = CreateContext();
 
-            var reasoningChoicesJson = await context.Models
-                .AsNoTracking()
-                .Where(m => m.ModelId == modelId)
-                .Select(m => m.ReasoningChoicesJson)
-                .FirstOrDefaultAsync(cancellationToken);
+                reasoningChoicesJson = await context.Models
+                    .AsNoTracking()
+                    .Where(m => m.ModelId == modelId)
+                    .Select(m => m.ReasoningChoicesJson)
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                ReasoningChoicesCache.Set(modelId, reasoningChoicesJson, nowUtc);
+            }
 
             return SelectDeclaredReasoningEffort(
                 reasoningEffort.Trim(),

--- a/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/ReasoningChoicesCache.cs
+++ b/src/server/AntRunner.Chat/AntRunner.ToolCalling/AssistantDefinitions.Storage/ReasoningChoicesCache.cs
@@ -1,0 +1,42 @@
+using System.Collections.Concurrent;
+
+namespace AntRunner.ToolCalling.AssistantDefinitions.Storage;
+
+/// <summary>
+/// Short-TTL per-process cache of <c>Models.ReasoningChoicesJson</c> keyed by model id, so
+/// <see cref="DatabaseStorage.ResolveModelReasoningEffortAsync"/> doesn't open a DbContext on
+/// every chat run. Catalog edits propagate within <see cref="Ttl"/>; a cached null means the
+/// model row exists but declares no choices (or the row is absent) — both are valid to cache.
+/// </summary>
+public static class ReasoningChoicesCache
+{
+    public static readonly TimeSpan Ttl = TimeSpan.FromSeconds(60);
+
+    private sealed record CacheEntry(string? Json, DateTime CachedAtUtc);
+
+    private static readonly ConcurrentDictionary<string, CacheEntry> Entries =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public static bool TryGet(string modelId, DateTime nowUtc, out string? reasoningChoicesJson)
+    {
+        reasoningChoicesJson = null;
+        if (!Entries.TryGetValue(modelId, out var entry))
+        {
+            return false;
+        }
+
+        if (nowUtc - entry.CachedAtUtc >= Ttl)
+        {
+            Entries.TryRemove(modelId, out _);
+            return false;
+        }
+
+        reasoningChoicesJson = entry.Json;
+        return true;
+    }
+
+    public static void Set(string modelId, string? reasoningChoicesJson, DateTime nowUtc) =>
+        Entries[modelId] = new CacheEntry(reasoningChoicesJson, nowUtc);
+
+    public static void Clear() => Entries.Clear();
+}

--- a/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationAssistantSwitchingTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationAssistantSwitchingTests.cs
@@ -76,9 +76,10 @@ public class NotebookConversationAssistantSwitchingTests
         }
 
         public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(
-            Guid conversationId, 
-            SendMessageRequest request, 
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            Guid conversationId,
+            SendMessageRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default,
+            Guid? resolvedAssistantId = null)
         {
             // Simulate assistant switching logic
             var isAssistantSwitch = IsAssistantSwitch(conversationId, request.AssistantName);

--- a/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationStreamingEndpointsTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationStreamingEndpointsTests.cs
@@ -53,7 +53,7 @@ public class NotebookConversationStreamingEndpointsTests
             yield break;
         }
 
-        public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default, Guid? resolvedAssistantId = null)
         {
             yield return new StreamingEvent("token", JsonSerializer.Serialize(new { role = "assistant", contentDelta = "Hel" }));
             await Task.Delay(10, cancellationToken);
@@ -117,7 +117,7 @@ public class NotebookConversationStreamingEndpointsTests
             yield break;
         }
 
-        public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default, Guid? resolvedAssistantId = null)
         {
             await Task.Yield();
             throw new InvalidOperationException("Conversation is locked by User");

--- a/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationStreamingToolCallsTests.cs
+++ b/src/server/GuideAntsApi.IntegrationTests/Endpoints/NotebookConversationStreamingToolCallsTests.cs
@@ -52,7 +52,7 @@ public class NotebookConversationStreamingToolCallsTests
             yield break;
         }
 
-        public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default, Guid? resolvedAssistantId = null)
         {
             // Simulate the complete flow with tool calls
             
@@ -355,7 +355,7 @@ public class NotebookConversationStreamingToolCallsTests
             ));
         }
         
-        public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default, Guid? resolvedAssistantId = null)
         {
             // Simple assistant without tools
             yield return new StreamingEvent(StreamingEventTypes.Token, JsonSerializer.Serialize(new { role = "assistant", contentDelta = "Hello " }));

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/AssistantResolutionTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/AssistantResolutionTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.Services.Conversations;
+using Microsoft.EntityFrameworkCore;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class AssistantResolutionTests
+{
+    private ApplicationDbContext _dbContext = null!;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new ApplicationDbContext(options);
+    }
+
+    [TestCleanup]
+    public void TestCleanup() => _dbContext.Dispose();
+
+    private Guid SeedAssistant(string name, bool isActive, bool isGlobal)
+    {
+        var assistant = new Assistant { Id = Guid.NewGuid(), Name = name, IsActive = isActive, IsGlobal = isGlobal };
+        _dbContext.Assistants.Add(assistant);
+        _dbContext.SaveChanges();
+        return assistant.Id;
+    }
+
+    [TestMethod]
+    public async Task Resolve_PrefersActiveNonGlobalOverGlobal_AndIgnoresInactive()
+    {
+        SeedAssistant("Claude", isActive: false, isGlobal: false);
+        var globalId = SeedAssistant("Claude", isActive: true, isGlobal: true);
+        var localId = SeedAssistant("Claude", isActive: true, isGlobal: false);
+
+        var resolved = await AssistantResolution.ResolveActiveAssistantIdAsync(_dbContext, "Claude", CancellationToken.None);
+
+        resolved.Should().Be(localId);
+        resolved.Should().NotBe(globalId);
+    }
+
+    [TestMethod]
+    public async Task Resolve_UnknownName_ReturnsNull()
+    {
+        var resolved = await AssistantResolution.ResolveActiveAssistantIdAsync(_dbContext, "Nope", CancellationToken.None);
+        resolved.Should().BeNull();
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/AttachmentRenderCacheTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/AttachmentRenderCacheTests.cs
@@ -1,0 +1,81 @@
+using AntRunner.Chat.Abstractions;
+using FluentAssertions;
+using GuideAntsApi.Options;
+using GuideAntsApi.Services.Conversations.Attachments;
+using Microsoft.Extensions.Options;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class AttachmentRenderCacheTests
+{
+    private static AttachmentRenderCache Create(long sizeLimitBytes = 1024 * 1024) =>
+        new(Microsoft.Extensions.Options.Options.Create(new AttachmentRenderCacheOptions
+        {
+            SizeLimitBytes = sizeLimitBytes,
+            SlidingExpirationMinutes = 30
+        }));
+
+    [TestMethod]
+    public void TryGet_Miss_ReturnsFalse()
+    {
+        using var cache = Create();
+        cache.TryGet(Guid.NewGuid(), 1, out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void SetThenGet_SameKey_ReturnsContent()
+    {
+        using var cache = Create();
+        var fileId = Guid.NewGuid();
+        cache.Set(fileId, 100, [new ChatContent("hello")]);
+
+        cache.TryGet(fileId, 100, out var contents).Should().BeTrue();
+        contents.Should().ContainSingle(c => c.Text == "hello");
+    }
+
+    [TestMethod]
+    public void Get_AfterLastModifiedChanges_Misses()
+    {
+        using var cache = Create();
+        var fileId = Guid.NewGuid();
+        cache.Set(fileId, 100, [new ChatContent("v1")]);
+
+        cache.TryGet(fileId, 200, out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Set_EmptyContent_IsNotCached()
+    {
+        using var cache = Create();
+        var fileId = Guid.NewGuid();
+        cache.Set(fileId, 100, []);
+
+        cache.TryGet(fileId, 100, out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void ReturnedList_IsACopy_MutationDoesNotPoisonCache()
+    {
+        using var cache = Create();
+        var fileId = Guid.NewGuid();
+        cache.Set(fileId, 100, [new ChatContent("hello")]);
+
+        cache.TryGet(fileId, 100, out var first).Should().BeTrue();
+        first.Add(new ChatContent("junk"));
+
+        cache.TryGet(fileId, 100, out var second).Should().BeTrue();
+        second.Should().HaveCount(1);
+    }
+
+    [TestMethod]
+    public void SizeLimit_EvictsWhenExceeded()
+    {
+        using var cache = Create(sizeLimitBytes: 10);
+        var bigId = Guid.NewGuid();
+        cache.Set(bigId, 1, [new ChatContent(new string('x', 100))]);
+
+        // Entry larger than the cache's SizeLimit is rejected outright by MemoryCache.
+        cache.TryGet(bigId, 1, out _).Should().BeFalse();
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationHistoryBuilderBatchingTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationHistoryBuilderBatchingTests.cs
@@ -1,4 +1,6 @@
+using AntRunner.Chat;
 using AntRunner.Chat.Abstractions;
+using AntRunner.ToolCalling.AssistantDefinitions;
 using FluentAssertions;
 using GuideAntsApi.DataModel;
 using GuideAntsApi.DataModel.Models;
@@ -12,13 +14,24 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using System.Collections;
+using System.Reflection;
 using DataModelChatRole = GuideAntsApi.DataModel.Models.ChatRole;
+using ChatMessageRole = AntRunner.Chat.Abstractions.ChatRole;
 
 namespace GuideAntsApi.Tests.Services.Conversations;
 
 [TestClass]
+[DoNotParallelize]
 public sealed class ConversationHistoryBuilderBatchingTests
 {
+    // AssistantUtility caches assistant definitions in a static, process-wide dictionary (see
+    // AssistantUtilityCacheTests.cs for the established seeding pattern this mirrors). ApplyAssistantSwitchLogicAsync
+    // resolves the switch-target assistant through that same static cache, so tests exercising it must seed and
+    // clear a name distinctive enough not to collide with any other suite's usage - hence [DoNotParallelize] plus
+    // this dedicated constant instead of reusing "Claude".
+    private const string SwitchAssistantName = "Task4BatchingSwitchTestAssistant";
+
     private sealed class CountingScopeFactory : IServiceScopeFactory
     {
         private readonly TestServiceScopeFactory _inner;
@@ -64,7 +77,11 @@ public sealed class ConversationHistoryBuilderBatchingTests
     }
 
     [TestCleanup]
-    public void TestCleanup() => _dbContext.Dispose();
+    public void TestCleanup()
+    {
+        _dbContext.Dispose();
+        AssistantUtility.ClearCache(SwitchAssistantName);
+    }
 
     private void SeedConversation()
     {
@@ -116,6 +133,21 @@ public sealed class ConversationHistoryBuilderBatchingTests
             .AsNoTracking()
             .Single(c => c.Id == _conversationId);
 
+    /// <summary>
+    /// Seeds AssistantUtility's static cache directly (bypassing the DB-backed lookup
+    /// ApplyAssistantSwitchLogicAsync would otherwise perform) so the assistant-switch branch that carries
+    /// the attachment batching can run hermetically. Mirrors AssistantUtilityCacheTests.SeedCache.
+    /// </summary>
+    private static void SeedAssistantCache(string assistantName)
+    {
+        var cacheType = typeof(AssistantUtility).GetNestedType("CachedAssistant", BindingFlags.NonPublic)!;
+        var entry = Activator.CreateInstance(cacheType, new AssistantDefinition { Name = assistantName })!;
+        var cache = (IDictionary)typeof(AssistantUtility)
+            .GetField("AssistantDefinitionCache", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetValue(null)!;
+        cache[assistantName] = entry;
+    }
+
     [TestMethod]
     public async Task BuildOpenAiMessages_UsesExactlyOneScopeForAttachments_RegardlessOfMessageCount()
     {
@@ -139,5 +171,36 @@ public sealed class ConversationHistoryBuilderBatchingTests
             "user message 1", "assistant message 1",
             "user message 2", "assistant message 2",
             "user message 3", "assistant message 3");
+    }
+
+    [TestMethod]
+    public async Task ApplyAssistantSwitchLogic_UsesExactlyOneScopeForAttachments_RegardlessOfMessageCount()
+    {
+        SeedAssistantCache(SwitchAssistantName);
+        var conv = LoadConversation();
+        _countingFactory.CreateScopeCount = 0;
+
+        await _builder.ApplyAssistantSwitchLogicAsync(conv, SwitchAssistantName);
+
+        _countingFactory.CreateScopeCount.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task ApplyAssistantSwitchLogic_ProducesSameMessageListShape()
+    {
+        SeedAssistantCache(SwitchAssistantName);
+        var conv = LoadConversation();
+
+        var messages = await _builder.ApplyAssistantSwitchLogicAsync(conv, SwitchAssistantName);
+
+        // 6 carried-over conversation messages (no attachments -> plain ToChatMessage path) plus the
+        // handoff system message ApplyAssistantSwitchLogicAsync appends whenever the conversation had messages.
+        messages.Should().HaveCount(7);
+        messages.Take(6).Select(m => m.GetText()).Should().ContainInOrder(
+            "user message 1", "assistant message 1",
+            "user message 2", "assistant message 2",
+            "user message 3", "assistant message 3");
+        messages[6].Role.Should().Be(ChatMessageRole.System);
+        messages[6].GetText().Should().Contain("previous messages between the user and assistant");
     }
 }

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationHistoryBuilderBatchingTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationHistoryBuilderBatchingTests.cs
@@ -148,6 +148,97 @@ public sealed class ConversationHistoryBuilderBatchingTests
         cache[assistantName] = entry;
     }
 
+    private NotebookFile NewNotebookFile(string relativePath, string hash)
+    {
+        var file = new NotebookFile { Id = Guid.NewGuid(), NotebookId = _notebookId, RelativePath = relativePath, FileHash = hash };
+        file.GenerateDocumentId(_notebookId);
+        return file;
+    }
+
+    /// <summary>
+    /// Appends one more message to the already-seeded conversation with two attachments, inserted in
+    /// reverse OrderIndex order (OrderIndex 1 saved before OrderIndex 0) so a test asserting output order
+    /// actually proves ordering comes from OrderIndex, not row-insertion sequence.
+    /// </summary>
+    private (NotebookFile FileA, NotebookFile FileB) AddAttachmentBearingMessage(
+        int turnIndex, DataModelChatRole role, string? assistantName, string content)
+    {
+        var messageId = Guid.NewGuid();
+        _dbContext.NotebookConversationMessages.Add(new NotebookConversationMessage
+        {
+            Id = messageId,
+            NotebookConversationId = _conversationId,
+            TurnIndex = turnIndex,
+            MessageSequence = 1,
+            Role = role,
+            Content = content,
+            AssistantName = assistantName,
+            Created = DateTime.UtcNow.AddMinutes(turnIndex)
+        });
+
+        var fileA = NewNotebookFile("a.txt", "hA");
+        var fileB = NewNotebookFile("b.txt", "hB");
+        _dbContext.NotebookFiles.AddRange(fileA, fileB);
+
+        _dbContext.MessageAttachments.Add(new MessageAttachment
+        {
+            Id = Guid.NewGuid(), MessageId = messageId, NotebookFileId = fileB.Id, OrderIndex = 1, Created = DateTime.UtcNow
+        });
+        _dbContext.MessageAttachments.Add(new MessageAttachment
+        {
+            Id = Guid.NewGuid(), MessageId = messageId, NotebookFileId = fileA.Id, OrderIndex = 0, Created = DateTime.UtcNow
+        });
+
+        _dbContext.SaveChanges();
+        return (fileA, fileB);
+    }
+
+    /// <summary>
+    /// Appends an orphan tool-call message (no assistant message declares this ToolCallId, so both
+    /// BuildOpenAiMessagesAsync and ApplyAssistantSwitchLogicAsync filter it via `continue`) that also
+    /// carries an attachment, proving a filtered message's attachment never leaks into the batch lookup's
+    /// output even though the batch query fetches attachments for every message id up front.
+    /// </summary>
+    private void AddOrphanToolMessageWithAttachment(int turnIndex, string toolCallId)
+    {
+        var messageId = Guid.NewGuid();
+        _dbContext.NotebookConversationMessages.Add(new NotebookConversationMessage
+        {
+            Id = messageId,
+            NotebookConversationId = _conversationId,
+            TurnIndex = turnIndex,
+            MessageSequence = 1,
+            Role = DataModelChatRole.Tool,
+            ToolCallId = toolCallId,
+            FunctionName = "whatever",
+            Content = "tool output",
+            Created = DateTime.UtcNow.AddMinutes(turnIndex)
+        });
+
+        var fileC = NewNotebookFile("c.txt", "hC");
+        _dbContext.NotebookFiles.Add(fileC);
+        _dbContext.MessageAttachments.Add(new MessageAttachment
+        {
+            Id = Guid.NewGuid(), MessageId = messageId, NotebookFileId = fileC.Id, OrderIndex = 0, Created = DateTime.UtcNow
+        });
+
+        _dbContext.SaveChanges();
+    }
+
+    private static Mock<IAttachmentContentService> CreateStrictAttachmentMockForFiles(NotebookFile fileA, NotebookFile fileB)
+    {
+        var mock = new Mock<IAttachmentContentService>(MockBehavior.Strict);
+        mock.Setup(s => s.CreateOpenAiContentFromLoadedFileAsync(
+                It.Is<NotebookFile>(nf => nf.Id == fileA.Id), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ChatContent> { new("FILE_A") });
+        mock.Setup(s => s.CreateOpenAiContentFromLoadedFileAsync(
+                It.Is<NotebookFile>(nf => nf.Id == fileB.Id), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ChatContent> { new("FILE_B") });
+        // CreateOpenAiContentFromNotebookFileAsync(Guid, ...) is intentionally left unstubbed: this strict
+        // mock throws if the id-based fallback is ever invoked, proving the loaded-file fast path is taken.
+        return mock;
+    }
+
     [TestMethod]
     public async Task BuildOpenAiMessages_UsesExactlyOneScopeForAttachments_RegardlessOfMessageCount()
     {
@@ -202,5 +293,76 @@ public sealed class ConversationHistoryBuilderBatchingTests
             "user message 3", "assistant message 3");
         messages[6].Role.Should().Be(ChatMessageRole.System);
         messages[6].GetText().Should().Contain("previous messages between the user and assistant");
+    }
+
+    [TestMethod]
+    public async Task BuildOpenAiMessages_PreservesMultiAttachmentOrderingAndUsesLoadedFileFastPath()
+    {
+        var (fileA, fileB) = AddAttachmentBearingMessage(
+            turnIndex: 4, role: DataModelChatRole.Assistant, assistantName: "Claude", content: "assistant text with files");
+        AddOrphanToolMessageWithAttachment(turnIndex: 5, toolCallId: "orphan_call_task4");
+
+        var mockAttachments = CreateStrictAttachmentMockForFiles(fileA, fileB);
+        var builder = new ConversationHistoryBuilder(
+            _countingFactory,
+            Mock.Of<IContextOptionsService>(),
+            mockAttachments.Object,
+            Mock.Of<ILogger<ConversationHistoryBuilder>>());
+
+        var conv = LoadConversation();
+        _countingFactory.CreateScopeCount = 0;
+
+        var messages = await builder.BuildOpenAiMessagesAsync(conv, "Claude");
+
+        // One scope for the whole call, even with attachments and a filtered message present.
+        _countingFactory.CreateScopeCount.Should().Be(1);
+
+        // 6 baseline messages + the attachment-bearing message; the orphan tool message never surfaces.
+        messages.Should().HaveCount(7);
+        var attachmentMessage = messages[6];
+        attachmentMessage.Content.Select(c => c.Text).Should().ContainInOrder(
+            "assistant text with files", "FILE_A", "FILE_B");
+
+        mockAttachments.Verify(
+            s => s.CreateOpenAiContentFromLoadedFileAsync(It.IsAny<NotebookFile>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        mockAttachments.Verify(
+            s => s.CreateOpenAiContentFromNotebookFileAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ApplyAssistantSwitchLogic_PreservesMultiAttachmentOrderingAndUsesLoadedFileFastPath()
+    {
+        SeedAssistantCache(SwitchAssistantName);
+        var (fileA, fileB) = AddAttachmentBearingMessage(
+            turnIndex: 4, role: DataModelChatRole.Assistant, assistantName: SwitchAssistantName, content: "switch text with files");
+
+        var mockAttachments = CreateStrictAttachmentMockForFiles(fileA, fileB);
+        var builder = new ConversationHistoryBuilder(
+            _countingFactory,
+            Mock.Of<IContextOptionsService>(),
+            mockAttachments.Object,
+            Mock.Of<ILogger<ConversationHistoryBuilder>>());
+
+        var conv = LoadConversation();
+        _countingFactory.CreateScopeCount = 0;
+
+        var messages = await builder.ApplyAssistantSwitchLogicAsync(conv, SwitchAssistantName);
+
+        _countingFactory.CreateScopeCount.Should().Be(1);
+
+        // 6 baseline messages + the attachment-bearing message + the trailing handoff system message.
+        messages.Should().HaveCount(8);
+        var attachmentMessage = messages[6];
+        attachmentMessage.Content.Select(c => c.Text).Should().ContainInOrder(
+            "switch text with files", "FILE_A", "FILE_B");
+
+        mockAttachments.Verify(
+            s => s.CreateOpenAiContentFromLoadedFileAsync(It.IsAny<NotebookFile>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        mockAttachments.Verify(
+            s => s.CreateOpenAiContentFromNotebookFileAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationHistoryBuilderBatchingTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationHistoryBuilderBatchingTests.cs
@@ -1,0 +1,143 @@
+using AntRunner.Chat.Abstractions;
+using FluentAssertions;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.Services.Conversations;
+using GuideAntsApi.Services.Conversations.Attachments;
+using GuideAntsApi.Services.Conversations.Mapping;
+using GuideAntsApi.Services.Core;
+using GuideAntsApi.Tests.TestUtils;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using DataModelChatRole = GuideAntsApi.DataModel.Models.ChatRole;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class ConversationHistoryBuilderBatchingTests
+{
+    private sealed class CountingScopeFactory : IServiceScopeFactory
+    {
+        private readonly TestServiceScopeFactory _inner;
+        public int CreateScopeCount;
+        public CountingScopeFactory(TestServiceScopeFactory inner) => _inner = inner;
+        public IServiceScope CreateScope()
+        {
+            Interlocked.Increment(ref CreateScopeCount);
+            return _inner.CreateScope();
+        }
+    }
+
+    private ApplicationDbContext _dbContext = null!;
+    private CountingScopeFactory _countingFactory = null!;
+    private ConversationHistoryBuilder _builder = null!;
+    private Guid _conversationId;
+    private Guid _notebookId;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new ApplicationDbContext(options);
+        _countingFactory = new CountingScopeFactory(new TestServiceScopeFactory(_dbContext));
+
+        var attachments = new AttachmentContentService(
+            _countingFactory,
+            Microsoft.Extensions.Options.Options.Create(new GuideAntsApi.Options.MarkdownAttachmentOptions()),
+            notebookFileService: null,
+            markdownExtractionService: null,
+            Mock.Of<ILogger<AttachmentContentService>>(),
+            configuration: null);
+
+        _builder = new ConversationHistoryBuilder(
+            _countingFactory,
+            Mock.Of<IContextOptionsService>(),
+            attachments,
+            Mock.Of<ILogger<ConversationHistoryBuilder>>());
+
+        SeedConversation();
+    }
+
+    [TestCleanup]
+    public void TestCleanup() => _dbContext.Dispose();
+
+    private void SeedConversation()
+    {
+        _conversationId = Guid.NewGuid();
+        _notebookId = Guid.NewGuid();
+        var notebook = new Notebook { Id = _notebookId, ProjectId = Guid.NewGuid(), Title = "NB" };
+        var conversation = new NotebookConversation
+        {
+            Id = _conversationId,
+            NotebookId = _notebookId,
+            Title = "Convo",
+            Notebook = notebook
+        };
+        _dbContext.Notebooks.Add(notebook);
+        _dbContext.NotebookConversations.Add(conversation);
+
+        for (var turn = 1; turn <= 3; turn++)
+        {
+            _dbContext.NotebookConversationMessages.Add(new NotebookConversationMessage
+            {
+                Id = Guid.NewGuid(),
+                NotebookConversationId = _conversationId,
+                TurnIndex = turn,
+                MessageSequence = 1,
+                Role = DataModelChatRole.User,
+                Content = $"user message {turn}",
+                Created = DateTime.UtcNow.AddMinutes(turn)
+            });
+            _dbContext.NotebookConversationMessages.Add(new NotebookConversationMessage
+            {
+                Id = Guid.NewGuid(),
+                NotebookConversationId = _conversationId,
+                TurnIndex = turn,
+                MessageSequence = 2,
+                Role = DataModelChatRole.Assistant,
+                Content = $"assistant message {turn}",
+                AssistantName = "Claude",
+                Created = DateTime.UtcNow.AddMinutes(turn).AddSeconds(30)
+            });
+        }
+        _dbContext.SaveChanges();
+    }
+
+    private NotebookConversation LoadConversation() =>
+        _dbContext.NotebookConversations
+            .Include(c => c.Messages)
+            .Include(c => c.Turns)
+            .Include(c => c.Notebook)
+            .AsNoTracking()
+            .Single(c => c.Id == _conversationId);
+
+    [TestMethod]
+    public async Task BuildOpenAiMessages_UsesExactlyOneScopeForAttachments_RegardlessOfMessageCount()
+    {
+        var conv = LoadConversation();
+        _countingFactory.CreateScopeCount = 0;
+
+        await _builder.BuildOpenAiMessagesAsync(conv, "Claude");
+
+        _countingFactory.CreateScopeCount.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task BuildOpenAiMessages_ProducesSameMessageListShape()
+    {
+        var conv = LoadConversation();
+
+        var messages = await _builder.BuildOpenAiMessagesAsync(conv, "Claude");
+
+        messages.Should().HaveCount(6);
+        messages.Select(m => m.GetText()).Should().ContainInOrder(
+            "user message 1", "assistant message 1",
+            "user message 2", "assistant message 2",
+            "user message 3", "assistant message 3");
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationPersistenceTurnStatusTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationPersistenceTurnStatusTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.Services.Conversations.Persistence;
+using GuideAntsApi.Tests.TestUtils;
+using Microsoft.EntityFrameworkCore;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class ConversationPersistenceTurnStatusTests
+{
+    private ApplicationDbContext _dbContext = null!;
+    private ConversationPersistence _persistence = null!;
+    private Guid _conversationId;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        _dbContext = new ApplicationDbContext(options);
+
+        _conversationId = Guid.NewGuid();
+        var notebook = new Notebook { Id = Guid.NewGuid(), ProjectId = Guid.NewGuid(), Title = "NB" };
+        _dbContext.Notebooks.Add(notebook);
+        _dbContext.NotebookConversations.Add(new NotebookConversation
+        {
+            Id = _conversationId,
+            NotebookId = notebook.Id,
+            Title = "Convo",
+            Notebook = notebook
+        });
+        _dbContext.SaveChanges();
+
+        (_persistence, _) = ConversationTestServices.CreatePersistence(new TestServiceScopeFactory(_dbContext));
+    }
+
+    [TestCleanup]
+    public void TestCleanup() => _dbContext.Dispose();
+
+    [TestMethod]
+    public async Task CreateNextTurn_WithStreamingInitialStatus_IsBornStreamingWithExecutionId()
+    {
+        var result = await _persistence.CreateNextTurnAsync(
+            new CreateTurnRequest(_conversationId, "Claude", "gpt-4o-mini", "Hi", InitialStatus: "streaming"));
+
+        result.Turn.Status.Should().Be("streaming");
+        result.Turn.ExecutionId.Should().NotBeNull();
+        result.TurnIndex.Should().Be(1);
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
@@ -244,4 +244,39 @@ public sealed class ConversationServicePreflightTests
         {
         }
     }
+
+    [TestMethod]
+    public async Task SendMessageStream_HistoryFailureAfterTurnCreated_EmitsErrorAndTerminalizesTurn()
+    {
+        var lockMock = new Mock<IDistributedConversationLock>();
+        var registry = new ConversationStreamRunRegistry();
+        var failingHistory = new Mock<IConversationHistoryBuilder>();
+        failingHistory
+            .Setup(h => h.PrepareMessagesForAssistantAsync(It.IsAny<NotebookConversation>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("history exploded"));
+        var service = CreateFixture(historyBuilderOverride: failingHistory.Object, registry: registry, lockMock: lockMock);
+
+        var events = await RunStreamAsync(service);
+
+        events.Should().HaveCount(2);
+        events[0].EventType.Should().Be(StreamingEventTypes.TurnCreated);
+        events[1].EventType.Should().Be(StreamingEventTypes.Error);
+
+        var turn = _dbContext.ConversationTurns.AsNoTracking().Single(t => t.NotebookConversationId == _conversationId);
+        turn.Status.Should().Be("failed");
+
+        registry.RequestCancel(turn.Id).Should().BeFalse("the worker registration must be cleaned up");
+        lockMock.Verify(l => l.ReleaseLockAsync(_conversationId, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    [TestMethod]
+    public async Task SendMessageStream_HappyPath_StillCompletesAfterEarlyYieldRestructure()
+    {
+        var service = CreateFixture();
+
+        var events = await RunStreamAsync(service);
+
+        events[0].EventType.Should().Be(StreamingEventTypes.TurnCreated);
+        events.Select(e => e.EventType).Should().Contain(StreamingEventTypes.Complete);
+    }
 }

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
@@ -23,6 +23,7 @@ using ChatRole = AntRunner.Chat.Abstractions.ChatRole;
 namespace GuideAntsApi.Tests.Services.Conversations;
 
 [TestClass]
+[DoNotParallelize]
 public sealed class ConversationServicePreflightTests
 {
     private ApplicationDbContext _dbContext = null!;

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
@@ -1,0 +1,217 @@
+using System.Collections;
+using System.Reflection;
+using AntRunner.Chat;
+using AntRunner.Chat.Abstractions;
+using AntRunner.ToolCalling.AssistantDefinitions;
+using FluentAssertions;
+using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
+using GuideAntsApi.Models.Conversations;
+using GuideAntsApi.Services.Conversations;
+using GuideAntsApi.Services.Conversations.Mapping;
+using GuideAntsApi.Services.Conversations.Streaming;
+using GuideAntsApi.Services.Core;
+using GuideAntsApi.Services.Routing;
+using GuideAnts.Usage;
+using GuideAntsApi.Tests.TestUtils;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ChatRole = AntRunner.Chat.Abstractions.ChatRole;
+
+namespace GuideAntsApi.Tests.Services.Conversations;
+
+[TestClass]
+public sealed class ConversationServicePreflightTests
+{
+    private ApplicationDbContext _dbContext = null!;
+    private Guid _userId;
+    private Guid _projectId;
+    private Guid _notebookId;
+    private Guid _conversationId;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        AssistantUtility.ClearAllCache();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        _dbContext = new ApplicationDbContext(options);
+
+        _userId = Guid.NewGuid();
+        _projectId = Guid.NewGuid();
+        _notebookId = Guid.NewGuid();
+        _conversationId = Guid.NewGuid();
+
+        _dbContext.Users.Add(new User { Id = _userId, Email = "preflight@test.local", Name = "Preflight Tester" });
+        // Notebook.Project is a required navigation; the InMemory provider's Include treats required
+        // navigations as an inner join, so the root conversation query returns null unless a matching
+        // Project row exists here.
+        var project = new Project { Id = _projectId, Title = "Preflight Project", Slug = "preflight-project" };
+        _dbContext.Projects.Add(project);
+        var notebook = new Notebook { Id = _notebookId, ProjectId = _projectId, Title = "Preflight Notebook", Project = project };
+        _dbContext.Notebooks.Add(notebook);
+        _dbContext.NotebookConversations.Add(new NotebookConversation
+        {
+            Id = _conversationId,
+            NotebookId = _notebookId,
+            Title = "Preflight Conversation",
+            Notebook = notebook
+        });
+        _dbContext.SaveChanges();
+
+        SeedAssistantDefinitionCache("Claude", new AssistantDefinition
+        {
+            Name = "Claude",
+            Model = "gpt-4o-mini",
+            Instructions = "You are a test assistant."
+        });
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        AssistantUtility.ClearAllCache();
+        _dbContext.Dispose();
+    }
+
+    private ConversationService CreateFixture(
+        IConversationHistoryBuilder? historyBuilderOverride = null,
+        ConversationStreamRunRegistry? registry = null,
+        Mock<IDistributedConversationLock>? lockMock = null,
+        ILogger<ConversationService>? logger = null)
+    {
+        var scopeFactory = new TestServiceScopeFactory(_dbContext);
+
+        lockMock ??= new Mock<IDistributedConversationLock>();
+        lockMock
+            .Setup(l => l.TryAcquireLockAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid conversationId, string userName, CancellationToken _) =>
+                LockAcquisitionResult.Acquired(new ConversationLock
+                {
+                    ConversationId = conversationId,
+                    LockedByUserName = userName,
+                    LockedAt = DateTime.UtcNow,
+                    ExpiresAt = DateTime.UtcNow.AddMinutes(5)
+                }));
+        lockMock
+            .Setup(l => l.RenewLockAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        lockMock
+            .Setup(l => l.ReleaseLockAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var chatClient = new Mock<IChatCompletionClient>();
+        chatClient.SetupGet(c => c.SupportsToolChoiceNone).Returns(true);
+        var completedResponse = new ChatCompletionResponse(
+            new[] { new ChatChoice(new ChatMessage(ChatRole.Assistant, "Hello from the mock model."), "stop") },
+            null);
+        chatClient
+            .Setup(c => c.GetCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(completedResponse);
+        chatClient
+            .Setup(c => c.StreamCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<Action<ChatCompletionChunk>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(completedResponse);
+
+        var chatClientFactory = new Mock<IChatCompletionClientFactory>();
+        chatClientFactory
+            .Setup(f => f.CreateClient(It.IsAny<string>(), It.IsAny<HttpClient>()))
+            .Returns(chatClient.Object);
+
+        var chatModelResolver = new Mock<IChatModelResolver>();
+        chatModelResolver
+            .Setup(r => r.Resolve(It.IsAny<string?>()))
+            .Returns((string? id) => new ResolvedChatModel(
+                string.IsNullOrWhiteSpace(id) ? "gpt-4o-mini" : id!,
+                ChatModelReferenceKind.Direct,
+                new ResolvedExecutionPolicy(
+                    string.IsNullOrWhiteSpace(id) ? "gpt-4o-mini" : id!,
+                    "openai-chat",
+                    ParameterAuthority.AssistantDefinition,
+                    new Dictionary<string, System.Text.Json.JsonElement>())));
+
+        var contextOptions = new Mock<IContextOptionsService>();
+        contextOptions
+            .Setup(m => m.BuildContextMessageAsync(It.IsAny<AssistantDefinition>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var configuration = new Mock<IConfiguration>();
+        configuration.Setup(x => x["FileStorage:Path"]).Returns("/tmp/preflight-test-storage");
+
+        var (queryService, commandService, historyBuilder, attachmentService) = ConversationTestServices.Create(
+            scopeFactory,
+            contextOptions.Object,
+            Mock.Of<IMarkdownExtractionService>(),
+            configuration.Object);
+        var (persistence, usageReporter) = ConversationTestServices.CreatePersistence(scopeFactory);
+
+        return ConversationTestServices.CreateConversationService(
+            scopeFactory,
+            chatModelResolver.Object,
+            queryService,
+            commandService,
+            historyBuilderOverride ?? historyBuilder,
+            attachmentService,
+            persistence,
+            usageReporter,
+            chatClientFactory.Object,
+            lockMock.Object,
+            logger: logger,
+            streamRunRegistry: registry);
+    }
+
+    private async Task<List<StreamingEvent>> RunStreamAsync(ConversationService service, string instructions = "Hi")
+    {
+        var events = new List<StreamingEvent>();
+        await foreach (var ev in service.SendMessageStreamToConversationAsUserAsync(
+            _conversationId,
+            new SendMessageRequest { Instructions = instructions, AssistantName = "Claude" },
+            _userId))
+        {
+            events.Add(ev);
+        }
+        return events;
+    }
+
+    private static void SeedAssistantDefinitionCache(string assistantName, AssistantDefinition definition)
+    {
+        var cacheType = typeof(AssistantUtility).GetNestedType("CachedAssistant", BindingFlags.NonPublic)!;
+        var entry = Activator.CreateInstance(cacheType, definition)!;
+        var cache = (IDictionary)typeof(AssistantUtility)
+            .GetField("AssistantDefinitionCache", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetValue(null)!;
+        cache[assistantName] = entry;
+    }
+
+    [TestMethod]
+    public async Task SendMessageStream_HappyPath_EmitsTurnCreatedFirst()
+    {
+        var service = CreateFixture();
+
+        var events = await RunStreamAsync(service);
+
+        events.Should().NotBeEmpty();
+        events[0].EventType.Should().Be(StreamingEventTypes.TurnCreated);
+    }
+
+    [TestMethod]
+    public async Task SendMessageStream_LogsPreflightTimings()
+    {
+        var loggerMock = new Mock<ILogger<ConversationService>>();
+        var service = CreateFixture(logger: loggerMock.Object);
+
+        await RunStreamAsync(service);
+
+        loggerMock.Verify(l => l.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Preflight timings")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
@@ -84,7 +84,8 @@ public sealed class ConversationServicePreflightTests
         IConversationHistoryBuilder? historyBuilderOverride = null,
         ConversationStreamRunRegistry? registry = null,
         Mock<IDistributedConversationLock>? lockMock = null,
-        ILogger<ConversationService>? logger = null)
+        ILogger<ConversationService>? logger = null,
+        Mock<IConversationBroadcastHub>? hubMock = null)
     {
         var scopeFactory = new TestServiceScopeFactory(_dbContext);
 
@@ -161,6 +162,7 @@ public sealed class ConversationServicePreflightTests
             usageReporter,
             chatClientFactory.Object,
             lockMock.Object,
+            broadcastHub: hubMock?.Object,
             logger: logger,
             streamRunRegistry: registry);
     }
@@ -250,11 +252,21 @@ public sealed class ConversationServicePreflightTests
     {
         var lockMock = new Mock<IDistributedConversationLock>();
         var registry = new ConversationStreamRunRegistry();
+        var hubMock = new Mock<IConversationBroadcastHub>();
+        var broadcasts = new List<StreamingEvent>();
+        hubMock
+            .Setup(h => h.BroadcastToConversationAsync(It.IsAny<Guid>(), It.IsAny<StreamingEvent>()))
+            .Callback((Guid _, StreamingEvent ev) => broadcasts.Add(ev))
+            .Returns(Task.CompletedTask);
         var failingHistory = new Mock<IConversationHistoryBuilder>();
         failingHistory
             .Setup(h => h.PrepareMessagesForAssistantAsync(It.IsAny<NotebookConversation>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("history exploded"));
-        var service = CreateFixture(historyBuilderOverride: failingHistory.Object, registry: registry, lockMock: lockMock);
+        var service = CreateFixture(
+            historyBuilderOverride: failingHistory.Object,
+            registry: registry,
+            lockMock: lockMock,
+            hubMock: hubMock);
 
         var events = await RunStreamAsync(service);
 
@@ -267,6 +279,16 @@ public sealed class ConversationServicePreflightTests
 
         registry.RequestCancel(turn.Id).Should().BeFalse("the worker registration must be cleaned up");
         lockMock.Verify(l => l.ReleaseLockAsync(_conversationId, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+
+        // Observers attached via ObserveConversationEventsAsync must receive the same terminal error
+        // the requesting client got - they have no handler for conversation_unlocked, so without this
+        // broadcast they stay stuck showing a mid-stream turn.
+        hubMock.Verify(
+            h => h.BroadcastToConversationAsync(_conversationId, It.Is<StreamingEvent>(ev => ev.EventType == StreamingEventTypes.Error)),
+            Times.Once);
+        broadcasts.Select(b => b.EventType).Should().ContainInOrder(
+            StreamingEventTypes.Error,
+            StreamingEventTypes.ConversationUnlocked);
     }
 
     [TestMethod]

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
@@ -215,4 +215,16 @@ public sealed class ConversationServicePreflightTests
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }
+
+    [TestMethod]
+    public async Task SendMessageStream_TurnIsStreamingWithExecutionIdWhenTurnCreatedEmitted()
+    {
+        var service = CreateFixture();
+
+        var events = await RunStreamAsync(service);
+
+        events[0].EventType.Should().Be(StreamingEventTypes.TurnCreated);
+        var turn = _dbContext.ConversationTurns.AsNoTracking().Single(t => t.NotebookConversationId == _conversationId);
+        turn.ExecutionId.Should().NotBeNull();
+    }
 }

--- a/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
+++ b/src/server/GuideAntsApi.Tests/Services/Conversations/ConversationServicePreflightTests.cs
@@ -221,10 +221,27 @@ public sealed class ConversationServicePreflightTests
     {
         var service = CreateFixture();
 
-        var events = await RunStreamAsync(service);
+        // Manually step the stream instead of draining it via RunStreamAsync: the mock chat client
+        // resolves the whole turn synchronously, so a fully-drained stream would already show the
+        // turn's terminal "completed" status by the time any assertion ran. Stopping right after the
+        // first MoveNextAsync captures the DB state at the actual moment turn_created is observable,
+        // which is the invariant this test protects.
+        await using var enumerator = service.SendMessageStreamToConversationAsUserAsync(
+            _conversationId,
+            new SendMessageRequest { Instructions = "Hi", AssistantName = "Claude" },
+            _userId).GetAsyncEnumerator();
 
-        events[0].EventType.Should().Be(StreamingEventTypes.TurnCreated);
+        (await enumerator.MoveNextAsync()).Should().BeTrue();
+        enumerator.Current.EventType.Should().Be(StreamingEventTypes.TurnCreated);
+
         var turn = _dbContext.ConversationTurns.AsNoTracking().Single(t => t.NotebookConversationId == _conversationId);
         turn.ExecutionId.Should().NotBeNull();
+        turn.Status.Should().Be("streaming");
+
+        // Drain the remainder so the mocked run completes and releases its lock/registry entries
+        // deterministically before the test ends, matching how the other tests in this class finish.
+        while (await enumerator.MoveNextAsync())
+        {
+        }
     }
 }

--- a/src/server/GuideAntsApi.Tests/TestUtils/ConversationTestServices.cs
+++ b/src/server/GuideAntsApi.Tests/TestUtils/ConversationTestServices.cs
@@ -83,7 +83,8 @@ internal static class ConversationTestServices
         IConversationBroadcastHub? broadcastHub = null,
         INotebookFileSyncService? notebookFileSyncService = null,
         IToolOAuthService? toolOAuthService = null,
-        ILogger<ConversationService>? logger = null)
+        ILogger<ConversationService>? logger = null,
+        ConversationStreamRunRegistry? streamRunRegistry = null)
     {
         var lockService = distributedLock ?? Mock.Of<IDistributedConversationLock>();
         var hub = broadcastHub ?? Mock.Of<IConversationBroadcastHub>();
@@ -101,7 +102,7 @@ internal static class ConversationTestServices
             scopeFactory,
             Mock.Of<ILogger<ConversationStreamEngine>>(),
             notebookFileSyncService);
-        var streamRunRegistry = new ConversationStreamRunRegistry();
+        streamRunRegistry ??= new ConversationStreamRunRegistry();
         var undoService = new ConversationUndoService(
             lockService,
             hub,

--- a/src/server/GuideAntsApi.Tests/ToolCalling/ReasoningChoicesCacheTests.cs
+++ b/src/server/GuideAntsApi.Tests/ToolCalling/ReasoningChoicesCacheTests.cs
@@ -1,0 +1,44 @@
+using AntRunner.ToolCalling.AssistantDefinitions.Storage;
+using FluentAssertions;
+
+namespace GuideAntsApi.Tests.ToolCalling;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class ReasoningChoicesCacheTests
+{
+    [TestInitialize]
+    public void SetUp() => ReasoningChoicesCache.Clear();
+
+    [TestCleanup]
+    public void TearDown() => ReasoningChoicesCache.Clear();
+
+    [TestMethod]
+    public void TryGet_MissingModel_ReturnsFalse()
+    {
+        ReasoningChoicesCache.TryGet("gpt-x", DateTime.UtcNow, out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TryGet_FreshEntry_ReturnsCachedJson_IncludingNull()
+    {
+        var now = new DateTime(2026, 8, 28, 12, 0, 0, DateTimeKind.Utc);
+        ReasoningChoicesCache.Set("gpt-x", "[\"low\",\"high\"]", now);
+        ReasoningChoicesCache.Set("gpt-y", null, now);
+
+        ReasoningChoicesCache.TryGet("gpt-x", now.AddSeconds(59), out var json).Should().BeTrue();
+        json.Should().Be("[\"low\",\"high\"]");
+
+        ReasoningChoicesCache.TryGet("gpt-y", now.AddSeconds(59), out var nullJson).Should().BeTrue();
+        nullJson.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void TryGet_ExpiredEntry_ReturnsFalse()
+    {
+        var now = new DateTime(2026, 8, 28, 12, 0, 0, DateTimeKind.Utc);
+        ReasoningChoicesCache.Set("gpt-x", "[]", now);
+
+        ReasoningChoicesCache.TryGet("gpt-x", now.AddSeconds(60), out _).Should().BeFalse();
+    }
+}

--- a/src/server/GuideAntsApi/Configuration/StartupConfiguration.cs
+++ b/src/server/GuideAntsApi/Configuration/StartupConfiguration.cs
@@ -149,6 +149,7 @@ public static class StartupConfiguration
         services.AddScoped<IConversationQueryService, ConversationQueryService>();
         services.AddScoped<IConversationCommandService, ConversationCommandService>();
         services.AddScoped<IAttachmentContentService, AttachmentContentService>();
+        services.AddSingleton<IAttachmentRenderCache, AttachmentRenderCache>();
         services.AddScoped<IConversationHistoryBuilder, ConversationHistoryBuilder>();
         services.AddScoped<IConversationPersistence, ConversationPersistence>();
         services.AddScoped<IConversationUsageReporter, ConversationUsageReporter>();
@@ -800,6 +801,7 @@ public static class StartupConfiguration
         services.Configure<VideoAudioExtractionOptions>(configuration.GetSection(VideoAudioExtractionOptions.SectionName));
         services.Configure<MarkdownExtractionOptions>(configuration.GetSection(MarkdownExtractionOptions.SectionName));
         services.Configure<MarkdownAttachmentOptions>(configuration.GetSection(MarkdownAttachmentOptions.SectionName));
+        services.Configure<AttachmentRenderCacheOptions>(configuration.GetSection(AttachmentRenderCacheOptions.SectionName));
         services.Configure<SearXngSearchOptions>(configuration.GetSection(SearXngSearchOptions.SectionName));
         services.Configure<BrowserRenderingOptions>(configuration.GetSection(BrowserRenderingOptions.SectionName));
         services.Configure<GoogleGeminiApiOptions>(configuration.GetSection(GoogleGeminiApiOptions.SectionName));

--- a/src/server/GuideAntsApi/Endpoints/NotebookConversationsEndpoints.cs
+++ b/src/server/GuideAntsApi/Endpoints/NotebookConversationsEndpoints.cs
@@ -160,13 +160,8 @@ public static class NotebookConversationsEndpoints
             Guid? targetAssistantId = null;
             if (!string.IsNullOrEmpty(request.AssistantName))
             {
-                var assistant = await dbContext.Assistants
-                    .Where(a => a.Name == request.AssistantName)
-                    .FirstOrDefaultAsync(CancellationToken.None);
-                if (assistant != null)
-                {
-                    targetAssistantId = assistant.Id;
-                }
+                targetAssistantId = await GuideAntsApi.Services.Conversations.AssistantResolution
+                    .ResolveActiveAssistantIdAsync(dbContext, request.AssistantName, CancellationToken.None);
             }
 
             // Preflight local runtime readiness (do not link to client disconnect; streaming setup must still run)
@@ -228,7 +223,7 @@ public static class NotebookConversationsEndpoints
             try
             {
                 await ctx.Response.WriteSseStreamWithKeepAliveAsync(
-                    service.SendMessageStreamToConversationAsync(convoId, request, ctx.RequestAborted),
+                    service.SendMessageStreamToConversationAsync(convoId, request, ctx.RequestAborted, targetAssistantId),
                     ctx.RequestAborted);
             }
             catch (UnauthorizedAccessException)

--- a/src/server/GuideAntsApi/Options/AttachmentRenderCacheOptions.cs
+++ b/src/server/GuideAntsApi/Options/AttachmentRenderCacheOptions.cs
@@ -1,0 +1,15 @@
+namespace GuideAntsApi.Options;
+
+/// <summary>
+/// Bounds for the in-memory cache of chat-ready attachment renderings
+/// (see <see cref="Services.Conversations.Attachments.AttachmentRenderCache"/>).
+/// </summary>
+public class AttachmentRenderCacheOptions
+{
+    public const string SectionName = "AttachmentRenderCache";
+
+    /// <summary>Total cache budget; entry sizes are summed rendered text/base64 lengths.</summary>
+    public long SizeLimitBytes { get; set; } = 128L * 1024 * 1024;
+
+    public int SlidingExpirationMinutes { get; set; } = 30;
+}

--- a/src/server/GuideAntsApi/Services/Conversations/AssistantResolution.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/AssistantResolution.cs
@@ -1,0 +1,22 @@
+using GuideAntsApi.DataModel;
+using Microsoft.EntityFrameworkCore;
+
+namespace GuideAntsApi.Services.Conversations;
+
+/// <summary>
+/// Single definition of "which assistant does this name refer to": active assistants only,
+/// preferring project-scoped (non-global) over global. Used by both the send endpoint's runtime
+/// preflight and the conversation stream setup so the two can never disagree.
+/// </summary>
+public static class AssistantResolution
+{
+    public static Task<Guid?> ResolveActiveAssistantIdAsync(
+        ApplicationDbContext db,
+        string assistantName,
+        CancellationToken ct) =>
+        db.Assistants
+            .Where(a => a.Name == assistantName && a.IsActive)
+            .OrderBy(a => a.IsGlobal)
+            .Select(a => (Guid?)a.Id)
+            .FirstOrDefaultAsync(ct);
+}

--- a/src/server/GuideAntsApi/Services/Conversations/Attachments/AttachmentContentService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Attachments/AttachmentContentService.cs
@@ -19,6 +19,7 @@ public class AttachmentContentService : IAttachmentContentService
     private readonly IConfiguration? _configuration;
     private readonly string _storagePath;
     private readonly IOptions<MarkdownAttachmentOptions> _markdownAttachmentOptions;
+    private readonly IAttachmentRenderCache? _renderCache;
 
     public AttachmentContentService(
         IServiceScopeFactory scopeFactory,
@@ -26,7 +27,8 @@ public class AttachmentContentService : IAttachmentContentService
         INotebookFileService? notebookFileService = null,
         IMarkdownExtractionService? markdownExtractionService = null,
         ILogger<AttachmentContentService>? logger = null,
-        IConfiguration? configuration = null)
+        IConfiguration? configuration = null,
+        IAttachmentRenderCache? renderCache = null)
     {
         _scopeFactory = scopeFactory;
         _markdownAttachmentOptions = markdownAttachmentOptions ?? throw new ArgumentNullException(nameof(markdownAttachmentOptions));
@@ -35,6 +37,7 @@ public class AttachmentContentService : IAttachmentContentService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _configuration = configuration;
         _storagePath = configuration?["FileStorage:Path"] ?? string.Empty;
+        _renderCache = renderCache;
     }
 
     public async Task AddAttachmentsToUserMessageAsync(
@@ -165,7 +168,12 @@ public class AttachmentContentService : IAttachmentContentService
                 .FirstOrDefaultAsync(nf => nf.Id == notebookFileId, cancellationToken);
             if (notebookFile == null) return contents;
 
-            return await AttachmentMessageBuilder.CreateContentFromNotebookFileAsync(
+            if (_renderCache != null && _renderCache.TryGet(notebookFile.Id, notebookFile.LastModifiedUtc.Ticks, out var cached))
+            {
+                return cached;
+            }
+
+            var rendered = await AttachmentMessageBuilder.CreateContentFromNotebookFileAsync(
                 notebookFile,
                 _notebookFileService,
                 _markdownExtractionService,
@@ -173,6 +181,9 @@ public class AttachmentContentService : IAttachmentContentService
                 cancellationToken,
                 _markdownAttachmentOptions.Value.MaxInlineCharacters,
                 _logger);
+
+            _renderCache?.Set(notebookFile.Id, notebookFile.LastModifiedUtc.Ticks, rendered);
+            return rendered;
         }
         catch (GuideAntsApi.Exceptions.AttachmentNotReadyException)
         {
@@ -194,7 +205,12 @@ public class AttachmentContentService : IAttachmentContentService
 
         try
         {
-            return await AttachmentMessageBuilder.CreateContentFromNotebookFileAsync(
+            if (_renderCache != null && _renderCache.TryGet(notebookFile.Id, notebookFile.LastModifiedUtc.Ticks, out var cached))
+            {
+                return cached;
+            }
+
+            var rendered = await AttachmentMessageBuilder.CreateContentFromNotebookFileAsync(
                 notebookFile,
                 _notebookFileService,
                 _markdownExtractionService,
@@ -202,6 +218,9 @@ public class AttachmentContentService : IAttachmentContentService
                 cancellationToken,
                 _markdownAttachmentOptions.Value.MaxInlineCharacters,
                 _logger);
+
+            _renderCache?.Set(notebookFile.Id, notebookFile.LastModifiedUtc.Ticks, rendered);
+            return rendered;
         }
         catch (GuideAntsApi.Exceptions.AttachmentNotReadyException)
         {

--- a/src/server/GuideAntsApi/Services/Conversations/Attachments/AttachmentContentService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Attachments/AttachmentContentService.cs
@@ -184,4 +184,33 @@ public class AttachmentContentService : IAttachmentContentService
             return contents;
         }
     }
+
+    public async Task<List<ChatContent>> CreateOpenAiContentFromLoadedFileAsync(
+        NotebookFile notebookFile,
+        CancellationToken cancellationToken = default)
+    {
+        var contents = new List<ChatContent>();
+        if (_notebookFileService == null) return contents;
+
+        try
+        {
+            return await AttachmentMessageBuilder.CreateContentFromNotebookFileAsync(
+                notebookFile,
+                _notebookFileService,
+                _markdownExtractionService,
+                _storagePath,
+                cancellationToken,
+                _markdownAttachmentOptions.Value.MaxInlineCharacters,
+                _logger);
+        }
+        catch (GuideAntsApi.Exceptions.AttachmentNotReadyException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error creating OpenAI content for file {NotebookFileId}", notebookFile.Id);
+            return contents;
+        }
+    }
 }

--- a/src/server/GuideAntsApi/Services/Conversations/Attachments/AttachmentRenderCache.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Attachments/AttachmentRenderCache.cs
@@ -1,0 +1,64 @@
+using AntRunner.Chat.Abstractions;
+using GuideAntsApi.Options;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace GuideAntsApi.Services.Conversations.Attachments;
+
+/// <summary>
+/// Per-process cache of chat-ready attachment content keyed by (NotebookFileId, LastModifiedUtc.Ticks).
+/// A file change rotates the key, so stale entries need no invalidation hooks — they die by
+/// size pressure or sliding expiration. Uses a dedicated MemoryCache instance so the size limit
+/// doesn't force Size declarations onto the app's shared IMemoryCache users.
+/// </summary>
+public interface IAttachmentRenderCache
+{
+    bool TryGet(Guid notebookFileId, long lastModifiedTicks, out List<ChatContent> contents);
+    void Set(Guid notebookFileId, long lastModifiedTicks, List<ChatContent> contents);
+}
+
+public sealed class AttachmentRenderCache : IAttachmentRenderCache, IDisposable
+{
+    private readonly MemoryCache _cache;
+    private readonly TimeSpan _slidingExpiration;
+
+    public AttachmentRenderCache(IOptions<AttachmentRenderCacheOptions> options)
+    {
+        var value = options.Value;
+        _cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = value.SizeLimitBytes });
+        _slidingExpiration = TimeSpan.FromMinutes(value.SlidingExpirationMinutes);
+    }
+
+    public bool TryGet(Guid notebookFileId, long lastModifiedTicks, out List<ChatContent> contents)
+    {
+        if (_cache.TryGetValue((notebookFileId, lastModifiedTicks), out List<ChatContent>? cached) && cached != null)
+        {
+            // ChatContent is immutable; only the list wrapper needs copying.
+            contents = new List<ChatContent>(cached);
+            return true;
+        }
+
+        contents = [];
+        return false;
+    }
+
+    public void Set(Guid notebookFileId, long lastModifiedTicks, List<ChatContent> contents)
+    {
+        if (contents.Count == 0)
+        {
+            return;
+        }
+
+        var size = contents.Sum(c => (long)(c.Text?.Length ?? 0) + (c.ImageUrl?.Url.Length ?? 0));
+        _cache.Set(
+            (notebookFileId, lastModifiedTicks),
+            new List<ChatContent>(contents),
+            new MemoryCacheEntryOptions
+            {
+                Size = Math.Max(size, 1),
+                SlidingExpiration = _slidingExpiration
+            });
+    }
+
+    public void Dispose() => _cache.Dispose();
+}

--- a/src/server/GuideAntsApi/Services/Conversations/Attachments/IAttachmentContentService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Attachments/IAttachmentContentService.cs
@@ -1,5 +1,6 @@
 using AntRunner.Chat.Abstractions;
 using GuideAntsApi.DataModel;
+using GuideAntsApi.DataModel.Models;
 using GuideAntsApi.Models.Conversations;
 
 namespace GuideAntsApi.Services.Conversations.Attachments;
@@ -35,5 +36,9 @@ public interface IAttachmentContentService
     Task<List<ChatContent>> CreateOpenAiContentFromNotebookFileAsync(
         ApplicationDbContext db,
         Guid notebookFileId,
+        CancellationToken cancellationToken = default);
+
+    Task<List<ChatContent>> CreateOpenAiContentFromLoadedFileAsync(
+        NotebookFile notebookFile,
         CancellationToken cancellationToken = default);
 }

--- a/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
@@ -103,10 +103,11 @@ public class ConversationService : IConversationService
     public async IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(
         Guid conversationId,
         SendMessageRequest request,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        Guid? resolvedAssistantId = null)
     {
         var user = await _streamPolicy.ResolveUserIdentityAsync(internalUserId: null, externalUserIdentity: null, CancellationToken.None);
-        await foreach (var ev in SendMessageStreamCoreAsync(conversationId, request, user, cancellationToken))
+        await foreach (var ev in SendMessageStreamCoreAsync(conversationId, request, user, cancellationToken, resolvedAssistantId))
         {
             yield return ev;
         }
@@ -169,7 +170,8 @@ public class ConversationService : IConversationService
         Guid conversationId,
         SendMessageRequest request,
         StreamUserIdentity user,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken,
+        Guid? resolvedAssistantId = null)
     {
         var preflight = System.Diagnostics.Stopwatch.StartNew();
         var lockHandle = await _streamPolicy.TryAcquireStreamAsync(conversationId, user, CancellationToken.None);
@@ -182,7 +184,7 @@ public class ConversationService : IConversationService
         try
         {
             var setupCt = CancellationToken.None;
-            var loaded = await LoadStreamMetadataAsync(conversationId, request, user, setupCt);
+            var loaded = await LoadStreamMetadataAsync(conversationId, request, user, setupCt, resolvedAssistantId);
             loadMs = preflight.ElapsedMilliseconds;
 
             await CreateTurnAndUserMessageAsync(loaded, setupCt);
@@ -271,7 +273,8 @@ public class ConversationService : IConversationService
         Guid conversationId,
         SendMessageRequest request,
         StreamUserIdentity user,
-        CancellationToken ct)
+        CancellationToken ct,
+        Guid? resolvedAssistantId = null)
     {
         if (string.IsNullOrWhiteSpace(request.Instructions) && (request.Attachments == null || request.Attachments.Count == 0))
         {
@@ -282,6 +285,8 @@ public class ConversationService : IConversationService
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
         var conv = await db.NotebookConversations
+            .AsNoTracking()
+            .AsSplitQuery()
             .Include(c => c.Messages)
                 .ThenInclude(m => m.EditHistory)
             .Include(c => c.Notebook)
@@ -314,11 +319,8 @@ public class ConversationService : IConversationService
             LogValueSanitizer.Sanitize(resolvedModel.ExecutionPolicy.Authority),
             LogValueSanitizer.Sanitize(string.Join(", ", resolvedModel.ExecutionPolicy.Parameters.Keys)));
 
-        var assistantId = await db.Assistants
-            .Where(a => a.Name == assistantName && a.IsActive)
-            .OrderBy(a => a.IsGlobal)
-            .Select(a => (Guid?)a.Id)
-            .FirstOrDefaultAsync(ct);
+        var assistantId = resolvedAssistantId
+            ?? await AssistantResolution.ResolveActiveAssistantIdAsync(db, assistantName, ct);
 
         return new StreamSendContext
         {

--- a/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
@@ -20,6 +20,16 @@ namespace GuideAntsApi.Services.Conversations;
 
 public class ConversationService : IConversationService
 {
+    /// <summary>
+    /// Matches <c>ConversationStreamEngine</c>'s serializer options so every SSE payload this
+    /// service emits - including the preflight <c>error</c> event - reaches the client in the
+    /// same shape the engine's own events use.
+    /// </summary>
+    private static readonly JsonSerializerOptions StreamJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IConversationPersistence _persistence;
     private readonly IChatModelResolver _chatModelResolver;
@@ -177,14 +187,14 @@ public class ConversationService : IConversationService
         var lockHandle = await _streamPolicy.TryAcquireStreamAsync(conversationId, user, CancellationToken.None);
         var lockMs = preflight.ElapsedMilliseconds;
 
-        ConversationStreamRunContext runContext;
+        StreamSendContext loaded;
         CancellationTokenSource? workerCts = null;
         var registeredTurnId = Guid.Empty;
-        long loadMs = 0, turnMs = 0, historyMs = 0, attachmentsMs = 0;
+        long loadMs = 0, turnMs = 0;
         try
         {
             var setupCt = CancellationToken.None;
-            var loaded = await LoadStreamMetadataAsync(conversationId, request, user, setupCt, resolvedAssistantId);
+            loaded = await LoadStreamMetadataAsync(conversationId, request, user, setupCt, resolvedAssistantId);
             loadMs = preflight.ElapsedMilliseconds;
 
             await CreateTurnAndUserMessageAsync(loaded, setupCt);
@@ -202,16 +212,11 @@ public class ConversationService : IConversationService
                     loaded.AssistantName,
                     user),
                 setupCt);
-
-            await PopulateStreamHistoryAsync(loaded, setupCt);
-            historyMs = preflight.ElapsedMilliseconds;
-            await ProcessAttachmentsAsync(loaded, setupCt);
-            attachmentsMs = preflight.ElapsedMilliseconds;
-
-            runContext = BuildRunContext(_streamPolicy, loaded, user);
         }
         catch
         {
+            // Nothing has been yielded yet, so the SSE response has not started: the endpoint can
+            // still turn this into a clean HTTP error. Release what we took and rethrow.
             if (workerCts != null)
             {
                 _streamRunRegistry.Unregister(registeredTurnId);
@@ -219,6 +224,86 @@ public class ConversationService : IConversationService
 
             await lockHandle.ReleaseAsync(CancellationToken.None);
             throw;
+        }
+
+        // The client arms Stop on this event; emit it before history/attachment setup so Stop is
+        // available while the server is still assembling context. Failures from here on can no
+        // longer become HTTP errors (the response has started) - they are surfaced as an SSE error
+        // event below.
+        yield return new StreamingEvent(
+            StreamingEventTypes.TurnCreated,
+            JsonSerializer.Serialize(new { turnId = registeredTurnId }, StreamJsonOptions));
+
+        ConversationStreamRunContext? runContext = null;
+        StreamingEvent? preflightFailure = null;
+        long historyMs = 0, attachmentsMs = 0;
+        try
+        {
+            var setupCt = CancellationToken.None;
+            await PopulateStreamHistoryAsync(loaded, setupCt);
+            historyMs = preflight.ElapsedMilliseconds;
+
+            await ProcessAttachmentsAsync(loaded, setupCt);
+            attachmentsMs = preflight.ElapsedMilliseconds;
+
+            runContext = BuildRunContext(_streamPolicy, loaded, user);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Preflight failed after turnCreated for conversation {ConversationId} turn {TurnId}",
+                conversationId,
+                registeredTurnId);
+
+            // The turn row is already "streaming"; without this it would survive as a zombie.
+            try
+            {
+                await _persistence.TerminalizeTurnAsync(
+                    new TerminalizeTurnRequest(
+                        registeredTurnId,
+                        conversationId,
+                        loaded.TurnIndex,
+                        "failed",
+                        TerminationCode: "preflight_failed",
+                        TerminationDetail: ex.Message,
+                        ExecutionId: loaded.DbTurn!.ExecutionId),
+                    CancellationToken.None);
+            }
+            catch (Exception terminalizeEx)
+            {
+                _logger.LogError(
+                    terminalizeEx,
+                    "Failed to terminalize turn {TurnId} after preflight failure",
+                    registeredTurnId);
+            }
+
+            _streamRunRegistry.Unregister(registeredTurnId);
+
+            // Mirrors ConversationStreamEngine's release path: only broadcast the unlock if this
+            // handle broadcast the lock and actually released it.
+            var distributedLockReleased = await lockHandle.ReleaseAsync(CancellationToken.None);
+            if (lockHandle.ConversationLockEventSent && distributedLockReleased)
+            {
+                try
+                {
+                    await _streamPolicy.OnUnlockAsync(conversationId, CancellationToken.None);
+                }
+                catch (Exception unlockEx)
+                {
+                    _logger.LogWarning(unlockEx, "Failed to broadcast conversation unlock for {ConversationId}", conversationId);
+                }
+            }
+
+            preflightFailure = new StreamingEvent(
+                StreamingEventTypes.Error,
+                JsonSerializer.Serialize(StreamingErrorEnvelope.Build(ex), StreamJsonOptions));
+        }
+
+        if (preflightFailure != null)
+        {
+            yield return preflightFailure;
+            yield break;
         }
 
         preflight.Stop();
@@ -232,20 +317,13 @@ public class ConversationService : IConversationService
             attachmentsMs - historyMs,
             preflight.ElapsedMilliseconds);
 
-        yield return new StreamingEvent(
-            StreamingEventTypes.TurnCreated,
-            JsonSerializer.Serialize(new { turnId = registeredTurnId }, new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            }));
-
         Action onWorkerCompleted = () => _streamRunRegistry.Unregister(registeredTurnId);
 
         await foreach (var ev in _streamEngine.RunStreamAsync(
-            runContext,
+            runContext!,
             lockHandle,
             cancellationToken,
-            workerCts.Token,
+            workerCts!.Token,
             onWorkerCompleted))
         {
             yield return ev;

--- a/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
@@ -186,16 +186,9 @@ public class ConversationService : IConversationService
             loadMs = preflight.ElapsedMilliseconds;
 
             await CreateTurnAndUserMessageAsync(loaded, setupCt);
-            if (!await _persistence.SetTurnStatusAsync(loaded.DbTurn!.Id, "streaming", ct: setupCt))
-            {
-                _logger.LogWarning(
-                    "Turn {TurnId} disappeared before streaming status update in conversation {ConversationId}",
-                    loaded.DbTurn.Id,
-                    conversationId);
-            }
             turnMs = preflight.ElapsedMilliseconds;
 
-            registeredTurnId = loaded.DbTurn.Id;
+            registeredTurnId = loaded.DbTurn!.Id;
             workerCts = _streamRunRegistry.Register(registeredTurnId);
 
             await _streamPolicy.OnTurnCreatedAsync(
@@ -367,7 +360,8 @@ public class ConversationService : IConversationService
                 ctx.ConversationId,
                 ctx.AssistantName,
                 ctx.ModelDeploymentId,
-                ctx.Request.Instructions),
+                ctx.Request.Instructions,
+                InitialStatus: "streaming"),
             ct);
 
         var userResult = await _persistence.CreateUserMessageAsync(

--- a/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
@@ -171,15 +171,19 @@ public class ConversationService : IConversationService
         StreamUserIdentity user,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        var preflight = System.Diagnostics.Stopwatch.StartNew();
         var lockHandle = await _streamPolicy.TryAcquireStreamAsync(conversationId, user, CancellationToken.None);
+        var lockMs = preflight.ElapsedMilliseconds;
 
         ConversationStreamRunContext runContext;
         CancellationTokenSource? workerCts = null;
         var registeredTurnId = Guid.Empty;
+        long loadMs = 0, turnMs = 0, historyMs = 0, attachmentsMs = 0;
         try
         {
             var setupCt = CancellationToken.None;
             var loaded = await LoadStreamMetadataAsync(conversationId, request, user, setupCt);
+            loadMs = preflight.ElapsedMilliseconds;
 
             await CreateTurnAndUserMessageAsync(loaded, setupCt);
             if (!await _persistence.SetTurnStatusAsync(loaded.DbTurn!.Id, "streaming", ct: setupCt))
@@ -189,6 +193,7 @@ public class ConversationService : IConversationService
                     loaded.DbTurn.Id,
                     conversationId);
             }
+            turnMs = preflight.ElapsedMilliseconds;
 
             registeredTurnId = loaded.DbTurn.Id;
             workerCts = _streamRunRegistry.Register(registeredTurnId);
@@ -204,7 +209,9 @@ public class ConversationService : IConversationService
                 setupCt);
 
             await PopulateStreamHistoryAsync(loaded, setupCt);
+            historyMs = preflight.ElapsedMilliseconds;
             await ProcessAttachmentsAsync(loaded, setupCt);
+            attachmentsMs = preflight.ElapsedMilliseconds;
 
             runContext = BuildRunContext(_streamPolicy, loaded, user);
         }
@@ -218,6 +225,17 @@ public class ConversationService : IConversationService
             await lockHandle.ReleaseAsync(CancellationToken.None);
             throw;
         }
+
+        preflight.Stop();
+        _logger.LogDebug(
+            "Preflight timings for {ConversationId}: lock={LockMs}ms load={LoadMs}ms turn={TurnMs}ms history={HistoryMs}ms attachments={AttachmentsMs}ms total={TotalMs}ms",
+            conversationId,
+            lockMs,
+            loadMs - lockMs,
+            turnMs - loadMs,
+            historyMs - turnMs,
+            attachmentsMs - historyMs,
+            preflight.ElapsedMilliseconds);
 
         yield return new StreamingEvent(
             StreamingEventTypes.TurnCreated,

--- a/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/ConversationService.cs
@@ -280,6 +280,24 @@ public class ConversationService : IConversationService
 
             _streamRunRegistry.Unregister(registeredTurnId);
 
+            var errorEvent = new StreamingEvent(
+                StreamingEventTypes.Error,
+                JsonSerializer.Serialize(StreamingErrorEnvelope.Build(ex), StreamJsonOptions));
+
+            // Observers attached via ObserveConversationEventsAsync saw turn_created for this turn
+            // and would otherwise never see a terminal event for it. The engine fans every event out
+            // to the hub as well as the SSE channel (ConversationStreamEngine's TryWrite), and it
+            // broadcasts the error before releasing the lock, so observers get error then
+            // conversation_unlocked in that order - mirror both the fan-out and the ordering here.
+            try
+            {
+                await _streamPolicy.BroadcastEventAsync(conversationId, errorEvent, CancellationToken.None);
+            }
+            catch (Exception broadcastEx)
+            {
+                _logger.LogWarning(broadcastEx, "Failed to broadcast preflight error for {ConversationId}", conversationId);
+            }
+
             // Mirrors ConversationStreamEngine's release path: only broadcast the unlock if this
             // handle broadcast the lock and actually released it.
             var distributedLockReleased = await lockHandle.ReleaseAsync(CancellationToken.None);
@@ -295,9 +313,7 @@ public class ConversationService : IConversationService
                 }
             }
 
-            preflightFailure = new StreamingEvent(
-                StreamingEventTypes.Error,
-                JsonSerializer.Serialize(StreamingErrorEnvelope.Build(ex), StreamJsonOptions));
+            preflightFailure = errorEvent;
         }
 
         if (preflightFailure != null)

--- a/src/server/GuideAntsApi/Services/Conversations/IConversationService.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/IConversationService.cs
@@ -12,7 +12,7 @@ public interface IConversationService
     Task RenameConversationAsync(Guid conversationId, string title);
     Task DeleteConversationAsync(Guid conversationId);
     
-    IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsync(Guid conversationId, SendMessageRequest request, CancellationToken cancellationToken = default, Guid? resolvedAssistantId = null);
 
     IAsyncEnumerable<StreamingEvent> SendMessageStreamToConversationAsUserAsync(
         Guid conversationId,

--- a/src/server/GuideAntsApi/Services/Conversations/Mapping/ConversationHistoryBuilder.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Mapping/ConversationHistoryBuilder.cs
@@ -206,21 +206,8 @@ public class ConversationHistoryBuilder : IConversationHistoryBuilder
             .ThenBy(m => m.MessageSequence)
             .ToList();
 
-        var messageIds = orderedMessages.Select(m => m.Id).ToList();
-        Dictionary<Guid, List<MessageAttachment>> attachmentsByMessageId;
-        using (var attachmentScope = _scopeFactory.CreateScope())
-        {
-            var attachmentDb = attachmentScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            attachmentsByMessageId = (await attachmentDb.MessageAttachments
-                    .AsNoTracking()
-                    .Include(ma => ma.NotebookFile)
-                        .ThenInclude(nf => nf.Notebook)
-                    .Where(ma => messageIds.Contains(ma.MessageId))
-                    .OrderBy(ma => ma.OrderIndex)
-                    .ToListAsync(cancellationToken))
-                .GroupBy(ma => ma.MessageId)
-                .ToDictionary(g => g.Key, g => g.ToList());
-        }
+        var attachmentsByMessageId = await LoadAttachmentsByMessageIdAsync(
+            orderedMessages.Select(m => m.Id).ToList(), cancellationToken);
 
         var filteredMessages = new List<ChatMessage>();
         foreach (var m in orderedMessages)
@@ -340,21 +327,8 @@ public class ConversationHistoryBuilder : IConversationHistoryBuilder
             .ThenBy(m => m.MessageSequence)
             .ToList();
 
-        var messageIds = orderedMessages.Select(m => m.Id).ToList();
-        Dictionary<Guid, List<MessageAttachment>> attachmentsByMessageId;
-        using (var attachmentScope = _scopeFactory.CreateScope())
-        {
-            var attachmentDb = attachmentScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            attachmentsByMessageId = (await attachmentDb.MessageAttachments
-                    .AsNoTracking()
-                    .Include(ma => ma.NotebookFile)
-                        .ThenInclude(nf => nf.Notebook)
-                    .Where(ma => messageIds.Contains(ma.MessageId))
-                    .OrderBy(ma => ma.OrderIndex)
-                    .ToListAsync(cancellationToken))
-                .GroupBy(ma => ma.MessageId)
-                .ToDictionary(g => g.Key, g => g.ToList());
-        }
+        var attachmentsByMessageId = await LoadAttachmentsByMessageIdAsync(
+            orderedMessages.Select(m => m.Id).ToList(), cancellationToken);
 
         foreach (var dbMsg in orderedMessages)
         {
@@ -671,6 +645,29 @@ public class ConversationHistoryBuilder : IConversationHistoryBuilder
         }
 
         return validToolCallIds;
+    }
+
+    /// <summary>
+    /// Batch-loads message attachments for a set of message ids in a single scope/query, replacing what
+    /// used to be a per-message scope+query inside the BuildOpenAiMessagesAsync/ApplyAssistantSwitchLogicAsync
+    /// loops. NotebookFile (and its Notebook) is eagerly included so callers can render attachment content
+    /// from the already-loaded entity via CreateOpenAiContentFromLoadedFileAsync instead of re-querying per file.
+    /// </summary>
+    private async Task<Dictionary<Guid, List<MessageAttachment>>> LoadAttachmentsByMessageIdAsync(
+        List<Guid> messageIds,
+        CancellationToken cancellationToken)
+    {
+        using var attachmentScope = _scopeFactory.CreateScope();
+        var attachmentDb = attachmentScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return (await attachmentDb.MessageAttachments
+                .AsNoTracking()
+                .Include(ma => ma.NotebookFile)
+                    .ThenInclude(nf => nf.Notebook)
+                .Where(ma => messageIds.Contains(ma.MessageId))
+                .OrderBy(ma => ma.OrderIndex)
+                .ToListAsync(cancellationToken))
+            .GroupBy(ma => ma.MessageId)
+            .ToDictionary(g => g.Key, g => g.ToList());
     }
 
     private static void AddSkillsDiscoveryMessage(

--- a/src/server/GuideAntsApi/Services/Conversations/Mapping/ConversationHistoryBuilder.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Mapping/ConversationHistoryBuilder.cs
@@ -201,8 +201,29 @@ public class ConversationHistoryBuilder : IConversationHistoryBuilder
             }
         }
 
+        var orderedMessages = dedupedMessages
+            .OrderBy(m => m.TurnIndex)
+            .ThenBy(m => m.MessageSequence)
+            .ToList();
+
+        var messageIds = orderedMessages.Select(m => m.Id).ToList();
+        Dictionary<Guid, List<MessageAttachment>> attachmentsByMessageId;
+        using (var attachmentScope = _scopeFactory.CreateScope())
+        {
+            var attachmentDb = attachmentScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            attachmentsByMessageId = (await attachmentDb.MessageAttachments
+                    .AsNoTracking()
+                    .Include(ma => ma.NotebookFile)
+                        .ThenInclude(nf => nf.Notebook)
+                    .Where(ma => messageIds.Contains(ma.MessageId))
+                    .OrderBy(ma => ma.OrderIndex)
+                    .ToListAsync(cancellationToken))
+                .GroupBy(ma => ma.MessageId)
+                .ToDictionary(g => g.Key, g => g.ToList());
+        }
+
         var filteredMessages = new List<ChatMessage>();
-        foreach (var m in dedupedMessages.OrderBy(m => m.TurnIndex).ThenBy(m => m.MessageSequence))
+        foreach (var m in orderedMessages)
         {
             if (m.Role == DataModelChatRole.Tool)
             {
@@ -223,16 +244,9 @@ public class ConversationHistoryBuilder : IConversationHistoryBuilder
                 continue;
             }
 
-            List<MessageAttachment> attachments;
-            using (var attachmentScope = _scopeFactory.CreateScope())
-            {
-                var attachmentDb = attachmentScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-                attachments = await attachmentDb.MessageAttachments
-                    .Include(ma => ma.NotebookFile)
-                    .Where(ma => ma.MessageId == m.Id)
-                    .OrderBy(ma => ma.OrderIndex)
-                    .ToListAsync(cancellationToken);
-            }
+            var attachments = attachmentsByMessageId.TryGetValue(m.Id, out var msgAttachments)
+                ? msgAttachments
+                : [];
 
             if (attachments.Count > 0)
             {
@@ -245,8 +259,9 @@ public class ConversationHistoryBuilder : IConversationHistoryBuilder
 
                 foreach (var attachment in attachments)
                 {
-                    var fileContents = await _attachmentContentService.CreateOpenAiContentFromNotebookFileAsync(
-                        attachment.NotebookFileId, cancellationToken);
+                    var fileContents = attachment.NotebookFile != null
+                        ? await _attachmentContentService.CreateOpenAiContentFromLoadedFileAsync(attachment.NotebookFile, cancellationToken)
+                        : await _attachmentContentService.CreateOpenAiContentFromNotebookFileAsync(attachment.NotebookFileId, cancellationToken);
                     contents.AddRange(fileContents);
                 }
 

--- a/src/server/GuideAntsApi/Services/Conversations/Mapping/ConversationHistoryBuilder.cs
+++ b/src/server/GuideAntsApi/Services/Conversations/Mapping/ConversationHistoryBuilder.cs
@@ -320,7 +320,28 @@ public class ConversationHistoryBuilder : IConversationHistoryBuilder
             }
         }
 
-        foreach (var dbMsg in filteredMessages.OrderBy(m => m.TurnIndex).ThenBy(m => m.MessageSequence))
+        var orderedMessages = filteredMessages
+            .OrderBy(m => m.TurnIndex)
+            .ThenBy(m => m.MessageSequence)
+            .ToList();
+
+        var messageIds = orderedMessages.Select(m => m.Id).ToList();
+        Dictionary<Guid, List<MessageAttachment>> attachmentsByMessageId;
+        using (var attachmentScope = _scopeFactory.CreateScope())
+        {
+            var attachmentDb = attachmentScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            attachmentsByMessageId = (await attachmentDb.MessageAttachments
+                    .AsNoTracking()
+                    .Include(ma => ma.NotebookFile)
+                        .ThenInclude(nf => nf.Notebook)
+                    .Where(ma => messageIds.Contains(ma.MessageId))
+                    .OrderBy(ma => ma.OrderIndex)
+                    .ToListAsync(cancellationToken))
+                .GroupBy(ma => ma.MessageId)
+                .ToDictionary(g => g.Key, g => g.ToList());
+        }
+
+        foreach (var dbMsg in orderedMessages)
         {
             if (dbMsg.Role == DataModelChatRole.Tool)
             {
@@ -338,16 +359,9 @@ public class ConversationHistoryBuilder : IConversationHistoryBuilder
                 }
             }
 
-            List<MessageAttachment> attachments;
-            using (var attachmentScope = _scopeFactory.CreateScope())
-            {
-                var attachmentDb = attachmentScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-                attachments = await attachmentDb.MessageAttachments
-                    .Include(ma => ma.NotebookFile)
-                    .Where(ma => ma.MessageId == dbMsg.Id)
-                    .OrderBy(ma => ma.OrderIndex)
-                    .ToListAsync(cancellationToken);
-            }
+            var attachments = attachmentsByMessageId.TryGetValue(dbMsg.Id, out var msgAttachments)
+                ? msgAttachments
+                : [];
 
             if (attachments.Count > 0)
             {
@@ -360,8 +374,9 @@ public class ConversationHistoryBuilder : IConversationHistoryBuilder
 
                 foreach (var attachment in attachments)
                 {
-                    var fileContents = await _attachmentContentService.CreateOpenAiContentFromNotebookFileAsync(
-                        attachment.NotebookFileId, cancellationToken);
+                    var fileContents = attachment.NotebookFile != null
+                        ? await _attachmentContentService.CreateOpenAiContentFromLoadedFileAsync(attachment.NotebookFile, cancellationToken)
+                        : await _attachmentContentService.CreateOpenAiContentFromNotebookFileAsync(attachment.NotebookFileId, cancellationToken);
                     contents.AddRange(fileContents);
                 }
 


### PR DESCRIPTION
## Summary

Reduces the delay between a user sending a chat message and the request reaching the LLM (the "preflight" path in `ConversationService.SendMessageStreamCoreAsync`). The bottlenecks were query-shape/N+1/round-trip issues, not missing indexes — this branch fixes those directly:

- Create turns already in `"streaming"` status, dropping a redundant DB round trip
- Unify assistant-name resolution and load the conversation preflight query with `.AsNoTracking()` + `.AsSplitQuery()`, removing a cartesian-product join
- Batch per-message attachment loading into one query instead of one per message — the main N+1, fixed in both places it occurred (history building and assistant-switch logic)
- Yield `turn_created` before preflight history/attachment setup finishes, so the client isn't blocked on it, with proper failure handling if preflight fails after that early yield
- Render the sent message optimistically on the client before the runtime-status preflight check resolves, with rollback on not-ready/error
- Cache model reasoning-effort choices for 60s instead of reading them from the DB on every turn (`29f1ae9d`)
- Cache chat-ready attachment renderings keyed by `(fileId, lastModifiedTicks)` instead of re-rendering the same attachment on every send
- Fix a correctness regression the optimistic-render change opened up: clicking Stop during the preflight window had nowhere to go and was silently dropped

Also: removes a redundant conversation-snapshot GET after sending a message, and adds preflight timing instrumentation.

## Measured impact

| | `main` (before) | this branch (after) |
|---|---|---|
| 1st message (cold) | 1386ms | 746ms |
| 2nd message | 691ms | 28ms |
| 3rd message | 866ms | 32ms |
